### PR TITLE
Sprint 1 Phase 3 prerequisite: Resolve scripting API audit

### DIFF
--- a/docs/sprints/sprint-01-resolve-api-audit.md
+++ b/docs/sprints/sprint-01-resolve-api-audit.md
@@ -1,0 +1,81 @@
+# Resolve Scripting API Audit (Sprint 1, Phase 3 prerequisite)
+
+**Status:** awaiting probe run · **Issue:** #3 · **Blocks:** #4 (Phase 3 apply script)
+
+## Background
+
+Phase 3 plans a per-cut Python script that consumes `<name>.recipe.json` and applies its directives to the imported timeline. Six capabilities sit on the critical path:
+
+1. **Speed ramps** — `TimelineItem` retime curve
+2. **Clip color tags** — `TimelineItem.SetClipColor`
+3. **Markers** — `TimelineItem.AddMarker`
+4. **PowerGrades** — apply a saved grade by name across all clips
+5. **Render presets** — load a saved preset and set it as current
+6. **Transitions** — insert dip-to-color / cross-dissolve between clips
+
+Some of these are well-supported on free Resolve. Others (transitions, PowerGrade-by-name) are documented gaps. This memo establishes verdicts before we commit Phase 3 scope.
+
+## Method
+
+1. Drop `scripts/resolve_api_audit.py` into Resolve's Edit scripts directory:
+   - macOS: `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/`
+   - Windows: `%APPDATA%\Blackmagic Design\DaVinci Resolve\Support\Fusion\Scripts\Edit\`
+   - Linux: `~/.local/share/DaVinciResolve/Fusion/Scripts/Edit/`
+2. Open Resolve, open any project with at least one clip on V1 of the current timeline.
+3. Open `Workspace > Console` (so the matrix prints somewhere visible).
+4. Run `Workspace > Scripts > Edit > resolve_api_audit`.
+5. Probe writes `~/buttercut_resolve_audit.json` and prints a feature matrix to the console.
+
+The probe is non-destructive: it adds and removes one disposable marker, sets and restores the first clip's color tag, and otherwise only reads.
+
+## Expected priors (from public Resolve scripting docs)
+
+These are the working assumptions going into the probe — to be confirmed or overturned by the run.
+
+| Capability      | Expected      | Reasoning |
+|-----------------|---------------|-----------|
+| `speed_ramps`   | Limited       | `GetClipProperty("Speed")` is documented; retime curve points are not a first-class API on free. Constant speed change is straightforward; multi-point ramps may require workarounds. |
+| `color_tags`    | Yes           | `SetClipColor` / `ClearClipColor` documented and stable across versions. |
+| `markers`       | Yes           | `AddMarker(frame, color, name, note, duration)` documented and stable. |
+| `powergrade`    | Limited       | No direct `ApplyPowerGradeByName()`. Accessible via `Gallery.GetGalleryStillAlbums()` → walk stills → apply. Workable but indirect; album naming matters. |
+| `render_preset` | Yes           | `LoadRenderPreset(name)` and `SetCurrentRenderMode()` documented. `GetRenderPresetList()` enumerates. |
+| `transitions`   | No (likely)   | The Resolve scripting API has historically lacked any public method to insert a transition between clips. The probe enumerates `*transition*` attributes on `project` / `timeline` / `TimelineItem` — if none surface, this is confirmed. |
+
+## Verdict matrix (TODO — fill after running the probe)
+
+Paste the rows from `~/buttercut_resolve_audit.json` here once you've run the script.
+
+| Capability      | API present | Probe result | Notes |
+|-----------------|-------------|--------------|-------|
+| `speed_ramps`   | TBD         | TBD          | TBD   |
+| `color_tags`    | TBD         | TBD          | TBD   |
+| `markers`       | TBD         | TBD          | TBD   |
+| `powergrade`    | TBD         | TBD          | TBD   |
+| `render_preset` | TBD         | TBD          | TBD   |
+| `transitions`   | TBD         | TBD          | TBD   |
+
+Probe environment:
+- Resolve product: TBD
+- Resolve version: TBD
+- Free or Studio: TBD
+
+## Phase 3 implications (TODO — finalize after verdict matrix)
+
+Two branches depending on the `transitions` verdict.
+
+**If transitions are scriptable:**
+- Phase 3 keeps the originally planned scope: speed ramps + color tags + markers + render preset + PowerGrade (best-effort) + transitions.
+- Recipe schema unchanged.
+
+**If transitions are not scriptable on free Resolve:**
+- Phase 3 ships everything *except* transitions. The recipe.json still carries the directives — they just won't be applied automatically.
+- The apply script logs a one-line note per transition: "Phase 4 (FCPXML 1.10) or manual: <type> between clip N and N+1".
+- Phase 4 (FCPXML 1.10 backend, currently optional) becomes the realistic path for transitions, since Resolve's FCPXML import is more permissive than Resolve's xmeml import.
+
+**For PowerGrade specifically** — even if the gallery-still walk is technically possible, the implementation cost may exceed the value. A documented one-click manual step ("right-click hero clip → Apply Grade > GymBlueOrange-v1") is acceptable for Phase 3 if the gallery API path turns out brittle. Decision deferred to verdict review.
+
+## Next steps
+
+1. Run the probe; paste results into the verdict matrix.
+2. Settle the transitions branch above.
+3. Open #4 (Phase 3 apply script) with finalized scope based on this memo.

--- a/scripts/resolve_api_audit.py
+++ b/scripts/resolve_api_audit.py
@@ -11,9 +11,10 @@ Run from inside Resolve via:
 
 Open the Console (Workspace > Console) before running so you can see the matrix.
 
-The probe is non-destructive: it adds one disposable marker to the current
-timeline (if any) and removes it on success. It does NOT modify clip color tags
-or save the project. It writes the result matrix to:
+The probe is non-destructive: it adds one disposable marker to an unused frame
+on the current timeline (if any) and removes it; it temporarily sets the first
+clip's color tag and restores the original value before exiting. It does NOT
+save the project. It writes the result matrix to:
   ~/buttercut_resolve_audit.json
 
 Paste that file back into the Phase 3 audit memo to finalize verdicts.
@@ -81,10 +82,23 @@ def probe_speed_ramp(ctx):
     item = ctx["first_clip"]
     if not item:
         return "skipped", "no clip on V1 to probe"
+    has_constant = hasattr(item, "GetClipProperty") and hasattr(item, "SetClipProperty")
     speed = item.GetClipProperty("Speed") if hasattr(item, "GetClipProperty") else None
-    has_retime = hasattr(item, "GetProperty") or hasattr(item, "SetClipProperty")
-    return ("yes" if speed is not None and has_retime else "limited",
-            f"GetClipProperty('Speed')={speed!r}; retime curve API on TimelineItem: {has_retime}")
+    # Look specifically for retime-curve / time-effect methods. Generic
+    # SetProperty/GetProperty don't count — they exist on builds where curve
+    # editing is unavailable.
+    ramp_methods = [
+        attr for attr in dir(item)
+        if any(needle in attr.lower() for needle in ("retime", "speedchange", "speedpoint", "timeeffect"))
+    ]
+    if ramp_methods:
+        return "yes", f"constant-speed via SetClipProperty('Speed') ({speed!r}); ramp methods: {ramp_methods}"
+    if has_constant:
+        return "limited", (
+            f"only constant speed via SetClipProperty('Speed') ({speed!r}); "
+            f"no retime/speedpoint/timeeffect methods on TimelineItem — multi-point ramps not in public API"
+        )
+    return "no", "no SetClipProperty on TimelineItem"
 
 
 def probe_color_tag(ctx):
@@ -94,16 +108,21 @@ def probe_color_tag(ctx):
     if not hasattr(item, "ClearClipColor") or not hasattr(item, "SetClipColor"):
         return "limited", "SetClipColor present but ClearClipColor missing"
     original = item.GetClipColor() if hasattr(item, "GetClipColor") else None
-    set_ok = item.SetClipColor("Orange")
-    if original:
-        item.SetClipColor(original)
-    else:
-        try:
-            item.ClearClipColor()
-        except Exception:
-            pass
+    set_ok = bool(item.SetClipColor("Orange"))
+    restore_ok = True
+    restore_err = None
+    try:
+        if original:
+            restore_ok = bool(item.SetClipColor(original))
+        else:
+            restore_ok = bool(item.ClearClipColor())
+    except Exception as e:
+        restore_ok = False
+        restore_err = f"{type(e).__name__}: {e}"
+    if set_ok and not restore_ok:
+        return "error", f"SetClipColor succeeded but restore failed ({restore_err or 'returned False'})"
     return ("yes" if set_ok else "no",
-            f"SetClipColor returned {set_ok!r}; original={original!r}")
+            f"SetClipColor returned {set_ok!r}; original={original!r}; restored={restore_ok!r}")
 
 
 def probe_marker(ctx):
@@ -111,49 +130,61 @@ def probe_marker(ctx):
     if not item:
         return "skipped", "no clip on V1 to probe"
     if not hasattr(item, "AddMarker") or not hasattr(item, "DeleteMarkerAtFrame"):
-        return "limited", "AddMarker present, DeleteMarkerAtFrame missing"
+        return "limited", "AddMarker / DeleteMarkerAtFrame missing"
+    if not hasattr(item, "GetMarkers"):
+        return "limited", "GetMarkers unavailable; skipping write probe to avoid colliding with existing markers"
+    existing = item.GetMarkers() or {}
+    used_frames = set()
+    for k in existing.keys():
+        try:
+            used_frames.add(int(k))
+        except Exception:
+            continue
     frame = 1
+    while frame in used_frames:
+        frame += 1
     added = item.AddMarker(frame, "Red", "buttercut_audit_probe", "buttercut audit", 1)
     if added:
         try:
-            item.DeleteMarkerAtFrame(frame)
-        except Exception:
-            pass
+            deleted = item.DeleteMarkerAtFrame(frame)
+            if not deleted:
+                return "error", f"AddMarker succeeded at frame {frame}, but DeleteMarkerAtFrame returned False"
+        except Exception as e:
+            return "error", f"AddMarker succeeded at frame {frame}, cleanup threw {type(e).__name__}: {e}"
     return ("yes" if added else "no",
-            f"AddMarker returned {added!r}; cleanup attempted")
+            f"AddMarker at frame {frame} returned {added!r}")
 
 
 def probe_powergrade(ctx):
     project = ctx["project"]
-    media_pool = project.GetMediaPool() if project and hasattr(project, "GetMediaPool") else None
     gallery = project.GetGallery() if project and hasattr(project, "GetGallery") else None
     if not gallery:
         return "limited", "Project.GetGallery() not available; PowerGrade-by-name not directly scriptable"
+    has_albums_api = hasattr(gallery, "GetGalleryStillAlbums") and hasattr(gallery, "GetCurrentStillAlbum")
+    if not has_albums_api:
+        return "limited", "Gallery present but album-walk API missing (no GetGalleryStillAlbums / GetCurrentStillAlbum)"
     albums = []
     try:
         albums = gallery.GetGalleryStillAlbums() or []
-    except Exception:
-        pass
-    has_apply = hasattr(gallery, "GetCurrentStillAlbum") and any(
-        hasattr(a, "GetStills") for a in albums
-    )
+    except Exception as e:
+        return "limited", f"GetGalleryStillAlbums raised {type(e).__name__}: {e}"
     album_names = [a.GetLabel() if hasattr(a, "GetLabel") else "?" for a in albums]
-    return ("limited" if has_apply else "no",
-            f"GalleryStillAlbums={album_names}; apply path requires gallery still walk, no direct ApplyPowerGradeByName()")
+    return ("limited",
+            f"album-walk API present (no direct ApplyPowerGradeByName); albums={album_names or '[]'}")
 
 
 def probe_render_preset(ctx):
     project = ctx["project"]
     if not project:
         return "skipped", "no project open"
-    presets = []
-    try:
-        presets = project.GetRenderPresetList() or []
-    except Exception:
-        pass
     has_load = hasattr(project, "LoadRenderPreset") and hasattr(project, "SetCurrentRenderMode")
-    return ("yes" if presets and has_load else "limited",
-            f"presets={len(presets)}; LoadRenderPreset+SetCurrentRenderMode={has_load}")
+    preset_count = None
+    try:
+        preset_count = len(project.GetRenderPresetList() or [])
+    except Exception:
+        preset_count = None
+    return ("yes" if has_load else "no",
+            f"LoadRenderPreset+SetCurrentRenderMode={has_load}; saved preset count={preset_count} (info only — verdict is API-driven)")
 
 
 def probe_transitions(ctx):

--- a/scripts/resolve_api_audit.py
+++ b/scripts/resolve_api_audit.py
@@ -106,7 +106,7 @@ def probe_color_tag(ctx):
     if not item:
         return "skipped", "no clip on V1 to probe"
     if not hasattr(item, "ClearClipColor") or not hasattr(item, "SetClipColor"):
-        return "limited", "SetClipColor present but ClearClipColor missing"
+        return "limited", "SetClipColor / ClearClipColor missing"
     original = item.GetClipColor() if hasattr(item, "GetClipColor") else None
     set_ok = bool(item.SetClipColor("Orange"))
     restore_ok = True

--- a/scripts/resolve_api_audit.py
+++ b/scripts/resolve_api_audit.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""DaVinci Resolve scripting API audit probe.
+
+Drop into:
+  macOS:   ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/
+  Windows: %APPDATA%\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Edit\\
+  Linux:   ~/.local/share/DaVinciResolve/Fusion/Scripts/Edit/
+
+Run from inside Resolve via:
+  Workspace > Scripts > Edit > resolve_api_audit
+
+Open the Console (Workspace > Console) before running so you can see the matrix.
+
+The probe is non-destructive: it adds one disposable marker to the current
+timeline (if any) and removes it on success. It does NOT modify clip color tags
+or save the project. It writes the result matrix to:
+  ~/buttercut_resolve_audit.json
+
+Paste that file back into the Phase 3 audit memo to finalize verdicts.
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+def get_resolve():
+    """Resolve injects `resolve` into the script's globals when run from
+    Workspace > Scripts. We also try the standard external bootstrap as a
+    fallback for users running externally with DaVinciResolveScript on path."""
+    if "resolve" in globals():
+        return globals()["resolve"]
+    try:
+        import DaVinciResolveScript as dvr_script  # type: ignore
+        return dvr_script.scriptapp("Resolve")
+    except Exception:
+        return None
+
+
+class Probe:
+    def __init__(self, name, present_check, probe):
+        self.name = name
+        self.present_check = present_check
+        self.probe = probe
+
+    def run(self, ctx):
+        try:
+            present = bool(self.present_check(ctx))
+        except Exception:
+            present = False
+
+        if not present:
+            return {
+                "capability": self.name,
+                "api_present": False,
+                "probe_result": "skipped",
+                "notes": "API entry point not found on this Resolve build."
+            }
+
+        try:
+            verdict, notes = self.probe(ctx)
+            return {
+                "capability": self.name,
+                "api_present": True,
+                "probe_result": verdict,
+                "notes": notes
+            }
+        except Exception as e:
+            return {
+                "capability": self.name,
+                "api_present": True,
+                "probe_result": "error",
+                "notes": f"{type(e).__name__}: {e}"
+            }
+
+
+def probe_speed_ramp(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    speed = item.GetClipProperty("Speed") if hasattr(item, "GetClipProperty") else None
+    has_retime = hasattr(item, "GetProperty") or hasattr(item, "SetClipProperty")
+    return ("yes" if speed is not None and has_retime else "limited",
+            f"GetClipProperty('Speed')={speed!r}; retime curve API on TimelineItem: {has_retime}")
+
+
+def probe_color_tag(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    if not hasattr(item, "ClearClipColor") or not hasattr(item, "SetClipColor"):
+        return "limited", "SetClipColor present but ClearClipColor missing"
+    original = item.GetClipColor() if hasattr(item, "GetClipColor") else None
+    set_ok = item.SetClipColor("Orange")
+    if original:
+        item.SetClipColor(original)
+    else:
+        try:
+            item.ClearClipColor()
+        except Exception:
+            pass
+    return ("yes" if set_ok else "no",
+            f"SetClipColor returned {set_ok!r}; original={original!r}")
+
+
+def probe_marker(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    if not hasattr(item, "AddMarker") or not hasattr(item, "DeleteMarkerAtFrame"):
+        return "limited", "AddMarker present, DeleteMarkerAtFrame missing"
+    frame = 1
+    added = item.AddMarker(frame, "Red", "buttercut_audit_probe", "buttercut audit", 1)
+    if added:
+        try:
+            item.DeleteMarkerAtFrame(frame)
+        except Exception:
+            pass
+    return ("yes" if added else "no",
+            f"AddMarker returned {added!r}; cleanup attempted")
+
+
+def probe_powergrade(ctx):
+    project = ctx["project"]
+    media_pool = project.GetMediaPool() if project and hasattr(project, "GetMediaPool") else None
+    gallery = project.GetGallery() if project and hasattr(project, "GetGallery") else None
+    if not gallery:
+        return "limited", "Project.GetGallery() not available; PowerGrade-by-name not directly scriptable"
+    albums = []
+    try:
+        albums = gallery.GetGalleryStillAlbums() or []
+    except Exception:
+        pass
+    has_apply = hasattr(gallery, "GetCurrentStillAlbum") and any(
+        hasattr(a, "GetStills") for a in albums
+    )
+    album_names = [a.GetLabel() if hasattr(a, "GetLabel") else "?" for a in albums]
+    return ("limited" if has_apply else "no",
+            f"GalleryStillAlbums={album_names}; apply path requires gallery still walk, no direct ApplyPowerGradeByName()")
+
+
+def probe_render_preset(ctx):
+    project = ctx["project"]
+    if not project:
+        return "skipped", "no project open"
+    presets = []
+    try:
+        presets = project.GetRenderPresetList() or []
+    except Exception:
+        pass
+    has_load = hasattr(project, "LoadRenderPreset") and hasattr(project, "SetCurrentRenderMode")
+    return ("yes" if presets and has_load else "limited",
+            f"presets={len(presets)}; LoadRenderPreset+SetCurrentRenderMode={has_load}")
+
+
+def probe_transitions(ctx):
+    project = ctx["project"]
+    timeline = ctx["timeline"]
+    has_anything = False
+    candidates = []
+    for obj_name, obj in (("project", project), ("timeline", timeline), ("first_clip", ctx["first_clip"])):
+        if obj is None:
+            continue
+        for attr in dir(obj):
+            if "transition" in attr.lower():
+                candidates.append(f"{obj_name}.{attr}")
+                has_anything = True
+    return ("yes" if has_anything else "no",
+            f"transition-related methods found: {candidates or 'none'}")
+
+
+PROBES = [
+    Probe("speed_ramps",   lambda ctx: ctx["first_clip"], probe_speed_ramp),
+    Probe("color_tags",    lambda ctx: ctx["first_clip"], probe_color_tag),
+    Probe("markers",       lambda ctx: ctx["first_clip"], probe_marker),
+    Probe("powergrade",    lambda ctx: ctx["project"],    probe_powergrade),
+    Probe("render_preset", lambda ctx: ctx["project"],    probe_render_preset),
+    Probe("transitions",   lambda ctx: ctx["timeline"] or ctx["project"], probe_transitions),
+]
+
+
+def build_context(resolve):
+    ctx = {"resolve": resolve, "project": None, "timeline": None, "first_clip": None}
+    if not resolve:
+        return ctx
+    pm = resolve.GetProjectManager()
+    if not pm:
+        return ctx
+    project = pm.GetCurrentProject()
+    ctx["project"] = project
+    if not project:
+        return ctx
+    timeline = project.GetCurrentTimeline()
+    ctx["timeline"] = timeline
+    if timeline and hasattr(timeline, "GetItemListInTrack"):
+        try:
+            items = timeline.GetItemListInTrack("video", 1) or []
+            if items:
+                ctx["first_clip"] = items[0]
+        except Exception:
+            pass
+    return ctx
+
+
+def main():
+    resolve = get_resolve()
+    if not resolve:
+        print("ERROR: could not connect to Resolve. Run from inside Resolve via Workspace > Scripts.")
+        sys.exit(1)
+
+    print(f"Resolve product: {resolve.GetProductName()}  version: {resolve.GetVersionString()}")
+    ctx = build_context(resolve)
+    print(f"  project: {ctx['project'].GetName() if ctx['project'] else '(none open)'}")
+    print(f"  timeline: {ctx['timeline'].GetName() if ctx['timeline'] else '(none)'}")
+    print(f"  first V1 clip: {ctx['first_clip'].GetName() if ctx['first_clip'] else '(none)'}")
+    print()
+
+    rows = [probe.run(ctx) for probe in PROBES]
+
+    width = max(len(r["capability"]) for r in rows)
+    print(f"{'capability'.ljust(width)}  api_present  probe_result  notes")
+    print(f"{'-' * width}  -----------  ------------  -----")
+    for r in rows:
+        print(f"{r['capability'].ljust(width)}  {str(r['api_present']).ljust(11)}  {r['probe_result'].ljust(12)}  {r['notes']}")
+
+    out_path = os.path.expanduser("~/buttercut_resolve_audit.json")
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "resolve_product": resolve.GetProductName(),
+        "resolve_version": resolve.GetVersionString(),
+        "results": rows,
+    }
+    try:
+        with open(out_path, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nWrote {out_path}")
+    except Exception as e:
+        print(f"\nFailed to write {out_path}: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()


### PR DESCRIPTION
## Summary
- New probe script \`scripts/resolve_api_audit.py\` that runs inside Resolve (\`Workspace > Scripts > Edit > resolve_api_audit\`) and reports a feature/probe matrix for the six Phase 3 capabilities. Non-destructive — it adds and removes a disposable marker, sets and restores the first clip's color tag, otherwise only reads. Writes JSON to \`~/buttercut_resolve_audit.json\`.
- New memo \`docs/sprints/sprint-01-resolve-api-audit.md\` with priors from public Resolve scripting docs, the verdict matrix (TBD pending probe run), and two pre-staged Phase 3 scope branches keyed on the transitions verdict.

## Capabilities probed
1. \`speed_ramps\` — \`TimelineItem\` retime curve
2. \`color_tags\` — \`SetClipColor\` / \`ClearClipColor\`
3. \`markers\` — \`AddMarker\` / \`DeleteMarkerAtFrame\`
4. \`powergrade\` — gallery still album walk (no direct \`ApplyByName\`)
5. \`render_preset\` — \`LoadRenderPreset\` + \`SetCurrentRenderMode\`
6. \`transitions\` — enumerates any \`*transition*\` attrs on project / timeline / TimelineItem

## What's NOT in this PR (intentional)
- The verdict matrix is filled by **you** running the probe in Resolve. A follow-up commit pastes the results back and finalizes the Phase 3 implications section. This PR can land with placeholders so #4 isn't blocked on a synchronous Resolve session.

Refs #3, blocks #4.

## Test plan
- [x] \`bundle exec rspec\` — no regressions (39 ButterCut specs unchanged; the 2 pre-existing fcpx fixture failures are not from this PR)
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` on the probe script — parses cleanly
- [ ] **Manual:** run \`Workspace > Scripts > Edit > resolve_api_audit\` in Resolve with a project + timeline + V1 clip open; paste matrix back into the memo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide describing a non-destructive Resolve scripting probe workflow and how to collect and interpret a verdict matrix.

* **New Features**
  * Added a standalone probe tool that exercises six Resolve scripting capabilities (speed ramps, color tags, markers, powergrades, render presets, transitions), prints a summary matrix, attempts best-effort cleanup, and writes a UTC‑timestamped JSON report to the user home.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->