### PR TITLE
Sprint 1 Phase 4: FCPXML 1.10 backend with timeMap speed ramps

### DIFF
--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -126,9 +126,17 @@ def main
 end
 
 def validate_fcpxml(xml_path)
-  dtd_path = File.expand_path('../../../dtd/FCPXMLv1_10.dtd', __dir__)
-  unless File.exist?(dtd_path)
-    puts "⚠ DTD not found at #{dtd_path}; skipping validation."
+  dtd_v110 = File.expand_path('../../../dtd/FCPXMLv1_10.dtd', __dir__)
+  dtd_v18 = File.expand_path('../../../dtd/FCPXMLv1_8.dtd', __dir__)
+
+  if File.exist?(dtd_v110)
+    dtd_path = dtd_v110
+    dtd_label = "FCPXMLv1_10.dtd"
+  elsif File.exist?(dtd_v18)
+    dtd_path = dtd_v18
+    dtd_label = "FCPXMLv1_8.dtd (best-effort fallback for 1.10 output)"
+  else
+    puts "⚠ No FCPXML DTD found in dtd/; skipping validation."
     return
   end
 
@@ -140,9 +148,9 @@ def validate_fcpxml(xml_path)
   # xmllint prints errors to stderr; --noout suppresses the doc dump on success.
   output = `xmllint --noout --dtdvalid "#{dtd_path}" "#{xml_path}" 2>&1`
   if $?.success?
-    puts "✓ FCPXML validates against FCPXMLv1_8.dtd"
+    puts "✓ FCPXML validates against #{dtd_label}"
   else
-    warn "✗ FCPXML failed DTD validation:"
+    warn "✗ FCPXML failed DTD validation against #{dtd_label}:"
     warn output
     exit 1
   end

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -77,11 +77,13 @@ def main
     out_point = timecode_to_seconds(clip['out_point'])
     duration = out_point - start_at
 
-    buttercut_clips << {
+    clip_entry = {
       path: full_path,
       start_at: start_at.to_f,
       duration: duration.to_f
     }
+    clip_entry[:speed_ramps] = clip['speed_ramps'] if clip['speed_ramps']
+    buttercut_clips << clip_entry
   end
 
   # Validate and normalize editor choice
@@ -124,7 +126,7 @@ def main
 end
 
 def validate_fcpxml(xml_path)
-  dtd_path = File.expand_path('../../../dtd/FCPXMLv1_8.dtd', __dir__)
+  dtd_path = File.expand_path('../../../dtd/FCPXMLv1_10.dtd', __dir__)
   unless File.exist?(dtd_path)
     puts "⚠ DTD not found at #{dtd_path}; skipping validation."
     return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **FCPXML output upgraded from 1.8 to 1.10.** When a roughcut clip carries `speed_ramps`, ButterCut now emits a `<timeMap>` with `<timept>` waypoints inside the `<asset-clip>`, so DaVinci Resolve preserves speed ramps on import without needing the apply script. Easing values map to FCPXML `interp`: `linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`. Transitions and color tags are not yet emitted via FCPXML — those still flow through the recipe + apply script (or stay manual in Resolve).
+
 ## [0.5.0] - 2026-04-24
 
 ### Added

--- a/lib/buttercut/fcpx.rb
+++ b/lib/buttercut/fcpx.rb
@@ -122,7 +122,7 @@ class ButterCut
         }
       end
 
-      waypoints.unshift({ at: Rational(0), speed: waypoints.first[:speed], interp: waypoints.first[:interp] }) if waypoints.first[:at] > 0
+      waypoints.unshift({ at: Rational(0), speed: Rational(1), interp: "linear" }) if waypoints.first[:at] > 0
       waypoints.push({ at: clip_duration, speed: waypoints.last[:speed], interp: waypoints.last[:interp] }) if waypoints.last[:at] < clip_duration
 
       points = []

--- a/lib/buttercut/fcpx.rb
+++ b/lib/buttercut/fcpx.rb
@@ -2,9 +2,20 @@ require_relative 'editor_base'
 require 'nokogiri'
 
 class ButterCut
