### PR TITLE
Sprint 1 Phase 2: Roughcut agent emits recipe alongside YAML and XML

### DIFF
--- a/.claude/skills/roughcut/agent_instructions.md
+++ b/.claude/skills/roughcut/agent_instructions.md
@@ -80,6 +80,53 @@ Each clip needs:
 - `created_date`: `YYYY-MM-DD HH:MM:SS`
 - `total_duration`: Sum of all clips in `HH:MM:SS.ss` format
 
+### 4b. Capture Editorial Directives (during clip selection, NOT as a post-pass)
+
+While picking clips, also capture the editorial reasoning you're already doing — speed ramps, color tags, markers, transitions, title cards — into the same YAML. The exporter will turn this into a `.recipe.json` that a Resolve apply script consumes after import.
+
+Clips are referenced by their **1-based position in the `clips:` list** (assigned automatically — you don't write the index field).
+
+**Per-clip directives** (add directly to the clip):
+
+```yaml
+- source_file: medicine-ball-slams.mp4
+  in_point: "00:00:01.50"
+  out_point: "00:00:04.00"
+  dialogue: ""
+  visual_description: "..."
+  speed_ramps:
+    - { at: 0.0, speed: 200, ease: ease-out }   # ramp to 200% over the slam
+    - { at: 1.0, speed: 100, ease: ease-in }
+  color_tag: Orange                              # Resolve clip color tag
+  markers:
+    - { at: 0.3, name: impact, color: Red }      # SFX hook for the editor
+```
+
+**Top-level directives** (siblings of `clips:`):
+
+```yaml
+transitions:
+  - { between: [3, 4], type: dip_to_color, color: black, duration_frames: 4 }
+  - { between: [11, 12], type: dip_to_color, color: white, duration_frames: 4 }
+title_card:
+  at_clip: 12
+  text: "{{user_handle}}"
+  fade_in_at: 0.5
+  fade_in_frames: 6
+render_preset: { format: mp4, codec: h264, resolution: 1080p, bitrate_kbps: 25000 }
+powergrade: { name: GymBlueOrange-v1, apply_to: all }
+```
+
+**Allowed values** (validated at export — invalid values fail the export):
+
+- `ease`: `linear`, `ease-in`, `ease-out`, `ease-in-out`
+- `color_tag` (Resolve clip colors): `Orange`, `Apricot`, `Yellow`, `Lime`, `Olive`, `Green`, `Teal`, `Navy`, `Blue`, `Purple`, `Violet`, `Pink`, `Tan`, `Beige`, `Brown`, `Chocolate`
+- marker `color` (Resolve marker colors): `Blue`, `Cyan`, `Green`, `Yellow`, `Red`, `Pink`, `Purple`, `Fuchsia`, `Rose`, `Lavender`, `Sky`, `Mint`, `Lemon`, `Sand`, `Cocoa`, `Cream`
+- transition `type`: `dip_to_color` (requires `color: black|white`) or `cross_dissolve`
+- `transitions[*].between`: must reference adjacent clips in YAML order
+
+If you have no editorial directives for a clip or the cut as a whole, omit the fields — they're all optional. The recipe is still emitted with the clips alone.
+
 ### 5. Export to Video Editor
 
 Check `library.yaml` for the `editor` field. If it's set, use that value. If it's not set or empty, check `libraries/settings.yaml` for the default `editor` value and use that (also save it back to `library.yaml`). If neither has an editor set, ask the user for their editor choice (Final Cut Pro X, Adobe Premiere Pro, or DaVinci Resolve), then save their choice back to both `library.yaml` and `libraries/settings.yaml`.
@@ -105,5 +152,7 @@ Run the `backup-library` skill to preserve the completed work.
 Provide summary with:
 - Rough cut name and duration
 - Number of clips included
-- File path for XML
+- File paths for XML and recipe.json
 - Backup confirmation
+
+The exporter writes `<roughcut>.recipe.json` next to the XML automatically — no separate command needed.

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -4,6 +4,7 @@
 require 'date'
 require 'yaml'
 require 'buttercut'
+require_relative 'recipe_from_roughcut'
 
 def timecode_to_seconds(timecode)
   # Convert HH:MM:SS or HH:MM:SS.s to seconds (supports decimal seconds)
@@ -104,6 +105,16 @@ def main
   puts "\n✓ Rough cut exported to: #{output_path}"
 
   validate_fcpxml(output_path) if editor_symbol == :fcpx
+
+  recipe_path = output_path.sub(/\.[^.]+\z/, '.recipe.json')
+  timeline_name = File.basename(roughcut_path, File.extname(roughcut_path))
+  RecipeFromRoughcut.export(
+    roughcut_path: roughcut_path,
+    recipe_path: recipe_path,
+    library_name: library_name,
+    timeline_name: timeline_name
+  )
+  puts "✓ Recipe exported to: #{recipe_path}"
 end
 
 def validate_fcpxml(xml_path)

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -66,8 +66,9 @@ def main
     source_file = clip['source_file']
 
     unless video_paths[source_file]
-      puts "Warning: Source file not found in library data: #{source_file}"
-      next
+      warn "Error: Source file not found in library data: #{source_file}"
+      warn "Refusing to export — silently skipping a clip would break recipe.json clip indices."
+      exit 1
     end
 
     full_path = video_paths[source_file]
@@ -106,7 +107,7 @@ def main
 
   validate_fcpxml(output_path) if editor_symbol == :fcpx
 
-  recipe_path = output_path.sub(/\.[^.]+\z/, '.recipe.json')
+  recipe_path = output_path.sub(/\.[^.]+\z/, '') + '.recipe.json'
   timeline_name = File.basename(roughcut_path, File.extname(roughcut_path))
   RecipeFromRoughcut.export(
     roughcut_path: roughcut_path,

--- a/.claude/skills/roughcut/recipe_from_roughcut.rb
+++ b/.claude/skills/roughcut/recipe_from_roughcut.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+# Build a ButterCut::Recipe (and its JSON file) from a rough-cut YAML.
+#
+# The YAML is the source of truth: clips are numbered 1..N by YAML order,
+# and editorial directives (speed_ramps, color_tag, markers, transitions,
+# title_card, render_preset, powergrade) are read off the same document.
+
+require 'date'
+require 'yaml'
+require 'buttercut'
+
+class RecipeFromRoughcut
+  def self.export(roughcut_path:, recipe_path:, library_name:, timeline_name:)
+    new(
+      roughcut_path: roughcut_path,
+      recipe_path: recipe_path,
+      library_name: library_name,
+      timeline_name: timeline_name
+    ).export
+  end
+
+  def initialize(roughcut_path:, recipe_path:, library_name:, timeline_name:)
+    raise ArgumentError, "roughcut_path required" if roughcut_path.nil? || roughcut_path.empty?
+    raise ArgumentError, "recipe_path required" if recipe_path.nil? || recipe_path.empty?
+    raise ArgumentError, "library_name required" if library_name.nil? || library_name.empty?
+    raise ArgumentError, "timeline_name required" if timeline_name.nil? || timeline_name.empty?
+
+    @roughcut_path = roughcut_path
+    @recipe_path = recipe_path
+    @library_name = library_name
+    @timeline_name = timeline_name
+  end
+
+  def export
+    recipe = build_recipe
+    recipe.save(@recipe_path)
+    @recipe_path
+  end
+
+  def build_recipe
+    ButterCut::Recipe.from_hash(build_hash)
+  end
+
+  private
+
+  def roughcut
+    @roughcut ||= YAML.load_file(@roughcut_path, permitted_classes: [Date, Time, Symbol])
+  end
+
+  def build_hash
+    h = {
+      "version" => ButterCut::Recipe::SCHEMA_VERSION,
+      "library" => @library_name,
+      "timeline" => @timeline_name,
+      "clips" => build_clips
+    }
+    h["render_preset"] = stringify(roughcut["render_preset"]) if roughcut["render_preset"]
+    h["powergrade"] = stringify(roughcut["powergrade"]) if roughcut["powergrade"]
+    h["transitions"] = stringify(roughcut["transitions"]) if roughcut["transitions"]
+    h["title_card"] = stringify(roughcut["title_card"]) if roughcut["title_card"]
+    h
+  end
+
+  def build_clips
+    raw_clips = roughcut["clips"]
+    raise ArgumentError, "roughcut must have a clips array" unless raw_clips.is_a?(Array) && !raw_clips.empty?
+
+    raw_clips.each_with_index.map do |clip, i|
+      entry = {
+        "index" => i + 1,
+        "source_file" => clip["source_file"]
+      }
+      entry["speed_ramps"] = stringify(clip["speed_ramps"]) if clip.key?("speed_ramps")
+      entry["color_tag"] = clip["color_tag"] if clip.key?("color_tag")
+      entry["markers"] = stringify(clip["markers"]) if clip.key?("markers")
+      entry
+    end
+  end
+
+  # YAML round-trips with string keys by default, but nested hashes loaded from
+  # YAML may have symbol keys depending on author style. Normalize to strings so
+  # the output JSON matches the Recipe schema exactly.
+  def stringify(obj)
+    case obj
+    when Hash
+      obj.each_with_object({}) { |(k, v), h| h[k.to_s] = stringify(v) }
+    when Array
+      obj.map { |v| stringify(v) }
+    else
+      obj
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  if ARGV.length != 2
+    warn "Usage: #{$PROGRAM_NAME} <roughcut.yaml> <output.recipe.json>"
+    exit 1
+  end
+
+  roughcut_path = ARGV[0]
+  recipe_path = ARGV[1]
+
+  unless File.exist?(roughcut_path)
+    warn "Error: Rough cut file not found: #{roughcut_path}"
+    exit 1
+  end
+
+  library_match = roughcut_path.match(%r{libraries/([^/]+)/roughcuts})
+  unless library_match
+    warn "Error: Could not extract library name from path: #{roughcut_path}"
+    exit 1
+  end
+  library_name = library_match[1]
+  timeline_name = File.basename(roughcut_path, File.extname(roughcut_path))
+
+  RecipeFromRoughcut.export(
+    roughcut_path: roughcut_path,
+    recipe_path: recipe_path,
+    library_name: library_name,
+    timeline_name: timeline_name
+  )
+  puts "✓ Recipe exported to: #{recipe_path}"
+end

--- a/spec/recipe_from_roughcut_spec.rb
+++ b/spec/recipe_from_roughcut_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require 'json'
+
+require_relative '../.claude/skills/roughcut/recipe_from_roughcut'
+
+RSpec.describe RecipeFromRoughcut do
+  def write_yaml(dir, name, hash)
+    path = File.join(dir, name)
+    File.write(path, YAML.dump(hash))
+    path
+  end
+
+  let(:full_roughcut) do
+    {
+      "description" => "highlight reel",
+      "clips" => [
+        { "source_file" => "opener.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:02.50" },
+        { "source_file" => "energy_a_1.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:02.50" },
+        {
+          "source_file" => "medicine-ball-slams.mp4",
+          "in_point" => "00:00:01.50",
+          "out_point" => "00:00:04.00",
+          "speed_ramps" => [
+            { "at" => 0.0, "speed" => 200, "ease" => "ease-out" },
+            { "at" => 1.0, "speed" => 100, "ease" => "ease-in" }
+          ],
+          "color_tag" => "Orange",
+          "markers" => [{ "at" => 0.3, "name" => "impact", "color" => "Red" }]
+        },
+        { "source_file" => "hero.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:03.00" }
+      ],
+      "transitions" => [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }
+      ],
+      "title_card" => {
+        "at_clip" => 4, "text" => "{{user_handle}}", "fade_in_at" => 0.5, "fade_in_frames" => 6
+      },
+      "render_preset" => {
+        "format" => "mp4", "codec" => "h264", "resolution" => "1080p", "bitrate_kbps" => 25000
+      },
+      "powergrade" => { "name" => "GymBlueOrange-v1", "apply_to" => "all" }
+    }
+  end
+
+  it 'builds a valid Recipe from a directive-rich rough cut YAML' do
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "highlight-reel.yaml", full_roughcut)
+      recipe_path = File.join(dir, "highlight-reel.recipe.json")
+
+      described_class.export(
+        roughcut_path: yaml_path,
+        recipe_path: recipe_path,
+        library_name: "march-30-workout",
+        timeline_name: "highlight-reel_20260430_184655"
+      )
+
+      h = JSON.parse(File.read(recipe_path))
+      expect(h["version"]).to eq(1)
+      expect(h["library"]).to eq("march-30-workout")
+      expect(h["timeline"]).to eq("highlight-reel_20260430_184655")
+      expect(h["clips"].map { |c| c["index"] }).to eq([1, 2, 3, 4])
+      expect(h["clips"][2]["speed_ramps"].first).to eq({ "at" => 0.0, "speed" => 200, "ease" => "ease-out" })
+      expect(h["clips"][2]["color_tag"]).to eq("Orange")
+      expect(h["clips"][2]["markers"]).to eq([{ "at" => 0.3, "name" => "impact", "color" => "Red" }])
+      expect(h["transitions"]).to eq([{ "between" => [3, 4], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }])
+      expect(h["title_card"]["at_clip"]).to eq(4)
+      expect(h["render_preset"]["bitrate_kbps"]).to eq(25000)
+      expect(h["powergrade"]).to eq({ "name" => "GymBlueOrange-v1", "apply_to" => "all" })
+    end
+  end
+
+  it 'produces a minimal-but-valid recipe when the rough cut has no directives' do
+    minimal = {
+      "clips" => [
+        { "source_file" => "a.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:01.00" },
+        { "source_file" => "b.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:01.00" }
+      ]
+    }
+
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "cut.yaml", minimal)
+      recipe_path = File.join(dir, "cut.recipe.json")
+
+      described_class.export(
+        roughcut_path: yaml_path,
+        recipe_path: recipe_path,
+        library_name: "lib",
+        timeline_name: "t"
+      )
+
+      h = JSON.parse(File.read(recipe_path))
+      expect(h.keys).to contain_exactly("version", "library", "timeline", "clips")
+      expect(h["clips"]).to eq([
+        { "index" => 1, "source_file" => "a.mp4" },
+        { "index" => 2, "source_file" => "b.mp4" }
+      ])
+    end
+  end
+
+  it 'requires roughcut_path, recipe_path, library_name, and timeline_name' do
+    expect {
+      described_class.new(roughcut_path: "", recipe_path: "x", library_name: "y", timeline_name: "z")
+    }.to raise_error(ArgumentError, /roughcut_path/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: nil, library_name: "y", timeline_name: "z")
+    }.to raise_error(ArgumentError, /recipe_path/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: "y", library_name: "", timeline_name: "z")
+    }.to raise_error(ArgumentError, /library_name/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: "y", library_name: "z", timeline_name: nil)
+    }.to raise_error(ArgumentError, /timeline_name/)
+  end
+
+  it 'raises if the rough cut has no clips' do
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "empty.yaml", { "clips" => [] })
+      recipe_path = File.join(dir, "empty.recipe.json")
+      expect {
+        described_class.export(
+          roughcut_path: yaml_path, recipe_path: recipe_path,
+          library_name: "l", timeline_name: "t"
+        )
+      }.to raise_error(ArgumentError, /clips/)
+    end
+  end
+
+  it 'propagates Recipe validation errors (e.g. invalid color_tag)' do
+    bad = {
+      "clips" => [{ "source_file" => "a.mp4", "color_tag" => "Mauve" }]
+    }
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "bad.yaml", bad)
+      expect {
+        described_class.export(
+          roughcut_path: yaml_path,
+          recipe_path: File.join(dir, "bad.recipe.json"),
+          library_name: "l", timeline_name: "t"
+        )
+      }.to raise_error(ArgumentError, /color_tag/)
+    end
+  end
+end

