### PR TITLE
Sprint 1 Phase 5: bump 0.6.0, document recipe + apply-script artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-05-02
+
+### Added
+- **Editorial recipe alongside the rough cut.** Every rough cut now exports an editorial recipe (`<name>.recipe.json`) capturing the agent's editorial intent: per-clip speed ramps, clip color tags, markers, between-clip transitions, an optional title card, render preset, and PowerGrade reference. The XML stays cuts-only; the recipe carries everything else. Schema is versioned and validated by `lib/buttercut/recipe.rb`.
+- **DaVinci Resolve apply script.** Each rough cut also generates `<name>_apply.py`, a Python script you drop into Resolve and run from `Workspace > Scripts > Edit > Apply <name>`. It walks the recipe and applies what Resolve's scripting API supports — speed ramps (single-point via `MediaPoolItem.SetClipProperty("Speed", …)`), clip color tags, markers, render preset, and a best-effort PowerGrade lookup. Multi-point ramps and transitions are logged as manual follow-ups. Companion audit doc at `docs/sprints/sprint-01-resolve-api-audit.md` documents the API gaps the script works around.
+- **FCPXML 1.10 backend with native speed ramps.** Recipe `speed_ramps` are emitted as `<timeMap>` / `<timept>` waypoints inside the `<asset-clip>`, so DaVinci Resolve preserves speed ramps on FCPXML import without needing the apply script. Easing values map to FCPXML `interp`: `linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`. Transitions and color tags still flow through the recipe + apply script.
 
 ### Changed
-- **FCPXML output upgraded from 1.8 to 1.10.** When a roughcut clip carries `speed_ramps`, ButterCut now emits a `<timeMap>` with `<timept>` waypoints inside the `<asset-clip>`, so DaVinci Resolve preserves speed ramps on import without needing the apply script. Easing values map to FCPXML `interp`: `linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`. Transitions and color tags are not yet emitted via FCPXML — those still flow through the recipe + apply script (or stay manual in Resolve).
+- **`fcpxml` version bumped from 1.8 to 1.10** in all FCPXML output. Existing fixtures and tests updated accordingly.
 
 ## [0.5.0] - 2026-04-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The project has two main components:
 ## Supported Editors
 
 Currently supports:
-- **Final Cut Pro X** (FCPXML 1.8 format)
+- **Final Cut Pro X** (FCPXML 1.10 format)
 - **Adobe Premiere Pro** (xmeml version 5)
 - **DaVinci Resolve** (xmeml version 5)
 
@@ -246,7 +246,7 @@ When you add a Ruby script under `.claude/scripts/` or similar, follow these con
 
 - `lib/buttercut.rb` - Factory class that creates editor-specific generators
 - `lib/buttercut/editor_base.rb` - Shared validation, metadata extraction, and timeline math
-- `lib/buttercut/fcpx.rb` - Final Cut Pro X implementation (FCPXML 1.8)
+- `lib/buttercut/fcpx.rb` - Final Cut Pro X implementation (FCPXML 1.10)
 - `lib/buttercut/fcp7.rb` - Final Cut Pro 7 / Premiere / DaVinci Resolve implementation (xmeml v5)
 - `.claude/skills/` - Claude Code skills for AI-powered workflow
 - `spec/` - RSpec test suite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ You are an AI video editor assistant working with a software engineer. You gener
    - **Rough cuts**: Multi-minute edits for full videos (typically 3-15+ minutes)
    - **Sequences**: 30-60 second clips that user will build to be imported into a larger video (created using the same roughcut skill with shorter target duration)
    - **PREREQUISITE:** Check library.yaml to verify all videos have `visual_transcript` and `summary` populated
+   - **Artifacts produced** (alongside the rough cut YAML): an editor XML (`*.xml`), an editorial recipe (`*.recipe.json`) capturing per-clip directives — speed ramps, color tags, markers, transitions, render preset, PowerGrade — and, for Resolve, a generated apply script (`*_apply.py`) that walks the recipe and applies what the Resolve scripting API supports (speed ramps, color tags, markers, render preset; PowerGrade best-effort). FCPXML output is now version 1.10 and emits `<timeMap>` natively for speed ramps, so Resolve can preserve ramps on import without running the apply script. An optional `*_edit_guide.html` documents the directives for human reference.
 4. **Backup** → Use `backup-library` skill to create compressed archives of all libraries
    - Creates timestamped ZIP backup of entire libraries directory
    - Backups are stored in `/backups/` and excluded from git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buttercut (0.5.0)
+    buttercut (0.6.0)
       nokogiri (~> 1.13)
       rubyzip (~> 2.3)
 

--- a/lib/buttercut/version.rb
+++ b/lib/buttercut/version.rb
@@ -1,3 +1,3 @@
 class ButterCut
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
## Summary
- Bumps `lib/buttercut/version.rb` to **0.6.0** and regenerates `Gemfile.lock`.
- Replaces the `[Unreleased]` CHANGELOG block with a single `0.6.0` entry covering the full sprint: editorial recipe schema, DaVinci Resolve apply script, and the FCPXML 1.10 backend with native `<timeMap>` speed ramps.
- Extends `CLAUDE.md` Workflow Steps so the **Edit** step names the four-artifact set the roughcut skill now produces (`*.yaml`, `*.xml`, `*.recipe.json`, `*_apply.py`), with `*_edit_guide.html` noted as optional.

## Out of scope for this commit
The end-to-end demo recording (acceptance bullet "Demo video lives in repo `docs/sprints/sprint-01-demo.mp4` or external link") is a human-only step — open Resolve, screen-record the round trip, render. It will land either as a follow-up commit on this branch (the file) or as a link added to the issue/PR description before merge.

## Test plan
- [x] `bundle exec rspec` — 117/119 pass; the 2 failures (`fcpx_spec.rb:495`, `:505`) pre-existed on `main` (require missing `media/` fixtures).
- [x] `Gemfile.lock` matches the new gem version.
- [ ] Manual: record the demo and either commit to `docs/sprints/sprint-01-demo.mp4` or paste an external link into the PR body before merge.

Closes #6 (after demo lands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editorial recipe JSON output per cut (clip intent, ramps, tags, transitions, optional title card, render preset, PowerGrade reference)
  * Optional DaVinci Resolve apply script generation (best-effort PowerGrade support)
  * FCPXML upgraded to 1.10 with native speed-ramp export

* **Documentation**
  * Release notes and workflow docs updated for v0.6.0; edit workflow includes optional human-readable edit guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->