-  # Final Cut Pro X (FCPXML 1.8) implementation.
+  # Final Cut Pro X (FCPXML 1.10) implementation. Speed ramps from the
+  # editorial recipe are emitted as <timeMap> elements inside <asset-clip>
+  # so that DaVinci Resolve preserves them on import without needing the
+  # apply script.
   class FCPX < EditorBase
     FORMAT_ID = "r1".freeze
+    FCPXML_VERSION = "1.10".freeze
+
+    EASE_TO_INTERP = {
+      "linear"       => "linear",
+      "ease-in"      => "smooth2",
+      "ease-out"     => "smooth2",
+      "ease-in-out"  => "smooth2"
+    }.freeze
 
     def to_xml
       raise ArgumentError, "No clips provided" if clips.empty?
@@ -23,7 +34,7 @@ class ButterCut
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
-        xml.fcpxml(version: '1.8') do
+        xml.fcpxml(version: FCPXML_VERSION) do
           xml.resources do
             xml.format(
               id: FORMAT_ID,
@@ -63,6 +74,7 @@ class ButterCut
                         duration: clip[:duration],
                         audioRole: 'dialogue'
                       ) do
+                        emit_time_map(xml, clip)
                         xml.send('adjust-volume', amount: volume_adjustment)
                       end
                     end
@@ -75,6 +87,72 @@ class ButterCut
       end
 
       builder.to_xml
+    end
+
+    private
+
+    def emit_time_map(xml, clip)
+      ramps = clip.dig(:clip_definition, :speed_ramps)
+      return if ramps.nil? || ramps.empty?
+
+      points = build_time_map_points(ramps, clip)
+      return if points.length < 2
+
+      xml.timeMap do
+        points.each do |pt|
+          xml.timept(time: pt[:time], value: pt[:value], interp: pt[:interp])
+        end
+      end
+    end
+
+    # Translate recipe speed ramps (output-time waypoints with speed %) into
+    # FCPXML <timept> control points. Each timept is (output_time, source_time);
+    # the slope between adjacent points is the effective speed for that segment.
+    # We integrate piecewise using the average of adjacent speeds, which gives
+    # a plausible source-time curve for both linear and smooth2 interp.
+    def build_time_map_points(ramps, clip)
+      sorted = ramps.sort_by { |r| ramp_at_seconds(r) }
+      clip_duration = fraction_to_rational(clip[:duration])
+
+      waypoints = sorted.map do |ramp|
+        {
+          at:     Rational(ramp_at_seconds(ramp)),
+          speed:  Rational(ramp["speed"]) / 100,
+          interp: EASE_TO_INTERP.fetch(ramp["ease"], "linear")
+        }
+      end
+
+      waypoints.unshift({ at: Rational(0), speed: waypoints.first[:speed], interp: waypoints.first[:interp] }) if waypoints.first[:at] > 0
+      waypoints.push({ at: clip_duration, speed: waypoints.last[:speed], interp: waypoints.last[:interp] }) if waypoints.last[:at] < clip_duration
+
+      points = []
+      cumulative_source = Rational(0)
+      waypoints.each_with_index do |wp, i|
+        if i > 0
+          prev = waypoints[i - 1]
+          segment_dt = wp[:at] - prev[:at]
+          avg_speed = (prev[:speed] + wp[:speed]) / 2
+          cumulative_source += segment_dt * avg_speed
+        end
+        points << {
+          time:   rational_to_fraction(wp[:at]),
+          value:  rational_to_fraction(cumulative_source),
+          interp: wp[:interp]
+        }
+      end
+      points
+    end
+
+    def ramp_at_seconds(ramp)
+      at = ramp["at"]
+      raise ArgumentError, "speed_ramp missing 'at'" if at.nil?
+      at.to_f
+    end
+
+    def rational_to_fraction(rational)
+      rational = Rational(rational) unless rational.is_a?(Rational)
+      return "0s" if rational.zero?
+      "#{rational.numerator}/#{rational.denominator}s"
     end
   end
 end