--- a/templates/roughcut_template.yaml
+++ b/templates/roughcut_template.yaml
@@ -36,6 +36,26 @@ clips:
     dialogue: ""
     visual_description: "[POV from inside San Francisco Muni bus looking out window at passing street. Yellow safety handrails visible. Transit journey B-roll.]"
 
+# Optional editorial directives (consumed by lib/buttercut/recipe.rb to emit
+# <name>.recipe.json alongside the XML). Clips are numbered 1..N by YAML order;
+# transitions and title_card reference clips by that numeric index.
+#
+# Per-clip directives go on the clip itself:
+#   speed_ramps: [{ at: 0.0, speed: 200, ease: ease-out }]
+#   color_tag: Orange
+#   markers: [{ at: 0.3, name: impact, color: Red }]
+#
+# Top-level directives below — uncomment and fill as needed:
+# transitions:
+#   - { between: [3, 4], type: dip_to_color, color: white, duration_frames: 4 }
+# title_card:
+#   at_clip: 12
+#   text: "{{user_handle}}"
+#   fade_in_at: 0.5
+#   fade_in_frames: 6
+# render_preset: { format: mp4, codec: h264, resolution: 1080p, bitrate_kbps: 25000 }
+# powergrade: { name: GymBlueOrange-v1, apply_to: all }
+
 # Rough cut metadata
 metadata:
   created_date: ""  # Will be populated when rough cut is created


