### PR TITLE
Sprint 1 Phase 1: Recipe class for editorial automation

### DIFF
--- a/docs/sprints/sprint-01-editorial-automation.md
+++ b/docs/sprints/sprint-01-editorial-automation.md
@@ -1,0 +1,130 @@
+# Sprint 1 — Editorial Automation
+
+**Status:** planning · **Branch:** `sprint/editorial-automation` (to create) · **Target:** ~2 weeks · **Date:** 2026-04-30
+
+## Goal
+
+Extend ButterCut so a rough cut isn't just a cuts-only timeline — it ships with an **editorial recipe** that can be applied to the imported timeline to produce an ~80%-finished edit hands-free. Speed ramps, transitions, color, markers, render presets — automated.
+
+The remaining 20% (music, art-direction color taste, titles) stays in the editor's hands because those are creative judgement calls.
+
+## Background — why
+
+Today ButterCut emits XML and the editor (DaVinci Resolve / Premiere / FCP) imports it as straight cuts. Everything else — speed ramps on slams, color grading, transitions, sound cue placement — is manual. We've prototyped a markdown/HTML edit guide that documents these choices, but it still requires the human to apply each one.
+
+The recipe + apply-script architecture closes that loop. ButterCut already knows *which* clips to ramp/grade because the editorial reasoning happened in the roughcut agent — we just lose that reasoning at the XML boundary. This sprint persists it.
+
+## Out of scope
+
+- Automatic music selection or sound-design generation.
+- Color grading taste decisions (we apply a saved PowerGrade; we don't generate one).
+- Premiere Pro / Final Cut Pro automation. Resolve only this sprint — Premiere has a separate scripting model (UXP/ExtendScript) and FCP X has a different XML round-trip. Both follow-on sprints.
+- Headless ffmpeg rendering. NLE-driven only.
+
+## Architecture
+
+```
+ButterCut roughcut skill
+  ├── highlight-reel_<ts>.yaml         (existing)
+  ├── highlight-reel_<ts>.xml          (existing — Resolve xmeml v5)
+  ├── highlight-reel_<ts>.recipe.json  (NEW — per-clip directives)
+  ├── highlight-reel_<ts>_apply.py     (NEW — Resolve Python, drop into Scripts/Edit/)
+  └── highlight-reel_<ts>_edit_guide.html (existing prototype, formalized)
+```
+
+The user imports the XML in Resolve (one-click), then runs `Workspace > Scripts > Edit > Apply <name>` and the recipe is applied to the timeline they just imported.
+
+## Phases
+
+### Phase 1 — Recipe schema (1–2 days)
+
+- `lib/buttercut/recipe.rb` — Ruby class that builds the recipe alongside the XML.
+- Schema (JSON):
+  ```json
+  {
+    "version": 1,
+    "library": "march-30-workout",
+    "timeline": "highlight-reel_20260430_184655",
+    "render_preset": { "format": "mp4", "codec": "h264", "resolution": "1080p", "bitrate_kbps": 25000 },
+    "powergrade": { "name": "GymBlueOrange-v1", "apply_to": "all" },
+    "clips": [
+      {
+        "index": 3,
+        "source_file": "medicine-ball-slams.mp4",
+        "speed_ramps": [
+          { "at": 1.5, "speed": 200, "ease": "ease-out" },
+          { "at": 2.5, "speed": 100, "ease": "ease-in" }
+        ],
+        "color_tag": "Orange",
+        "markers": [{ "at": 1.8, "name": "impact", "color": "Red" }]
+      }
+    ],
+    "transitions": [
+      { "between": [3, 4], "type": "dip_to_color", "color": "black", "duration_frames": 4 },
+      { "between": [11, 12], "type": "dip_to_color", "color": "white", "duration_frames": 4 }
+    ],
+    "title_card": {
+      "at_clip": 12,
+      "text": "{{user_handle}}",
+      "fade_in_at": 0.5,
+      "fade_in_frames": 6
+    }
+  }
+  ```
+- **Acceptance:** unit test in `spec/recipe_spec.rb` round-trips the schema; invalid inputs raise.
+
+### Phase 2 — Roughcut agent emits recipe (2–3 days)
+
+- Update `.claude/skills/roughcut/agent_instructions.md` to instruct the agent to produce recipe directives during clip selection (not as a post-pass) — the editorial reasoning ("ramp this slam to 200%", "dip to white before the hero") is already happening in the agent's head; capture it.
+- Wire `lib/buttercut/recipe.rb` into the roughcut export so YAML→XML+recipe is one operation.
+- **Acceptance:** running the roughcut skill produces all four artifacts (yaml, xml, recipe.json, edit_guide.html). The `march-30-workout` library is the regression fixture.
+
+### Phase 3 — Resolve apply script (3–4 days)
+
+- `.claude/skills/roughcut/templates/apply_recipe.py` — template Python that reads `<name>.recipe.json` next to itself.
+- Generate `<name>_apply.py` per cut by stamping the template with the recipe path.
+- Capabilities (in priority order):
+  1. Speed ramps via `clip.GetClipProperty("Speed")` and retime curve API.
+  2. Clip color tags via `SetClipColor()`.
+  3. Markers via `clip.AddMarker()`.
+  4. Apply saved PowerGrade by name (apply via `MediaPool.AppendToTimeline` workaround if direct API unavailable).
+  5. Render preset via `Project.LoadRenderPreset()` / `SetCurrentRenderMode`.
+  6. Transitions: best-effort — Resolve API for transitions is limited; may have to skip and document as manual.
+- **Acceptance:** drop the `march-30-workout` rough-cut XML into a fresh Resolve project, import, run the apply script, observe ramps + color tags + markers + render preset applied.
+
+### Phase 4 — Optional: FCPXML 1.10 backend (3 days, deferred if Phase 3 takes long)
+
+- `lib/buttercut/fcpx.rb` already exists (FCPXML 1.8). Bump to 1.10 and emit `<timeMap>` for speed ramps, `<filter-video>` references for transitions/color.
+- Resolve's FCPXML import is more permissive than its xmeml import — many recipe directives may "just work" without the apply script, giving fallback path.
+- **Acceptance:** same regression library imports into Resolve via FCPXML 1.10 with at least speed ramps preserved (transitions and color may not survive — document what does).
+
+### Phase 5 — Demo + cleanup (1 day)
+
+- End-to-end demo recording: open Resolve, import march-30-workout XML, run apply script, render. Capture timing.
+- Update CLAUDE.md "Workflow Steps" to reflect the new artifact set.
+- Bump version, update CHANGELOG.
+
+## Verification / demo
+
+The success bar: take the `march-30-workout` library, run the roughcut skill, import + apply in Resolve, render. The output should be a 30-second cut with:
+- All speed ramps applied (200% slam, 150% jump-rope insert, 60% hero closer)
+- A consistent color grade across all clips (the saved PowerGrade)
+- Markers at sound-cue points so the editor only has to drop SFX onto markers
+- Render preset loaded for 1080p YouTube
+
+Manual finishing: pick music, drop SFX onto markers, write title card text, render.
+
+## Open questions
+
+1. Resolve scripting API has gaps for transitions and certain effect parameters. Phase 3 needs early spike to confirm what's actually scriptable on the free Resolve version vs Studio. **Action:** day-1 spike script that probes the API; report findings before committing the phase plan.
+2. PowerGrades are project-local. Do we ship a default `GymBlueOrange-v1.drx` in `templates/`? Or require the user to create their own and reference by name?
+3. Where do we store the `<name>_apply.py` template? Inside the skill folder feels right, but Resolve script discovery is path-based — we may need to write the generated script directly into `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/`. Need to handle both "ship next to roughcut" and "install for Resolve" paths.
+
+## Branch / worktree setup
+
+```bash
+cd /Users/william-meroxa/Development/buttercut
+git checkout -b sprint/editorial-automation
+# or use a worktree to keep main clean for ad-hoc edits:
+git worktree add ../buttercut-sprint-01 sprint/editorial-automation
+```

--- a/docs/sprints/sprint-01-editorial-automation.md
+++ b/docs/sprints/sprint-01-editorial-automation.md
@@ -23,7 +23,7 @@ The recipe + apply-script architecture closes that loop. ButterCut already knows
 
 ## Architecture
 
-```
+```text
 ButterCut roughcut skill
   ├── highlight-reel_<ts>.yaml         (existing)
   ├── highlight-reel_<ts>.xml          (existing — Resolve xmeml v5)
@@ -123,7 +123,7 @@ Manual finishing: pick music, drop SFX onto markers, write title card text, rend
 ## Branch / worktree setup
 
 ```bash
-cd /Users/william-meroxa/Development/buttercut
+cd /path/to/buttercut
 git checkout -b sprint/editorial-automation
 # or use a worktree to keep main clean for ad-hoc edits:
 git worktree add ../buttercut-sprint-01 sprint/editorial-automation

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -1,5 +1,6 @@
 require_relative 'buttercut/fcpx'
 require_relative 'buttercut/fcp7'
+require_relative 'buttercut/recipe'
 
 # ButterCut - Video editor XML generator
 #

--- a/lib/buttercut/recipe.rb
+++ b/lib/buttercut/recipe.rb
@@ -109,10 +109,19 @@ class ButterCut
       raise ArgumentError, "clips must be a non-empty array" unless @clips.is_a?(Array) && !@clips.empty?
 
       @clips.each { |clip| validate_clip!(clip) }
+
+      duplicates = clip_indices.tally.select { |_, count| count > 1 }.keys
+      unless duplicates.empty?
+        raise ArgumentError, "clip indices must be unique, duplicates: #{duplicates.inspect}"
+      end
     end
 
     def clip_indices
       @clip_indices ||= @clips.map { |c| c["index"] }
+    end
+
+    def clip_positions
+      @clip_positions ||= @clips.each_with_index.to_h { |clip, pos| [clip["index"], pos] }
     end
 
     def validate_clip!(clip)
@@ -120,13 +129,17 @@ class ButterCut
       validate_positive_int!(clip["index"], "clip index")
       validate_string!(clip["source_file"], "clip source_file")
 
-      (clip["speed_ramps"] || []).each { |ramp| validate_speed_ramp!(ramp, clip["index"]) }
+      speed_ramps = clip["speed_ramps"] || []
+      raise ArgumentError, "clip #{clip["index"]} speed_ramps must be an array" unless speed_ramps.is_a?(Array)
+      speed_ramps.each { |ramp| validate_speed_ramp!(ramp, clip["index"]) }
 
       if clip.key?("color_tag") && !CLIP_COLOR_TAGS.include?(clip["color_tag"])
         raise ArgumentError, "clip #{clip["index"]} color_tag #{clip["color_tag"].inspect} not in #{CLIP_COLOR_TAGS.inspect}"
       end
 
-      (clip["markers"] || []).each { |marker| validate_marker!(marker, clip["index"]) }
+      markers = clip["markers"] || []
+      raise ArgumentError, "clip #{clip["index"]} markers must be an array" unless markers.is_a?(Array)
+      markers.each { |marker| validate_marker!(marker, clip["index"]) }
     end
 
     def validate_speed_ramp!(ramp, clip_index)
@@ -195,8 +208,8 @@ class ButterCut
         missing = [a, b].reject { |i| clip_indices.include?(i) }
         raise ArgumentError, "transition between references unknown clip index #{missing.first}"
       end
-      unless b == a + 1
-        raise ArgumentError, "transition between #{between.inspect} must be adjacent (b == a + 1)"
+      unless clip_positions[b] == clip_positions[a] + 1
+        raise ArgumentError, "transition between #{between.inspect} must reference adjacent clips in recipe order"
       end
 
       unless TRANSITION_TYPES.include?(t["type"])

--- a/lib/buttercut/recipe.rb
+++ b/lib/buttercut/recipe.rb
@@ -1,0 +1,226 @@
+require 'json'
+
+class ButterCut
+  # Editorial recipe emitted alongside the rough-cut XML. Captures per-clip
+  # directives (speed ramps, color tags, markers), transitions between clips,
+  # an optional title card, render preset, and PowerGrade reference. The
+  # recipe is consumed by a Resolve apply script (see Sprint 1).
+  class Recipe
+    SCHEMA_VERSION = 1
+
+    CLIP_COLOR_TAGS = %w[
+      Orange Apricot Yellow Lime Olive Green Teal Navy Blue
+      Purple Violet Pink Tan Beige Brown Chocolate
+    ].freeze
+
+    MARKER_COLORS = %w[
+      Blue Cyan Green Yellow Red Pink Purple Fuchsia Rose
+      Lavender Sky Mint Lemon Sand Cocoa Cream
+    ].freeze
+
+    EASE_TYPES = %w[linear ease-in ease-out ease-in-out].freeze
+    TRANSITION_TYPES = %w[dip_to_color cross_dissolve].freeze
+    DIP_COLORS = %w[black white].freeze
+
+    def self.from_hash(hash)
+      raise ArgumentError, "recipe hash required" unless hash.is_a?(Hash)
+
+      new(
+        version: hash["version"],
+        library: hash["library"],
+        timeline: hash["timeline"],
+        clips: hash["clips"],
+        render_preset: hash["render_preset"],
+        powergrade: hash["powergrade"],
+        transitions: hash["transitions"] || [],
+        title_card: hash["title_card"]
+      )
+    end
+
+    def self.load(path)
+      from_hash(JSON.parse(File.read(path)))
+    end
+
+    def initialize(version:, library:, timeline:, clips:, render_preset: nil, powergrade: nil, transitions: [], title_card: nil)
+      @version = version
+      @library = library
+      @timeline = timeline
+      @clips = clips
+      @render_preset = render_preset
+      @powergrade = powergrade
+      @transitions = transitions
+      @title_card = title_card
+
+      validate!
+    end
+
+    def to_h
+      h = {
+        "version" => @version,
+        "library" => @library,
+        "timeline" => @timeline
+      }
+      h["render_preset"] = @render_preset if @render_preset
+      h["powergrade"] = @powergrade if @powergrade
+      h["clips"] = @clips
+      h["transitions"] = @transitions unless @transitions.empty?
+      h["title_card"] = @title_card if @title_card
+      h
+    end
+
+    def to_json(*args)
+      JSON.generate(to_h, *args)
+    end
+
+    def save(path)
+      File.write(path, JSON.pretty_generate(to_h))
+    end
+
+    private
+
+    def validate!
+      validate_version!
+      validate_string!(@library, "library")
+      validate_string!(@timeline, "timeline")
+      validate_clips!
+      validate_render_preset! if @render_preset
+      validate_powergrade! if @powergrade
+      validate_transitions!
+      validate_title_card! if @title_card
+    end
+
+    def validate_version!
+      raise ArgumentError, "version must be #{SCHEMA_VERSION}, got #{@version.inspect}" unless @version == SCHEMA_VERSION
+    end
+
+    def validate_string!(value, field)
+      raise ArgumentError, "#{field} required" if value.nil? || !value.is_a?(String) || value.empty?
+    end
+
+    def validate_positive_int!(value, field)
+      raise ArgumentError, "#{field} must be a positive integer, got #{value.inspect}" unless value.is_a?(Integer) && value.positive?
+    end
+
+    def validate_non_negative_number!(value, field)
+      raise ArgumentError, "#{field} must be a non-negative number, got #{value.inspect}" unless value.is_a?(Numeric) && value >= 0
+    end
+
+    def validate_clips!
+      raise ArgumentError, "clips must be a non-empty array" unless @clips.is_a?(Array) && !@clips.empty?
+
+      @clips.each { |clip| validate_clip!(clip) }
+    end
+
+    def clip_indices
+      @clip_indices ||= @clips.map { |c| c["index"] }
+    end
+
+    def validate_clip!(clip)
+      raise ArgumentError, "clip must be a hash" unless clip.is_a?(Hash)
+      validate_positive_int!(clip["index"], "clip index")
+      validate_string!(clip["source_file"], "clip source_file")
+
+      (clip["speed_ramps"] || []).each { |ramp| validate_speed_ramp!(ramp, clip["index"]) }
+
+      if clip.key?("color_tag") && !CLIP_COLOR_TAGS.include?(clip["color_tag"])
+        raise ArgumentError, "clip #{clip["index"]} color_tag #{clip["color_tag"].inspect} not in #{CLIP_COLOR_TAGS.inspect}"
+      end
+
+      (clip["markers"] || []).each { |marker| validate_marker!(marker, clip["index"]) }
+    end
+
+    def validate_speed_ramp!(ramp, clip_index)
+      raise ArgumentError, "clip #{clip_index} speed_ramp must be a hash" unless ramp.is_a?(Hash)
+      validate_non_negative_number!(ramp["at"], "clip #{clip_index} speed_ramp at")
+      speed = ramp["speed"]
+      unless speed.is_a?(Numeric) && speed > 0
+        raise ArgumentError, "clip #{clip_index} speed_ramp speed must be > 0, got #{speed.inspect}"
+      end
+      unless EASE_TYPES.include?(ramp["ease"])
+        raise ArgumentError, "clip #{clip_index} speed_ramp ease #{ramp["ease"].inspect} not in #{EASE_TYPES.inspect}"
+      end
+    end
+
+    def validate_marker!(marker, clip_index)
+      raise ArgumentError, "clip #{clip_index} marker must be a hash" unless marker.is_a?(Hash)
+      validate_non_negative_number!(marker["at"], "clip #{clip_index} marker at")
+      name = marker["name"]
+      raise ArgumentError, "clip #{clip_index} marker name required" if !name.is_a?(String) || name.empty?
+      unless MARKER_COLORS.include?(marker["color"])
+        raise ArgumentError, "clip #{clip_index} marker color #{marker["color"].inspect} not in #{MARKER_COLORS.inspect}"
+      end
+    end
+
+    def validate_render_preset!
+      raise ArgumentError, "render_preset must be a hash" unless @render_preset.is_a?(Hash)
+      validate_string!(@render_preset["format"], "render_preset format")
+      validate_string!(@render_preset["codec"], "render_preset codec")
+      validate_string!(@render_preset["resolution"], "render_preset resolution")
+      validate_positive_int!(@render_preset["bitrate_kbps"], "render_preset bitrate_kbps")
+    end
+
+    def validate_powergrade!
+      raise ArgumentError, "powergrade must be a hash" unless @powergrade.is_a?(Hash)
+      validate_string!(@powergrade["name"], "powergrade name")
+
+      apply_to = @powergrade["apply_to"]
+      case apply_to
+      when "all"
+        # ok
+      when Array
+        apply_to.each do |idx|
+          unless clip_indices.include?(idx)
+            raise ArgumentError, "powergrade apply_to references unknown clip index #{idx}"
+          end
+        end
+      else
+        raise ArgumentError, "powergrade apply_to must be 'all' or an array of clip indices, got #{apply_to.inspect}"
+      end
+    end
+
+    def validate_transitions!
+      raise ArgumentError, "transitions must be an array" unless @transitions.is_a?(Array)
+      @transitions.each { |t| validate_transition!(t) }
+    end
+
+    def validate_transition!(t)
+      raise ArgumentError, "transition must be a hash" unless t.is_a?(Hash)
+
+      between = t["between"]
+      unless between.is_a?(Array) && between.length == 2 && between.all? { |i| i.is_a?(Integer) }
+        raise ArgumentError, "transition between must be a [a, b] pair of integers, got #{between.inspect}"
+      end
+      a, b = between
+      unless clip_indices.include?(a) && clip_indices.include?(b)
+        missing = [a, b].reject { |i| clip_indices.include?(i) }
+        raise ArgumentError, "transition between references unknown clip index #{missing.first}"
+      end
+      unless b == a + 1
+        raise ArgumentError, "transition between #{between.inspect} must be adjacent (b == a + 1)"
+      end
+
+      unless TRANSITION_TYPES.include?(t["type"])
+        raise ArgumentError, "transition type #{t["type"].inspect} not in #{TRANSITION_TYPES.inspect}"
+      end
+
+      validate_positive_int!(t["duration_frames"], "transition duration_frames")
+
+      if t["type"] == "dip_to_color"
+        unless DIP_COLORS.include?(t["color"])
+          raise ArgumentError, "dip_to_color transition color #{t["color"].inspect} not in #{DIP_COLORS.inspect}"
+        end
+      end
+    end
+
+    def validate_title_card!
+      raise ArgumentError, "title_card must be a hash" unless @title_card.is_a?(Hash)
+      at_clip = @title_card["at_clip"]
+      unless clip_indices.include?(at_clip)
+        raise ArgumentError, "title_card at_clip references unknown clip index #{at_clip.inspect}"
+      end
+      validate_string!(@title_card["text"], "title_card text")
+      validate_non_negative_number!(@title_card["fade_in_at"], "title_card fade_in_at")
+      validate_positive_int!(@title_card["fade_in_frames"], "title_card fade_in_frames")
+    end
+  end
+end

--- a/lib/buttercut/recipe.rb
+++ b/lib/buttercut/recipe.rb
@@ -32,7 +32,7 @@ class ButterCut
         clips: hash["clips"],
         render_preset: hash["render_preset"],
         powergrade: hash["powergrade"],
-        transitions: hash["transitions"] || [],
+        transitions: hash.key?("transitions") ? hash["transitions"] : [],
         title_card: hash["title_card"]
       )
     end

--- a/lib/buttercut/recipe.rb
+++ b/lib/buttercut/recipe.rb
@@ -129,7 +129,7 @@ class ButterCut
       validate_positive_int!(clip["index"], "clip index")
       validate_string!(clip["source_file"], "clip source_file")
 
-      speed_ramps = clip["speed_ramps"] || []
+      speed_ramps = clip.key?("speed_ramps") ? clip["speed_ramps"] : []
       raise ArgumentError, "clip #{clip["index"]} speed_ramps must be an array" unless speed_ramps.is_a?(Array)
       speed_ramps.each { |ramp| validate_speed_ramp!(ramp, clip["index"]) }
 
@@ -137,7 +137,7 @@ class ButterCut
         raise ArgumentError, "clip #{clip["index"]} color_tag #{clip["color_tag"].inspect} not in #{CLIP_COLOR_TAGS.inspect}"
       end
 
-      markers = clip["markers"] || []
+      markers = clip.key?("markers") ? clip["markers"] : []
       raise ArgumentError, "clip #{clip["index"]} markers must be an array" unless markers.is_a?(Array)
       markers.each { |marker| validate_marker!(marker, clip["index"]) }
     end

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -133,6 +133,37 @@ RSpec.describe ButterCut::Recipe do
     end
   end
 
+  describe 'duplicate clip indices' do
+    it 'rejects clips with duplicate index values' do
+      bad = valid_hash.dup
+      bad["clips"] = [
+        { "index" => 1, "source_file" => "a.mp4" },
+        { "index" => 1, "source_file" => "b.mp4" }
+      ]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /duplicate/i)
+    end
+  end
+
+  describe 'array-typed fields on clips' do
+    it 'rejects non-array speed_ramps' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "speed_ramps" => "fast" }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed_ramps.*array/)
+    end
+
+    it 'rejects non-array markers' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "markers" => 1 }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /markers.*array/)
+    end
+  end
+
   describe 'speed_ramp validation' do
     it 'rejects speed of 0' do
       bad = valid_hash.dup

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -155,6 +155,22 @@ RSpec.describe ButterCut::Recipe do
       expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed_ramps.*array/)
     end
 
+    it 'rejects null speed_ramps' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "speed_ramps" => nil }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed_ramps.*array/)
+    end
+
+    it 'rejects null markers' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "markers" => nil }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /markers.*array/)
+    end
+
     it 'rejects non-array markers' do
       bad = valid_hash.dup
       bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "markers" => 1 }]

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -1,0 +1,289 @@
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe ButterCut::Recipe do
+  let(:valid_hash) do
+    {
+      "version" => 1,
+      "library" => "march-30-workout",
+      "timeline" => "highlight-reel_20260430_184655",
+      "render_preset" => {
+        "format" => "mp4",
+        "codec" => "h264",
+        "resolution" => "1080p",
+        "bitrate_kbps" => 25000
+      },
+      "powergrade" => { "name" => "GymBlueOrange-v1", "apply_to" => "all" },
+      "clips" => [
+        {
+          "index" => 3,
+          "source_file" => "medicine-ball-slams.mp4",
+          "speed_ramps" => [
+            { "at" => 1.5, "speed" => 200, "ease" => "ease-out" },
+            { "at" => 2.5, "speed" => 100, "ease" => "ease-in" }
+          ],
+          "color_tag" => "Orange",
+          "markers" => [{ "at" => 1.8, "name" => "impact", "color" => "Red" }]
+        },
+        { "index" => 4, "source_file" => "rest.mp4" },
+        { "index" => 11, "source_file" => "jump-rope.mp4" },
+        { "index" => 12, "source_file" => "hero-closer.mp4" }
+      ],
+      "transitions" => [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 },
+        { "between" => [11, 12], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }
+      ],
+      "title_card" => {
+        "at_clip" => 12,
+        "text" => "{{user_handle}}",
+        "fade_in_at" => 0.5,
+        "fade_in_frames" => 6
+      }
+    }
+  end
+
+  describe '.from_hash' do
+    it 'round-trips a canonical recipe without loss' do
+      recipe = described_class.from_hash(valid_hash)
+      expect(recipe.to_h).to eq(valid_hash)
+    end
+
+    it 'round-trips through JSON file save/load' do
+      recipe = described_class.from_hash(valid_hash)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'recipe.json')
+        recipe.save(path)
+        loaded = described_class.load(path)
+        expect(loaded.to_h).to eq(valid_hash)
+        expect(JSON.parse(File.read(path))).to eq(valid_hash)
+      end
+    end
+
+    it 'accepts a minimal recipe (no optional fields)' do
+      minimal = {
+        "version" => 1,
+        "library" => "lib",
+        "timeline" => "t",
+        "clips" => [{ "index" => 1, "source_file" => "a.mp4" }]
+      }
+      expect(described_class.from_hash(minimal).to_h).to eq(minimal)
+    end
+  end
+
+  describe 'version validation' do
+    it 'rejects an unknown version' do
+      expect {
+        described_class.from_hash(valid_hash.merge("version" => 2))
+      }.to raise_error(ArgumentError, /version/)
+    end
+
+    it 'rejects a missing version' do
+      expect {
+        described_class.from_hash(valid_hash.reject { |k, _| k == "version" })
+      }.to raise_error(ArgumentError, /version/)
+    end
+  end
+
+  describe 'top-level validation' do
+    it 'rejects a missing library' do
+      expect {
+        described_class.from_hash(valid_hash.merge("library" => ""))
+      }.to raise_error(ArgumentError, /library/)
+    end
+
+    it 'rejects a missing timeline' do
+      expect {
+        described_class.from_hash(valid_hash.merge("timeline" => nil))
+      }.to raise_error(ArgumentError, /timeline/)
+    end
+
+    it 'rejects empty clips' do
+      expect {
+        described_class.from_hash(valid_hash.merge("clips" => []))
+      }.to raise_error(ArgumentError, /clips/)
+    end
+  end
+
+  describe 'clip validation' do
+    it 'rejects a clip without an index' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "source_file" => "x.mp4" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /index/)
+    end
+
+    it 'rejects a clip with a non-positive index' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 0, "source_file" => "x.mp4" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /index/)
+    end
+
+    it 'rejects a clip with empty source_file' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /source_file/)
+    end
+
+    it 'rejects an unknown color_tag' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "color_tag" => "Mauve" }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /color_tag/)
+    end
+  end
+
+  describe 'speed_ramp validation' do
+    it 'rejects speed of 0' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => 0.0, "speed" => 0, "ease" => "linear" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed/)
+    end
+
+    it 'rejects negative at' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => -0.1, "speed" => 100, "ease" => "linear" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /at/)
+    end
+
+    it 'rejects unknown ease' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => 0.0, "speed" => 100, "ease" => "bouncy" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /ease/)
+    end
+  end
+
+  describe 'marker validation' do
+    it 'rejects an unknown marker color' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "markers" => [{ "at" => 0.0, "name" => "x", "color" => "Chartreuse" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /marker.*color/i)
+    end
+
+    it 'rejects an empty marker name' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "markers" => [{ "at" => 0.0, "name" => "", "color" => "Red" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /marker.*name/i)
+    end
+  end
+
+  describe 'transition validation' do
+    it 'rejects between referencing a clip that does not exist' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 },
+        { "between" => [99, 100], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 }
+      ]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /transition.*99/)
+    end
+
+    it 'rejects non-adjacent between' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 11], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /adjacent/i)
+    end
+
+    it 'rejects non-positive duration_frames' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 0 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /duration_frames/)
+    end
+
+    it 'rejects unknown transition type' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "wipe", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /transition.*type/i)
+    end
+
+    it 'rejects unknown dip color' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "purple", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /dip.*color/i)
+    end
+  end
+
+  describe 'title_card validation' do
+    it 'rejects at_clip referencing a missing clip index' do
+      bad = valid_hash.dup
+      bad["title_card"] = bad["title_card"].merge("at_clip" => 999)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /title_card.*999/)
+    end
+
+    it 'rejects non-positive fade_in_frames' do
+      bad = valid_hash.dup
+      bad["title_card"] = bad["title_card"].merge("fade_in_frames" => 0)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /fade_in_frames/)
+    end
+  end
+
+  describe 'render_preset validation' do
+    it 'rejects non-positive bitrate_kbps' do
+      bad = valid_hash.dup
+      bad["render_preset"] = bad["render_preset"].merge("bitrate_kbps" => 0)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /bitrate_kbps/)
+    end
+
+    it 'rejects empty codec' do
+      bad = valid_hash.dup
+      bad["render_preset"] = bad["render_preset"].merge("codec" => "")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /codec/)
+    end
+  end
+
+  describe 'powergrade validation' do
+    it 'accepts apply_to with explicit clip indices' do
+      good = valid_hash.dup
+      good["powergrade"] = { "name" => "X", "apply_to" => [3, 4] }
+      expect(described_class.from_hash(good).to_h["powergrade"]["apply_to"]).to eq([3, 4])
+    end
+
+    it 'rejects apply_to referencing a missing clip' do
+      bad = valid_hash.dup
+      bad["powergrade"] = { "name" => "X", "apply_to" => [3, 999] }
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /powergrade.*999/)
+    end
+
+    it 'rejects unknown apply_to string' do
+      bad = valid_hash.dup
+      bad["powergrade"] = { "name" => "X", "apply_to" => "some" }
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /apply_to/)
+    end
+  end
+end

--- a/templates/highlight_reel_recipe.md
+++ b/templates/highlight_reel_recipe.md
@@ -1,0 +1,55 @@
+# Highlight Reel Recipe
+
+A reusable formula for ~30-second cinematic highlight reels (workouts, sports, action). When asked for a "highlight reel" or "hype edit", ButterCut should follow this structure.
+
+## Target spec
+
+- **Duration:** 28–35 seconds (default 30s).
+- **Cut count:** 10–14 clips.
+- **Average shot length:** 1.5–2.5s, with one held closing beat (3–5s).
+- **Energy curve:** opener → rapid alternating peaks → micro-rest beat → climax → calm hero hold.
+
+## Editorial structure
+
+1. **Opener (2–3s)** — wide kinetic shot establishing motion and tone. Best if it shows the subject in their element. Slight speed ramp from slow to normal works well.
+2. **Energy block A (8–10s, 4 clips)** — rapid alternation between two contrasting actions/textures (strength vs. striking, lifting vs. cardio, etc.). Each shot 1.5–2.5s. Cut on beat.
+3. **Breath beat (2s, 1 clip)** — quieter detail shot to give the eye a rest. Side profile, close-up, reflection — anything calmer than the surrounding pace.
+4. **Energy block B (6–8s, 3–4 clips)** — return to high energy with new angles. Mix in at least one through-something composition (rack, bag, glass, foreground bokeh).
+5. **Build (2–3s, 1–2 clips)** — fast inserts, optionally sped up to 150–200%. Compresses time before the closer.
+6. **Hero closer (3–5s)** — single held shot. Subject centered or in a strong stance, often looking at camera. Speed ramps down to 60–80% in the final beat. Color/look pushed strongest here.
+
+## Selection priorities
+
+- **Variety over completeness** — show 6–8 different exercises rather than every one.
+- **Strongest stylistic frames win** — through-rack, through-bag, foreground bokeh, rear/mirror angles all beat clean wide shots.
+- **End with the hero** — if any clip has a posed/portrait moment, save it for last.
+- **Skip mistakes** — re-racking, fumbles, breaks. Cut around them.
+
+## Pacing rules
+
+- No two adjacent clips from the same source file unless intentional rhythm.
+- Vary shot scale: never put two wides or two tight shots back-to-back.
+- Vary direction of motion: if clip N is moving left-to-right, clip N+1 should not.
+- Cuts should land on downbeats when scored to music (this is the editor's job in Resolve, not ButterCut's — but plan in/out points around 2-beat increments at ~100 BPM = ~1.2s).
+
+## Closing-beat cinematic moves (for the editor in post)
+
+- Subtle slow-down (60–80%) over the final 0.5–1s.
+- Glow effect on highlights (Resolve: ResolveFX Stylize > Glow, low strength).
+- Color: deepest teal shadows, warm skin highlights.
+- Title card or signature can fade in during the slowdown.
+
+## Inputs ButterCut needs
+
+When invoking the roughcut skill with this recipe:
+
+- `library_name` — required.
+- `target_duration` — default 30s, range 28–35s.
+- `vibe` — optional descriptor ("cinematic", "energetic", "dark trap", "Y2K-glitch"). Drives clip selection bias.
+- `closer_clip` — optional explicit pick for the hero shot. If omitted, ButterCut chooses from clips marked as having posed/portrait moments.
+- `exclude_moments` — optional list of "(file, time-range)" tuples to skip (e.g. known fumbles).
+
+## Output expectations
+
+- ButterCut produces the cuts-only YAML + XML.
+- A companion `_edit_guide.md` SHOULD be generated alongside the cut, with shot-by-shot post-production direction (color, ramps, transitions, SFX) for the editor to apply manually in their NLE.

--- a/templates/highlight_reel_template.yaml
+++ b/templates/highlight_reel_template.yaml
@@ -1,0 +1,118 @@
+# Highlight Reel Template (parameterized)
+#
+# This is a structural template for a ~30s highlight reel rough cut. ButterCut
+# fills in the source_file, in_point, and out_point fields by selecting the
+# strongest clips per the criteria in templates/highlight_reel_recipe.md.
+#
+# The role field is internal — it tells ButterCut what kind of clip belongs at
+# that timeline position. It does NOT appear in the final cut YAML produced for
+# export; it's used only during clip selection.
+
+description: "{{description}}"   # filled by ButterCut from the user request
+
+notes: |
+  Editorial approach (per highlight_reel_recipe.md):
+  - Opener establishes motion + tone
+  - Two energy blocks separated by a breath beat
+  - Build into a held hero closer
+  - All stylistic preferences (through-rack/bag, bokeh, rear/mirror) prioritized
+
+clips:
+  # Opener (2.0–3.0s) — wide kinetic motion shot
+  - role: opener
+    target_duration: 2.5
+    selection_criteria: "wide shot, kinetic motion, establishes subject and setting"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Energy block A — 4 clips alternating two contrasting actions (1.5–2.5s each)
+  - role: energy_a_1
+    target_duration: 2.5
+    selection_criteria: "high-energy action #1, prefer through-frame composition (rack/bag/bokeh)"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_2
+    target_duration: 2.0
+    selection_criteria: "contrasting action #2, rapid pace"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_3
+    target_duration: 2.0
+    selection_criteria: "back to action #1, NEW angle (rear/mirror or new exercise)"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_4
+    target_duration: 2.5
+    selection_criteria: "action #2 variant, vary shot scale from energy_a_2"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Breath beat (2.0s) — quieter detail shot
+  - role: breath
+    target_duration: 2.0
+    selection_criteria: "side profile, detail, or reflection — calmer than surrounding clips"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Energy block B — 3 clips, new angles (1.5–2.5s each)
+  - role: energy_b_1
+    target_duration: 2.0
+    selection_criteria: "fresh action, ideally through-something composition"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_b_2
+    target_duration: 2.0
+    selection_criteria: "different angle/scale from energy_b_1"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Build inserts (1.5s each) — short, fast, sets up the closer
+  - role: build_1
+    target_duration: 1.5
+    selection_criteria: "fast cut suitable for 150-200% speed ramp; brief peak energy"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: build_2
+    target_duration: 1.5
+    selection_criteria: "final accent before hero, prefers strike/peak/explosive moment"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Hero closer (3.0–5.0s) — held portrait/posed beat
+  - role: hero
+    target_duration: 3.0
+    selection_criteria: "subject centered, looking at camera or strong stance, posed/hero moment; ALWAYS the closer"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+metadata:
+  template: "highlight_reel_template.yaml"
+  recipe: "highlight_reel_recipe.md"
+  target_total_duration: "00:00:30.00"


### PR DESCRIPTION
## Summary
- Adds `ButterCut::Recipe` (`lib/buttercut/recipe.rb`) — versioned editorial recipe (speed ramps, color tags, markers, transitions, title card, render preset, PowerGrade) emitted alongside rough-cut XML.
- Validates everything in the initializer: schema version, clip-index references for transitions/title_card/powergrade, adjacent transitions, Resolve clip-color and marker-color palettes, and sign/positivity on numeric fields.
- Round-trips losslessly via `to_h` and JSON `save`/`load`.

This is a schema + class task only — wiring into the roughcut export is Phase 2 (#2).

Closes #1.

## Test plan
- [x] `bundle exec rspec spec/recipe_spec.rb` — 29 examples, 0 failures
- [x] Round-trip test: fixture hash → `Recipe.from_hash(h).to_h` deep-equals `h`
- [x] Round-trip via JSON file (`save` → `load`)
- [x] Rejects: bad version, missing required fields, `speed: 0`, negative `at`, unknown `color_tag` / marker color / transition type / dip color / ease, non-adjacent transitions, references to missing clip indices (transitions/title_card/powergrade), non-positive `duration_frames`/`fade_in_frames`/`bitrate_kbps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a versioned editorial recipe model and recipe-driven export/apply artifacts plus a highlight-reel template for ~30s cinematic cuts.

* **Documentation**
  * Added sprint planning and editorial workflow docs detailing phased work, verification criteria, and template usage guidance.

* **Tests**
  * Added comprehensive validation tests covering recipe schema, constraints, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->