--- a/scripts/verify_phase_4.sh
+++ b/scripts/verify_phase_4.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Phase 4 verification helper: regenerate the march-30-workout rough cut on
+# the current branch, structurally check the FCPXML for version 1.10 and
+# <timeMap> elements, and print next-step instructions for the manual
+# Resolve import check.
+#
+# Usage:
+#   scripts/verify_phase_4.sh                        # picks the most recent .yaml
+#   scripts/verify_phase_4.sh path/to/roughcut.yaml  # use a specific rough cut
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+LIBRARY="march-30-workout"
+ROUGHCUTS_DIR="libraries/$LIBRARY/roughcuts"
+
+if [[ $# -ge 1 ]]; then
+  YAML_PATH="$1"
+else
+  YAML_PATH="$(ls -t "$ROUGHCUTS_DIR"/*.yaml 2>/dev/null | head -n1 || true)"
+fi
+
+if [[ -z "${YAML_PATH:-}" || ! -f "$YAML_PATH" ]]; then
+  echo "ERROR: no rough cut YAML found. Pass one explicitly:" >&2
+  echo "  $0 $ROUGHCUTS_DIR/<name>.yaml" >&2
+  exit 1
+fi
+
+BASENAME="$(basename "$YAML_PATH" .yaml)"
+TS="$(date +%Y%m%d_%H%M%S)"
+OUT_XML="$ROUGHCUTS_DIR/${BASENAME}_phase4_${TS}.xml"
+
+echo "→ Source YAML : $YAML_PATH"
+echo "→ Output XML  : $OUT_XML"
+echo
+
+bundle exec ruby .claude/skills/roughcut/export_to_fcpxml.rb "$YAML_PATH" "$OUT_XML" fcpx
+
+echo
+echo "── Structural checks ─────────────────────────────"
+
+VERSION_LINE="$(grep -m1 '<fcpxml ' "$OUT_XML" || true)"
+TIMEMAP_COUNT="$(grep -c '<timeMap>' "$OUT_XML" || true)"
+TIMEPT_COUNT="$(grep -c '<timept ' "$OUT_XML" || true)"
+
+echo "  fcpxml header : $VERSION_LINE"
+echo "  <timeMap>     : $TIMEMAP_COUNT"
+echo "  <timept>      : $TIMEPT_COUNT"
+echo
+
+PASS=1
+if [[ "$VERSION_LINE" != *'version="1.10"'* ]]; then
+  echo "  ✗ FCPXML version is not 1.10"
+  PASS=0
+fi
+if [[ "$TIMEMAP_COUNT" -eq 0 ]]; then
+  echo "  ⚠ no <timeMap> elements found — does this rough cut have any speed_ramps?"
+  echo "    (not a hard fail; verify by inspecting the YAML)"
+fi
+if [[ "$PASS" -eq 1 ]]; then
+  echo "  ✓ Structural checks passed."
+fi
+
+echo
+echo "── Next steps (manual, in Resolve) ────────────────"
+cat <<EOF
+  1. Open DaVinci Resolve, create a new empty project.
+  2. File > Import > Timeline… and pick:
+       $OUT_XML
+     Relink media when prompted.
+  3. Open the imported timeline. Right-click a clip that had speed_ramps
+     in the YAML (e.g. medicine-ball-slams) → Retime Controls (⌘R).
+     If you see non-100% speed segments / retime control points matching
+     the recipe ramps, Phase 4 acceptance is met.
+
+  Optional automated check inside Resolve:
+    Drop scripts/verify_phase_4_resolve.py into
+      ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/
+    Open the imported timeline, then run:
+      Workspace > Scripts > Edit > verify_phase_4_resolve
+    It prints per-clip Speed values from the MediaPoolItem API.
+EOF

--- a/scripts/verify_phase_4_resolve.py
+++ b/scripts/verify_phase_4_resolve.py
@@ -31,11 +31,22 @@ import os
 OUT_PATH = os.path.expanduser("~/buttercut_phase4_verify.json")
 
 
-def main():
+def get_resolve():
+    """Resolve injects `resolve` into the script's globals when run from
+    Workspace > Scripts. Fall back to the external bootstrap for off-menu use."""
+    if "resolve" in globals():
+        return globals()["resolve"]
     try:
-        resolve = bmd.scriptapp("Resolve")  # noqa: F821 (Resolve injects this)
-    except NameError:
-        print("ERROR: this script must be run from within DaVinci Resolve.")
+        import DaVinciResolveScript as dvr_script  # type: ignore
+        return dvr_script.scriptapp("Resolve")
+    except Exception:
+        return None
+
+
+def main():
+    resolve = get_resolve()
+    if resolve is None:
+        print("ERROR: could not connect to Resolve. Run from Workspace > Scripts > Edit.")
         return
 
     pm = resolve.GetProjectManager()

--- a/scripts/verify_phase_4_resolve.py
+++ b/scripts/verify_phase_4_resolve.py
@@ -41,13 +41,14 @@ def normalize_speed(speed):
     s = str(speed).strip()
     if not s or s.startswith("<error:"):
         return None
-    if s.endswith("%"):
+    had_percent = s.endswith("%")
+    if had_percent:
         s = s[:-1].strip()
     try:
         v = float(s)
     except ValueError:
         return None
-    return v / 100.0 if v > 2 else v
+    return v / 100.0 if had_percent or v > 2 else v
 
 
 def get_resolve():

--- a/scripts/verify_phase_4_resolve.py
+++ b/scripts/verify_phase_4_resolve.py
@@ -96,13 +96,14 @@ def main():
                 except Exception as e:  # noqa: BLE001
                     speed = f"<error: {e}>"
             normalized = normalize_speed(speed)
+            appears_retimed = (
+                None if normalized is None else abs(normalized - 1.0) > 1e-6
+            )
             rows.append({
                 "track": f"V{track_idx}",
                 "name": ti.GetName(),
                 "media_pool_speed": speed,
-                "appears_retimed": (
-                    normalized is not None and abs(normalized - 1.0) > 1e-6
-                ),
+                "appears_retimed": appears_retimed,
             })
 
     if not rows:
@@ -129,7 +130,9 @@ def main():
     print()
     print("Cross-check: open the source rough-cut YAML and find clips with a")
     print("'speed_ramps' entry. Those should appear above with appears_retimed=True.")
-    print("If a ramped clip shows Speed=1.0, the FCPXML timeMap did not survive.")
+    print("If a ramped clip's media_pool_speed reads as 100 (normal speed),")
+    print("the FCPXML timeMap did not survive. appears_retimed=None means")
+    print("Resolve returned no Speed value — verdict unknown for that clip.")
 
 
 if __name__ == "__main__":

--- a/scripts/verify_phase_4_resolve.py
+++ b/scripts/verify_phase_4_resolve.py
@@ -15,10 +15,12 @@ Prereq:
   2. Make sure the imported timeline is the Current Timeline.
   3. Open Workspace > Console so the report is visible.
 
-The probe is read-only. For each clip on V1 it reports:
+The probe is read-only. For each clip on every video track it reports:
+  - track (e.g. V1, V2)
   - clip name
-  - MediaPoolItem 'Speed' property (constant-speed indicator)
-  - whether the underlying MediaPoolItem appears retimed (Speed != 1.0)
+  - MediaPoolItem 'Speed' property (returned by Resolve as a percentage
+    string — e.g. "100" for normal speed, "400" for 4x)
+  - whether the underlying MediaPoolItem appears retimed (Speed != 100%)
 
 A clip whose recipe carried speed_ramps but reports Speed == 1.0 in Resolve
 indicates the timeMap did NOT survive import — Phase 4 acceptance not met for
@@ -29,6 +31,23 @@ import json
 import os
 
 OUT_PATH = os.path.expanduser("~/buttercut_phase4_verify.json")
+
+
+def normalize_speed(speed):
+    """Resolve returns Speed as a percentage string (e.g. '100' for normal,
+    '400' for 4x). Map to a unit-less factor so we can compare against 1.0."""
+    if speed is None:
+        return None
+    s = str(speed).strip()
+    if not s or s.startswith("<error:"):
+        return None
+    if s.endswith("%"):
+        s = s[:-1].strip()
+    try:
+        v = float(s)
+    except ValueError:
+        return None
+    return v / 100.0 if v > 2 else v
 
 
 def get_resolve():
@@ -76,11 +95,14 @@ def main():
                     speed = mpi.GetClipProperty("Speed")
                 except Exception as e:  # noqa: BLE001
                     speed = f"<error: {e}>"
+            normalized = normalize_speed(speed)
             rows.append({
                 "track": f"V{track_idx}",
                 "name": ti.GetName(),
                 "media_pool_speed": speed,
-                "appears_retimed": (speed not in (None, "1.0", 1.0, "")),
+                "appears_retimed": (
+                    normalized is not None and abs(normalized - 1.0) > 1e-6
+                ),
             })
 
     if not rows:
@@ -110,4 +132,5 @@ def main():
     print("If a ramped clip shows Speed=1.0, the FCPXML timeMap did not survive.")
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_phase_4_resolve.py
+++ b/scripts/verify_phase_4_resolve.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Phase 4 verification probe — checks if FCPXML 1.10 timeMap survived import.
+
+Drop into:
+  macOS:   ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/
+  Windows: %APPDATA%\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Edit\\
+  Linux:   ~/.local/share/DaVinciResolve/Fusion/Scripts/Edit/
+
+Run from inside Resolve via:
+  Workspace > Scripts > Edit > verify_phase_4_resolve
+
+Prereq:
+  1. Open the FCPXML produced by scripts/verify_phase_4.sh in a fresh Resolve
+     project (File > Import > Timeline…).
+  2. Make sure the imported timeline is the Current Timeline.
+  3. Open Workspace > Console so the report is visible.
+
+The probe is read-only. For each clip on V1 it reports:
+  - clip name
+  - MediaPoolItem 'Speed' property (constant-speed indicator)
+  - whether the underlying MediaPoolItem appears retimed (Speed != 1.0)
+
+A clip whose recipe carried speed_ramps but reports Speed == 1.0 in Resolve
+indicates the timeMap did NOT survive import — Phase 4 acceptance not met for
+that clip and the apply script remains the fallback path.
+"""
+
+import json
+import os
+
+OUT_PATH = os.path.expanduser("~/buttercut_phase4_verify.json")
+
+
+def main():
+    try:
+        resolve = bmd.scriptapp("Resolve")  # noqa: F821 (Resolve injects this)
+    except NameError:
+        print("ERROR: this script must be run from within DaVinci Resolve.")
+        return
+
+    pm = resolve.GetProjectManager()
+    project = pm.GetCurrentProject()
+    if not project:
+        print("ERROR: no current project. Open a project with the imported timeline.")
+        return
+
+    timeline = project.GetCurrentTimeline()
+    if not timeline:
+        print("ERROR: no current timeline. Open the imported timeline.")
+        return
+
+    print(f"Project : {project.GetName()}")
+    print(f"Timeline: {timeline.GetName()}")
+    print()
+
+    track_count = timeline.GetTrackCount("video")
+    rows = []
+    for track_idx in range(1, track_count + 1):
+        items = timeline.GetItemListInTrack("video", track_idx) or []
+        for ti in items:
+            mpi = ti.GetMediaPoolItem()
+            speed = None
+            if mpi:
+                try:
+                    speed = mpi.GetClipProperty("Speed")
+                except Exception as e:  # noqa: BLE001
+                    speed = f"<error: {e}>"
+            rows.append({
+                "track": f"V{track_idx}",
+                "name": ti.GetName(),
+                "media_pool_speed": speed,
+                "appears_retimed": (speed not in (None, "1.0", 1.0, "")),
+            })
+
+    if not rows:
+        print("No clips found on any video track.")
+        return
+
+    name_w = max(len(r["name"]) for r in rows)
+    print(f"{'TRACK':<6} {'CLIP'.ljust(name_w)}  {'SPEED':<10}  RETIMED?")
+    print("-" * (6 + name_w + 24))
+    for r in rows:
+        print(
+            f"{r['track']:<6} {r['name'].ljust(name_w)}  "
+            f"{str(r['media_pool_speed']):<10}  {r['appears_retimed']}"
+        )
+
+    with open(OUT_PATH, "w") as f:
+        json.dump({
+            "project": project.GetName(),
+            "timeline": timeline.GetName(),
+            "clips": rows,
+        }, f, indent=2)
+    print()
+    print(f"Wrote: {OUT_PATH}")
+    print()
+    print("Cross-check: open the source rough-cut YAML and find clips with a")
+    print("'speed_ramps' entry. Those should appear above with appears_retimed=True.")
+    print("If a ramped clip shows Speed=1.0, the FCPXML timeMap did not survive.")
+
+
+main()

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe ButterCut::FCPX do
       xml = generator.to_xml
 
       expect(xml).to include('<?xml version="1.0" encoding="utf-8"?>')
-      expect(xml).to include('<fcpxml version="1.8">')
+      expect(xml).to include('<fcpxml version="1.10">')
       expect(xml).to include('</fcpxml>')
     end
 
@@ -539,7 +539,7 @@ RSpec.describe ButterCut::FCPX do
 
       expect(File.exist?(filename)).to be true
       content = File.read(filename)
-      expect(content).to include('<fcpxml version="1.8">')
+      expect(content).to include('<fcpxml version="1.10">')
     end
 
     it 'saves complete valid FCPXML' do

--- a/spec/buttercut/fcpx_speed_ramps_spec.rb
+++ b/spec/buttercut/fcpx_speed_ramps_spec.rb
@@ -80,14 +80,23 @@ RSpec.describe ButterCut::FCPX, 'speed ramps via FCPXML 1.10 timeMap' do
     expect(interps).to include('linear', 'smooth2')
   end
 
-  it 'pads with a leading timept at output 0 when first ramp is mid-clip' do
+  it 'pads with a leading 100%-baseline timept at output 0 when first ramp is mid-clip' do
     ramps = [{ 'at' => 0.5, 'speed' => 200, 'ease' => 'linear' }]
     generator = ButterCut::FCPX.new([
       { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
     ])
     doc = parse(generator.to_xml)
     timepts = doc.xpath('//timeMap/timept')
-    expect(timepts.first['time']).to eq('0s')
     expect(timepts.length).to be >= 2
+
+    leading = timepts.first
+    expect(leading['time']).to eq('0s')
+    expect(leading['value']).to eq('0s')
+
+    # The leading→first-ramp segment integrates as the average of (100%, 200%)
+    # over 0.5s = 1.5x * 0.5s = 0.75s of source advance.
+    second = timepts[1]
+    expect(second['time']).to eq('1/2s')
+    expect(second['value']).to eq('3/4s')
   end
 end

--- a/spec/buttercut/fcpx_speed_ramps_spec.rb
+++ b/spec/buttercut/fcpx_speed_ramps_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'nokogiri'
+
+RSpec.describe ButterCut::FCPX, 'speed ramps via FCPXML 1.10 timeMap' do
+  let(:clip_path) { '/tmp/ramp_clip.mov' }
+  let(:metadata) do
+    {
+      'streams' => [
+        {
+          'codec_type' => 'video',
+          'width' => 1920,
+          'height' => 1080,
+          'r_frame_rate' => '30000/1001',
+          'color_space' => 'bt709',
+          'color_primaries' => 'bt709',
+          'color_transfer' => 'bt709',
+          'tags' => { 'timecode' => '00:00:00;00' }
+        },
+        { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+      ],
+      'format' => { 'duration' => '10.0', 'tags' => { 'timecode' => '00:00:00;00' } }
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+  end
+
+  def parse(xml)
+    Nokogiri::XML(xml)
+  end
+
+  it 'declares FCPXML version 1.10' do
+    generator = ButterCut::FCPX.new([{ path: clip_path }])
+    doc = parse(generator.to_xml)
+    expect(doc.at_xpath('/fcpxml')['version']).to eq('1.10')
+  end
+
+  it 'omits timeMap when no speed_ramps are present' do
+    generator = ButterCut::FCPX.new([{ path: clip_path, start_at: 0.0, duration: 4.0 }])
+    doc = parse(generator.to_xml)
+    expect(doc.xpath('//timeMap')).to be_empty
+  end
+
+  it 'emits a timeMap with timept waypoints when a clip has speed_ramps' do
+    ramps = [
+      { 'at' => 0.0, 'speed' => 200, 'ease' => 'ease-out' },
+      { 'at' => 1.0, 'speed' => 100, 'ease' => 'ease-in' }
+    ]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+
+    time_maps = doc.xpath('//timeMap')
+    expect(time_maps.length).to eq(1)
+
+    timepts = time_maps.first.xpath('timept')
+    expect(timepts.length).to be >= 2
+
+    times = timepts.map { |t| t['time'] }
+    expect(times.first).to eq('0s')
+
+    interps = timepts.map { |t| t['interp'] }
+    expect(interps).to all(satisfy { |v| %w[linear smooth2].include?(v) })
+
+    expect(timepts.last['value']).not_to eq('0s')
+  end
+
+  it 'maps ease values to FCPXML interp keywords' do
+    ramps = [
+      { 'at' => 0.0, 'speed' => 100, 'ease' => 'linear' },
+      { 'at' => 0.5, 'speed' => 150, 'ease' => 'ease-in-out' }
+    ]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+    interps = doc.xpath('//timeMap/timept').map { |t| t['interp'] }
+    expect(interps).to include('linear', 'smooth2')
+  end
+
+  it 'pads with a leading timept at output 0 when first ramp is mid-clip' do
+    ramps = [{ 'at' => 0.5, 'speed' => 200, 'ease' => 'linear' }]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+    timepts = doc.xpath('//timeMap/timept')
+    expect(timepts.first['time']).to eq('0s')
+    expect(timepts.length).to be >= 2
+  end
+end

--- a/spec/fixtures/full_media_all_clips.fcpxml
+++ b/spec/fixtures/full_media_all_clips.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="__ASSET_ID_MVI_0309__" name="MVI_0309_720p.mov" uid="__ASSET_UID_MVI_0309__" src="__SRC_MVI_0309__" start="0s" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>

--- a/spec/fixtures/full_media_last_second.fcpxml
+++ b/spec/fixtures/full_media_last_second.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="__ASSET_ID_MVI_0309__" name="MVI_0309_720p.mov" uid="__ASSET_UID_MVI_0309__" src="__SRC_MVI_0309__" start="0s" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>

--- a/spec/fixtures/three_clip_timeline.fcpxml
+++ b/spec/fixtures/three_clip_timeline.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="r2" name="MVI_0309_720p.mov" uid="" src="__SRC_MVI_0309__" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>


### PR DESCRIPTION
## Summary
- Bumps `lib/buttercut/fcpx.rb` from FCPXML 1.8 to 1.10 and emits `<timeMap>` inside `<asset-clip>` when the clip carries `speed_ramps`, giving Resolve a path to preserve ramps directly through the FCPXML import without the apply script.
- Threads `speed_ramps` from the rough-cut YAML into the FCPX clip hash via `.claude/skills/roughcut/export_to_fcpxml.rb`; updates DTD validation path to `FCPXMLv1_10.dtd` (gracefully skips when not shipped).
- Maps recipe `ease` values to FCPXML `interp` (`linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`). Source-time waypoints are integrated piecewise from the speed waypoints, with synthetic leading/trailing timepts as needed.

## Out of scope (still recipe + apply-script only)
Transitions, color tags, title cards, and render presets — recipe still carries them, but the FCPXML doesn't emit them yet. Documented in CHANGELOG.

## Test plan
- [x] `bundle exec rspec` — 117/119 pass; the 2 failing examples (`fcpx_spec.rb:495`, `:505`) pre-existed on `main` and require media files in a `media/` directory that isn't in the repo.
- [x] New `spec/buttercut/fcpx_speed_ramps_spec.rb` covers version bump, no-recipe opt-out, timept emission, ease→interp mapping, and leading-pad.
- [x] Existing `fcpx_spec.rb` version assertions and three `.fcpxml` fixtures updated 1.8 → 1.10.
- [ ] Manual: regenerate the `march-30-workout` rough cut, import the FCPXML into a fresh Resolve project, confirm at least the speed ramps survive without running the apply script (Phase 4 acceptance bar).

Closes the Phase 4 bullet of `docs/sprints/sprint-01-editorial-automation.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exports now include speed‑ramp waypoint data in FCPXML so retimes are preserved on import.

* **Changed**
  * FCPXML output upgraded to v1.10; validation prefers v1.10 with a v1.8 fallback. Easing values are mapped to supported interpolation types.

* **New Tools**
  * Added CLI and Resolve-side verification utilities to inspect exports, counts of timeMap/timept waypoints, and retime indicators.

* **Tests**
  * Updated/added specs and fixtures to assert v1.10 and timeMap/timept behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->