### PR DESCRIPTION
## Summary
- Extends the roughcut YAML schema with optional editorial directives (speed_ramps / color_tag / markers per clip; transitions / title_card / render_preset / powergrade at the top level).
- New `.claude/skills/roughcut/recipe_from_roughcut.rb` — pure data transform that builds a validated `ButterCut::Recipe` from the YAML and writes \`<name>.recipe.json\`.
- `export_to_fcpxml.rb` now emits both XML and recipe.json in one invocation.
- `agent_instructions.md` gains section 4b telling the agent to capture editorial reasoning during clip selection (not as a post-pass).
- Roughcut template gets a commented example of every directive type.

Clips are numbered 1..N by YAML order — the agent doesn't author the index field. Transitions and title_card reference those numeric indices directly.

Closes #2.

## What's NOT in this PR
- `_edit_guide.html` (mentioned in acceptance, not in deliverables) — deferred to Phase 5 per the sprint plan, which calls it an existing prototype to be formalized.
- `march-30-workout` regression run — the library is gitignored, so the regression is verified via spec coverage with a synthetic fixture YAML. End-to-end run to be done locally.

## Test plan
- [x] \`bundle exec rspec spec/recipe_spec.rb spec/recipe_from_roughcut_spec.rb\` — 39 examples, 0 failures
- [x] Directive-rich fixture YAML round-trips into a valid Recipe (every field type covered)
- [x] Minimal YAML (no directives) produces a minimal-but-valid recipe — just version/library/timeline/clips
- [x] Required-args contract on \`RecipeFromRoughcut.new\`
- [x] Empty clips array raises
- [x] Recipe validation errors propagate (e.g. invalid color_tag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rough-cut exports now automatically generate accompanying recipe JSON files for enhanced editorial workflows.
  * Expanded editorial directive support: per-clip speed ramps, color tags, markers; plus transitions, title cards, render presets, and powergrade.

* **Bug Fixes**
  * Export will now fail if a referenced source file is missing, preventing incomplete outputs.

* **Documentation**
  * Updated rough-cut template with examples and guidance for all supported editorial directives.

* **Tests**
  * Added tests validating recipe generation, directive preservation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->