### PR TITLE
M2: Library creation + analysis from the UI

### DIFF
--- a/.claude/skills/analyze-video/agent_prompt.md
+++ b/.claude/skills/analyze-video/agent_prompt.md
@@ -36,37 +36,10 @@ ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" tmp/frames/[vide
 
 ## 3. Add visual descriptions
 
-Read the visual transcript JSON you created in step 1.
+The output schema and description guidelines are defined in
+`ui/sidecar/prompts/analyze_video.md` — read it before continuing.
 
 **Read the JPG frames** from `tmp/frames/[video_name]/` using the Read tool, then **Edit** the file at `<visual_transcript_path>`. Do this incrementally — no script needed; just edit the JSON each time you read new frames.
-
-**Dialogue segments — add `visual` field:**
-```json
-{
-  "start": 2.917,
-  "end": 7.586,
-  "text": "Hey, good afternoon everybody.",
-  "visual": "Man in red shirt speaking to camera in medium shot. Home office with bookshelf. Natural lighting.",
-  "words": [...]
-}
-```
-
-**B-roll segments — insert new entries:**
-```json
-{
-  "start": 35.474,
-  "end": 56.162,
-  "text": "",
-  "visual": "Green bicycle parked in front of building. Urban street with trees.",
-  "b_roll": true,
-  "words": []
-}
-```
-
-**Guidelines:**
-- Descriptions: 3 sentences max
-- First segment: detailed (subject, setting, shot type, lighting, camera style)
-- Continuing shots: brief if similar; up to 3 sentences if drastically different
 
 ## 4. Cleanup & return
 

--- a/.claude/skills/summarize-video/agent_prompt.md
+++ b/.claude/skills/summarize-video/agent_prompt.md
@@ -23,12 +23,15 @@ Read `<summary_output_path>`. The Edit tool requires this before editing.
 
 ## Action 3 — Edit each placeholder
 
-Use the **Edit** tool four times to replace each `<!-- FILL_X -->` marker with the corresponding content:
+The four sections (Overview, Key visuals, Dialogue, B-roll) are defined in
+`ui/sidecar/prompts/summarize_video.md` — read it for the exact content rules.
 
-- `<!-- FILL_OVERVIEW -->` → 2-3 sentences describing the narrative arc. Be specific; avoid vague endings like "the clip ends with..." or "discusses something."
-- `<!-- FILL_KEY_VISUALS -->` → 3-6 bullets covering locations, distinctive shots, visual changes.
-- `<!-- FILL_DIALOGUE -->` → 0–3 quotes formatted as `> [MM:SS] "Quote"`. For clips under 30 seconds, often 0 or 1 is enough — write `None` if nothing stands out. Skip filler ("um", "you know", "I have to be honest"). Use the `[MM:SS]` shown next to each line in the script.
-- `<!-- FILL_BROLL -->` → cutaway descriptions distinct from the main subject. For single-shot clips, write `None`. Do not speculate about how the footage could be used as b-roll elsewhere.
+Use the **Edit** tool four times to replace each `<!-- FILL_X -->` marker with the corresponding section's content:
+
+- `<!-- FILL_OVERVIEW -->` → the Overview section.
+- `<!-- FILL_KEY_VISUALS -->` → the Key visuals bullets.
+- `<!-- FILL_DIALOGUE -->` → the Dialogue quotes (or `None`).
+- `<!-- FILL_BROLL -->` → the B-roll list (or `None`).
 
 ## Action 4 — Reply with one line
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- M2: New Project flow + streaming analysis progress UI in the desktop app. Drop a folder of videos, name a project, pick a language, and watch the three-stage pipeline (transcribe → analyze → summarize) run with per-file per-stage progress streamed over JSON-RPC notifications. Removes the last terminal dependency from onboarding.
+- Sidecar gains: `inspect_video_paths`, `create_library`, `has_api_key`, `set_api_key`, `start_analysis`, `cancel_job`. Validates Anthropic keys with a Haiku ping; persists to `libraries/settings.yaml` (gitignored). Extracts analyze + summarize prompt content into shared `ui/sidecar/prompts/` files referenced by both the CLI agent and the new sidecar parent.
+
 ## [0.6.0] - 2026-05-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# ButterCut — common dev tasks (desktop + sidecar).
+# Run `make` or `make help` for targets.
+
+.PHONY: help check setup dev sidecar-spec
+
+help:
+	@echo "ButterCut Makefile"
+	@echo ""
+	@echo "  make check         Verify desktop/Tauri + sidecar prerequisites"
+	@echo "  make setup         bundle install (sidecar) + pnpm install (ui) + libraries/"
+	@echo "  make dev           pnpm tauri dev (from ui/)"
+	@echo "  make sidecar-spec  bundle exec rspec in ui/sidecar (needs Ruby 3.3 on PATH)"
+	@echo ""
+	@echo "Full Mac + Python + WhisperX audit: ruby .claude/skills/setup/verify_install.rb"
+	@echo ""
+
+check:
+	@chmod +x scripts/check_desktop_prereqs.sh 2>/dev/null || true
+	@./scripts/check_desktop_prereqs.sh
+
+setup:
+	@echo "Requires Ruby $$(sed 's/[[:space:]]*$$//' .ruby-version | cut -d. -f1,2).x on PATH (see: make check)."
+	@echo "→ ui/sidecar: bundle install"
+	cd ui/sidecar && bundle install
+	@echo "→ ui: pnpm install"
+	cd ui && pnpm install
+	@mkdir -p libraries
+	@echo ""
+	@echo "Setup finished. Run: make check"
+
+dev:
+	cd ui && pnpm tauri dev
+
+sidecar-spec:
+	cd ui/sidecar && bundle exec rspec

--- a/docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md
+++ b/docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md
@@ -16,6 +16,40 @@
 
 ---
 
+## Handoff briefing — read this if you're picking up a single task cold
+
+Each task below is self-contained: exact file paths, complete code, expected test output, and a commit message. You don't have to read the whole plan to execute one. But here's the surrounding context an outside agent (Cursor, Codex, fresh Claude) needs to make sense of any individual task:
+
+**Repo:** `buttercut` — a Ruby gem for generating Final Cut Pro / Resolve XML, with a Tauri 2 desktop UI in `ui/`. The CLI workflow is driven by Claude Code via skills under `.claude/skills/`. M2 adds a New Project flow + streaming progress view to the desktop UI so non-terminal users can create and analyze libraries.
+
+**Stack invariants — do not change:**
+- Tauri 2 + React 19 + plain CSS. No Tailwind, no component libraries.
+- `@fontsource/eb-garamond` (italic display) + `@fontsource/jetbrains-mono` (technical metadata).
+- Tungsten amber `#e0a55a` accent on dark stage `#14141a`.
+- Local Ruby sidecar over JSON-RPC stdio. Ruby ≥ 3, Bundler.
+- Sidecar entrypoint: `ui/sidecar/buttercut_ui_sidecar.rb` (one class per file convention; see `CLAUDE.md` "Programming Style").
+- Rust shell: `ui/src-tauri/src/lib.rs` (commands) + `ui/src-tauri/src/sidecar.rs` (JSON-RPC reader/writer + `init`).
+
+**Architectural decisions locked in by the spec** (`docs/superpowers/specs/2026-05-03-m2-library-creation-and-analysis-design.md`):
+1. **Streaming progress over JSON-RPC notifications** — sidecar emits payloads with no `id`; Rust reader recognizes them as notifications and forwards to Tauri events scoped per `job_id` (`sidecar-event:JOB_ID`).
+2. **Sidecar owns the analysis pipeline** — calls whisperx + ffmpeg as subprocesses, calls Anthropic SDK directly for analyze + summarize. The CLI workflow continues to use Claude Code as parent. Two parents share prompt content via `ui/sidecar/prompts/*.md`.
+3. **Plain-text API key in `libraries/settings.yaml`** (gitignored), with `ANTHROPIC_API_KEY` env override. Validated on save with a Haiku ping.
+4. **Hard-stop cancellation** — `cancel_job` kills child PIDs (SIGTERM → SIGKILL after 2s) and aborts SDK calls. Artifacts are written via tempfile + atomic rename so partial state is never half-written.
+5. **Concurrency caps as constants** — transcribe=2, analyze=8, summarize=10. No global rate limiter (the SDK retries 429s).
+
+**Existing patterns to follow:**
+- Ruby: one class per file; required args raise `ArgumentError` in `initialize`; CLI parsing in a bottom-of-file `if __FILE__ == $PROGRAM_NAME` block; exposed entry method (`Klass.run`/`Klass.create!`); spec at `spec/<same path>_spec.rb` using `Dir.mktmpdir` + `LibraryFixture` from `ui/sidecar/spec/fixtures/library_fixture.rb`.
+- Rust: every Tauri command is `async fn`, returns `Result<Value, String>`, delegates to `sidecar::call(...)`; register the command in the `tauri::generate_handler![...]` list inside `run()`.
+- TypeScript: typed wrappers in `ui/src/ipc/sidecar.ts`; React components default-exported from their file; CSS imported alongside the component (see `ui/src/routes/projects.tsx` + `projects.css`).
+
+**Don't:** add Co-Authored-By or Claude attribution to commits; skip git hooks (`--no-verify`); use `git add .`/`git add -A` (be explicit); add Tailwind, shadcn, or other styling libs; modify `lib/buttercut/` (the gem core) unless the task explicitly says so.
+
+**Pre-existing failures to ignore:** `spec/buttercut/fcpx_spec.rb` may have failures unrelated to M2 — don't try to fix them.
+
+**When stuck on a task:** re-read the spec section it implements (referenced at the top of each Phase). The spec's "Decisions log" answers most "but why this way?" questions. If the spec doesn't cover it, add a brief note to the PR description rather than expanding scope.
+
+---
+
 ## File Structure
 
 ### New Ruby files (sidecar)

--- a/docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md
+++ b/docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md
@@ -1,0 +1,3713 @@
+# M2 — Library Creation + Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the New Project flow + streaming analysis progress UI so a non-terminal user can drag a folder, name a project, and watch the three-stage pipeline run to completion.
+
+**Architecture:** Promote the Ruby sidecar from a thin YAML reader to the owner of the analysis pipeline (whisperx + ffmpeg subprocesses, Anthropic SDK calls for analyze + summarize). Stream per-file per-stage progress via JSON-RPC notifications, which the Rust reader forwards as Tauri events scoped per `job_id`. Frontend builds a five-step wizard window that morphs into a progress view after kickoff.
+
+**Tech Stack:** Tauri 2 / Rust, Ruby 3 (stdlib + `concurrent-ruby` + `anthropic` SDK), React 19 + TS, plain CSS. Spec source: `docs/superpowers/specs/2026-05-03-m2-library-creation-and-analysis-design.md`.
+
+**Working assumptions:**
+- TDD with RSpec for every new Ruby module; tests live under `ui/sidecar/spec/lib/buttercut_ui_sidecar/`. Existing test pattern is in `ui/sidecar/spec/buttercut_ui_sidecar_spec.rb` (StringIO + tmpdir + `LibraryFixture`).
+- TDD with `cargo test` for non-trivial Rust pure-logic helpers; Tauri command wrappers are smoke-tested manually as in M0/M1.
+- Frontend has no test harness; manual smoke testing matches M0/M1 conventions. Components are kept small and pure where possible.
+- Branch is `ui-m2-library-creation-and-analysis` (already created from main).
+
+---
+
+## File Structure
+
+### New Ruby files (sidecar)
+```
+ui/sidecar/lib/buttercut_ui_sidecar/
+├── limits.rb               # parallelism caps as constants
+├── settings_store.rb       # libraries/settings.yaml + ENV layering for the API key
+├── notifier.rb             # writes JSON-RPC notifications to stdout (mutex-guarded)
+├── video_inspector.rb      # ffprobe-backed inspect_video_paths
+├── library_creator.rb      # atomic create_library
+├── anthropic_client.rb     # thin SDK wrapper with abort + Haiku ping for validation
+├── job_registry.rb         # in-memory job_id → AnalysisJob
+├── analysis_job.rb         # cancel token, child PID + abort handle registry, worker pools
+└── stages/
+    ├── transcribe.rb
+    ├── analyze.rb
+    └── summarize.rb
+
+ui/sidecar/prompts/
+├── analyze_video.md        # extracted creative content (shared with CLI)
+└── summarize_video.md
+
+ui/sidecar/spec/lib/buttercut_ui_sidecar/
+├── limits_spec.rb
+├── settings_store_spec.rb
+├── notifier_spec.rb
+├── video_inspector_spec.rb
+├── library_creator_spec.rb
+└── analysis_job_spec.rb    # narrow: cancellation semantics, registry behavior
+```
+
+### Modified Ruby files
+```
+ui/sidecar/buttercut_ui_sidecar.rb   # dispatch new methods, hold notifier, hold registry
+.claude/skills/analyze-video/agent_prompt.md     # delegate to ui/sidecar/prompts/analyze_video.md
+.claude/skills/summarize-video/agent_prompt.md   # delegate to ui/sidecar/prompts/summarize_video.md
+```
+
+### Modified Rust files
+```
+ui/src-tauri/src/sidecar.rs   # Notification deserializer, AppHandle, emit events
+ui/src-tauri/src/lib.rs       # new commands + new_project window
+ui/src-tauri/Cargo.toml       # no new deps expected
+ui/src-tauri/tauri.conf.json  # additional capability if needed for events
+```
+
+### New TypeScript / React files
+```
+ui/src/ipc/events.ts                          # typed listen helper
+ui/src/routes/new-project/
+├── index.tsx                                 # window root + phase switch
+├── state.ts                                  # setup phase reducer + types
+├── jobReducer.ts                             # progress phase reducer + types
+├── api-key-modal.tsx
+├── steps/
+│   ├── pick-footage.tsx
+│   ├── name.tsx
+│   ├── language.tsx
+│   ├── refinement.tsx
+│   └── confirm.tsx
+├── progress/
+│   ├── progress-view.tsx
+│   ├── clip-row.tsx
+│   └── artifact-preview.tsx
+└── new-project.css
+```
+
+### Modified TypeScript / React files
+```
+ui/src/ipc/sidecar.ts        # new typed wrappers for the new RPCs
+ui/src/main.tsx              # route on /new-project hash
+ui/src/routes/projects.tsx   # add "+ New Project" tile
+ui/src/routes/projects.css   # tile styling
+```
+
+### Manifest changes
+```
+ui/sidecar/Gemfile           # add anthropic, concurrent-ruby
+ui/sidecar/Gemfile.lock      # regenerated
+```
+
+---
+
+## Phase 0 — Branch hygiene & dependency baseline
+
+### Task 0.1: Add Ruby dependencies
+
+**Files:**
+- Create: `ui/sidecar/Gemfile`
+- Create: `ui/sidecar/Gemfile.lock` (generated)
+
+- [ ] **Step 1: Check whether a Gemfile exists**
+
+```bash
+ls ui/sidecar/Gemfile 2>&1
+```
+If it exists, skip to Step 3 and add the new gems to the existing file.
+
+- [ ] **Step 2: Create Gemfile**
+
+```ruby
+# ui/sidecar/Gemfile
+source "https://rubygems.org"
+
+gem "concurrent-ruby", "~> 1.3"
+gem "anthropic",       "~> 1.0"
+
+group :development, :test do
+  gem "rspec", "~> 3.13"
+end
+```
+
+- [ ] **Step 3: Install**
+
+Run: `cd ui/sidecar && bundle install`
+Expected: lockfile generated, both gems resolved.
+
+- [ ] **Step 4: Update Rakefile to load bundler**
+
+Edit `ui/sidecar/Rakefile`:
+```ruby
+require "bundler/setup"
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
+task default: :spec
+```
+
+- [ ] **Step 5: Run baseline spec**
+
+Run: `cd ui/sidecar && bundle exec rake spec`
+Expected: existing M1 specs still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/sidecar/Gemfile ui/sidecar/Gemfile.lock ui/sidecar/Rakefile
+git commit -m "M2: add concurrent-ruby and anthropic SDK to the sidecar"
+```
+
+---
+
+## Phase 1 — Sidecar foundation
+
+### Task 1.1: Parallelism caps
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/limits.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/limits_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/limits_spec.rb
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/limits"
+
+RSpec.describe ButtercutUiSidecar::Limits do
+  it "matches the values declared in the SKILL.md files" do
+    expect(described_class::TRANSCRIBE_PARALLELISM).to eq(2)
+    expect(described_class::ANALYZE_PARALLELISM).to eq(8)
+    expect(described_class::SUMMARIZE_PARALLELISM).to eq(10)
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/limits_spec.rb`
+Expected: LoadError on the require.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/limits.rb
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  module Limits
+    # Mirrors .claude/skills/<skill>/SKILL.md parent briefs.
+    TRANSCRIBE_PARALLELISM = 2
+    ANALYZE_PARALLELISM    = 8
+    SUMMARIZE_PARALLELISM  = 10
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/limits_spec.rb`
+Expected: 1 example, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/limits.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/limits_spec.rb
+git commit -m "M2: extract parallelism caps into a single source"
+```
+
+---
+
+### Task 1.2: Notifier (JSON-RPC notifications)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/notifier.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/notifier_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/notifier_spec.rb
+require "spec_helper"
+require "stringio"
+require "json"
+require_relative "../../../lib/buttercut_ui_sidecar/notifier"
+
+RSpec.describe ButtercutUiSidecar::Notifier do
+  it "writes a JSON-RPC 2.0 notification (no id) and flushes" do
+    io = StringIO.new
+    described_class.new(io: io).notify("file_started", job_id: "j1", video: "a.mp4", stage: "transcribe")
+
+    line = io.string.lines.last
+    payload = JSON.parse(line)
+    expect(payload["jsonrpc"]).to eq("2.0")
+    expect(payload).not_to have_key("id")
+    expect(payload["method"]).to eq("file_started")
+    expect(payload["params"]).to include("job_id" => "j1", "video" => "a.mp4", "stage" => "transcribe")
+    expect(payload["params"]).to have_key("ts")
+  end
+
+  it "is safe to call concurrently — lines are not interleaved" do
+    io = StringIO.new
+    notifier = described_class.new(io: io)
+    threads = 16.times.map do |i|
+      Thread.new { 50.times { notifier.notify("ping", n: i) } }
+    end
+    threads.each(&:join)
+
+    io.string.each_line do |line|
+      expect { JSON.parse(line) }.not_to raise_error
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/notifier_spec.rb`
+Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/notifier.rb
+# frozen_string_literal: true
+
+require "json"
+require "time"
+
+module ButtercutUiSidecar
+  # Writes JSON-RPC 2.0 notifications (payloads without an `id`) on a shared
+  # output stream — the same stream that carries request/response. The Rust
+  # reader distinguishes them by the absence of `id`. A mutex serializes
+  # writes so notifications and responses don't interleave at the byte level.
+  class Notifier
+    def initialize(io:, mutex: Mutex.new)
+      @io = io
+      @mutex = mutex
+      @io.sync = true if @io.respond_to?(:sync=)
+    end
+
+    def notify(method, **params)
+      params[:ts] ||= Time.now.utc.iso8601(3)
+      line = JSON.generate(jsonrpc: "2.0", method: method, params: params)
+      @mutex.synchronize do
+        @io.puts(line)
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/notifier_spec.rb`
+Expected: 2 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/notifier.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/notifier_spec.rb
+git commit -m "M2: notifier emits mutex-guarded JSON-RPC notifications"
+```
+
+---
+
+### Task 1.3: Settings store (API key persistence)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/settings_store.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/settings_store_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/settings_store_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/settings_store"
+
+RSpec.describe ButtercutUiSidecar::SettingsStore do
+  it "prefers ENV over the YAML file" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("anthropic_api_key" => "from-yaml"))
+      store = described_class.new(libraries_root: root, env: { "ANTHROPIC_API_KEY" => "from-env" })
+      expect(store.api_key).to eq("from-env")
+    end
+  end
+
+  it "falls back to settings.yaml when ENV is unset" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("anthropic_api_key" => "from-yaml"))
+      store = described_class.new(libraries_root: root, env: {})
+      expect(store.api_key).to eq("from-yaml")
+    end
+  end
+
+  it "returns nil when neither is set" do
+    Dir.mktmpdir do |root|
+      store = described_class.new(libraries_root: root, env: {})
+      expect(store.api_key).to be_nil
+    end
+  end
+
+  it "writes the key to settings.yaml without clobbering other fields" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("editor" => "fcpx", "whisper_model" => "small"))
+      store = described_class.new(libraries_root: root, env: {})
+      store.write_api_key!("sk-abc")
+
+      data = YAML.safe_load(File.read(File.join(root, "settings.yaml")))
+      expect(data["editor"]).to eq("fcpx")
+      expect(data["whisper_model"]).to eq("small")
+      expect(data["anthropic_api_key"]).to eq("sk-abc")
+    end
+  end
+
+  it "creates settings.yaml when missing" do
+    Dir.mktmpdir do |root|
+      store = described_class.new(libraries_root: root, env: {})
+      store.write_api_key!("sk-xyz")
+      data = YAML.safe_load(File.read(File.join(root, "settings.yaml")))
+      expect(data["anthropic_api_key"]).to eq("sk-xyz")
+    end
+  end
+
+  it "configured? reflects whether a key is available" do
+    Dir.mktmpdir do |root|
+      empty = described_class.new(libraries_root: root, env: {})
+      expect(empty.configured?).to be false
+      configured = described_class.new(libraries_root: root, env: { "ANTHROPIC_API_KEY" => "x" })
+      expect(configured.configured?).to be true
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/settings_store_spec.rb`
+Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/settings_store.rb
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+require "yaml"
+
+module ButtercutUiSidecar
+  class SettingsStore
+    SETTINGS_FILENAME = "settings.yaml"
+
+    def initialize(libraries_root:, env: ENV.to_h)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      @root = Pathname.new(libraries_root)
+      @env = env
+    end
+
+    def api_key
+      env_key = @env["ANTHROPIC_API_KEY"]
+      return env_key unless env_key.nil? || env_key.empty?
+      data = read_yaml
+      key = data["anthropic_api_key"]
+      key.nil? || key.empty? ? nil : key
+    end
+
+    def configured?
+      !api_key.nil?
+    end
+
+    def write_api_key!(key)
+      raise ArgumentError, "key required" if key.nil? || key.empty?
+      data = read_yaml
+      data["anthropic_api_key"] = key
+      write_yaml(data)
+    end
+
+    private
+
+    def settings_path
+      @root.join(SETTINGS_FILENAME)
+    end
+
+    def read_yaml
+      return {} unless settings_path.file?
+      YAML.safe_load(settings_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def write_yaml(data)
+      FileUtils.mkdir_p(@root)
+      tmp = settings_path.to_s + ".tmp"
+      File.write(tmp, YAML.dump(data))
+      File.rename(tmp, settings_path.to_s)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/settings_store_spec.rb`
+Expected: 6 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/settings_store.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/settings_store_spec.rb
+git commit -m "M2: settings store layers ENV over libraries/settings.yaml"
+```
+
+---
+
+### Task 1.4: Anthropic client wrapper
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb`
+
+- [ ] **Step 1: Failing test (uses a stubbed transport)**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/anthropic_client"
+
+RSpec.describe ButtercutUiSidecar::AnthropicClient do
+  # The wrapper takes a client factory so tests can inject a fake.
+  class FakeSdk
+    def initialize(response: nil, raise_with: nil)
+      @response = response
+      @raise_with = raise_with
+      @calls = []
+    end
+    attr_reader :calls
+
+    def messages
+      self
+    end
+
+    def create(**kwargs)
+      @calls << kwargs
+      raise @raise_with if @raise_with
+      @response
+    end
+  end
+
+  it "validates a key with a 1-token Haiku ping and returns true on success" do
+    fake = FakeSdk.new(response: { "content" => [{ "type" => "text", "text" => "ok" }] })
+    client = described_class.new(api_key: "sk-test", sdk: fake)
+    expect(client.validate_key!).to be true
+    expect(fake.calls.first[:model]).to match(/haiku/i)
+    expect(fake.calls.first[:max_tokens]).to eq(1)
+  end
+
+  it "raises InvalidApiKey when the SDK raises an auth error" do
+    fake = FakeSdk.new(raise_with: described_class::FakeAuthError.new("invalid x-api-key"))
+    client = described_class.new(api_key: "sk-bad", sdk: fake, auth_error_classes: [described_class::FakeAuthError])
+    expect { client.validate_key! }.to raise_error(ButtercutUiSidecar::AnthropicClient::InvalidApiKey, /invalid/)
+  end
+end
+```
+
+(`FakeAuthError` is just an alias for `RuntimeError` defined inside the wrapper for tests; in production, the auth-error class list comes from the `anthropic` gem.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb`
+Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  # Thin wrapper around the anthropic gem. Holds the api_key, exposes
+  # `validate_key!` (single Haiku ping) and `messages_create` (regular calls).
+  # Auth errors surface as InvalidApiKey; everything else propagates.
+  class AnthropicClient
+    HAIKU_MODEL = "claude-haiku-4-5-20251001"
+    VISION_MODEL = "claude-sonnet-4-6"
+
+    class InvalidApiKey < StandardError; end
+    class FakeAuthError < StandardError; end # used only in tests
+
+    def initialize(api_key:, sdk: nil, auth_error_classes: nil)
+      raise ArgumentError, "api_key required" if api_key.nil? || api_key.empty?
+      @api_key = api_key
+      @sdk = sdk || build_sdk(api_key)
+      @auth_error_classes = auth_error_classes || default_auth_error_classes
+    end
+
+    def validate_key!
+      @sdk.messages.create(
+        model: HAIKU_MODEL,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "ping" }]
+      )
+      true
+    rescue *@auth_error_classes => e
+      raise InvalidApiKey, e.message
+    end
+
+    def messages_create(**kwargs)
+      @sdk.messages.create(**kwargs)
+    rescue *@auth_error_classes => e
+      raise InvalidApiKey, e.message
+    end
+
+    private
+
+    def build_sdk(api_key)
+      require "anthropic"
+      Anthropic::Client.new(api_key: api_key)
+    end
+
+    def default_auth_error_classes
+      classes = []
+      begin
+        require "anthropic"
+        classes << Anthropic::AuthenticationError if defined?(Anthropic::AuthenticationError)
+      rescue LoadError
+        # fall through; tests inject explicit classes
+      end
+      classes
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb`
+Expected: 2 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
+git commit -m "M2: AnthropicClient wraps the SDK with validate_key! + InvalidApiKey"
+```
+
+---
+
+## Phase 2 — Stateless RPCs (no worker pool yet)
+
+### Task 2.1: Video inspector
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/video_inspector.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb
+require "spec_helper"
+require "tmpdir"
+require_relative "../../../lib/buttercut_ui_sidecar/video_inspector"
+
+RSpec.describe ButtercutUiSidecar::VideoInspector do
+  it "rejects paths that do not exist" do
+    result = described_class.new.inspect(["/no/such/file.mov"])
+    expect(result[:accepted]).to be_empty
+    expect(result[:rejected].first[:reason]).to eq("not_found")
+  end
+
+  it "rejects non-video files", skip: !system("which ffprobe > /dev/null 2>&1") do
+    Dir.mktmpdir do |dir|
+      txt = File.join(dir, "notes.txt")
+      File.write(txt, "hello")
+      result = described_class.new.inspect([txt])
+      expect(result[:rejected].first[:reason]).to eq("not_video")
+    end
+  end
+
+  it "accepts a real video and returns duration_seconds + size_bytes",
+     skip: !system("which ffmpeg > /dev/null 2>&1 && which ffprobe > /dev/null 2>&1") do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "tiny.mp4")
+      system("ffmpeg -y -loglevel error -f lavfi -i color=c=red:s=64x64:d=2 -pix_fmt yuv420p #{video}")
+      result = described_class.new.inspect([video])
+      expect(result[:accepted].first[:path]).to eq(video)
+      expect(result[:accepted].first[:duration_seconds]).to be > 0
+      expect(result[:accepted].first[:size_bytes]).to be > 0
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/video_inspector.rb
+# frozen_string_literal: true
+
+require "open3"
+require "json"
+
+module ButtercutUiSidecar
+  class VideoInspector
+    def inspect(paths)
+      accepted = []
+      rejected = []
+
+      paths.each do |p|
+        unless File.file?(p)
+          rejected << { path: p, reason: "not_found" }
+          next
+        end
+
+        info = probe(p)
+        if info.nil?
+          rejected << { path: p, reason: "not_video" }
+        elsif info[:duration_seconds].to_f <= 0
+          rejected << { path: p, reason: "zero_duration" }
+        else
+          accepted << { path: p, duration_seconds: info[:duration_seconds], size_bytes: File.size(p) }
+        end
+      end
+
+      { accepted: accepted, rejected: rejected }
+    end
+
+    private
+
+    def probe(path)
+      cmd = ["ffprobe", "-v", "error", "-print_format", "json",
+             "-show_format", "-show_streams", "-select_streams", "v:0", path]
+      out, _err, status = Open3.capture3(*cmd)
+      return nil unless status.success?
+      data = JSON.parse(out) rescue nil
+      return nil unless data && (data["streams"] || []).any? { |s| s["codec_type"] == "video" }
+      duration = (data.dig("format", "duration") || 0).to_f
+      { duration_seconds: duration }
+    rescue StandardError
+      nil
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bundle exec rspec spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb`
+Expected: 3 examples, 0 failures (some skipped if ffmpeg/ffprobe absent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/video_inspector.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb
+git commit -m "M2: VideoInspector wraps ffprobe and classifies rejections"
+```
+
+---
+
+### Task 2.2: Library creator
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/library_creator.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/library_creator_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/library_creator_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/library_creator"
+
+RSpec.describe ButtercutUiSidecar::LibraryCreator do
+  def video(dir, name, duration: "00:00:05")
+    path = File.join(dir, name)
+    File.write(path, "x")
+    { path: path, duration_seconds: 5 }
+  end
+
+  it "slugifies the name and creates the directory tree + library.yaml" do
+    Dir.mktmpdir do |root|
+      Dir.mktmpdir do |footage|
+        creator = described_class.new(libraries_root: root)
+        result = creator.create!(
+          name: "My Bike Series",
+          language: "English",
+          language_code: "en",
+          refinement: true,
+          videos: [video(footage, "a.mp4"), video(footage, "b.mp4")]
+        )
+        expect(result[:name]).to eq("my-bike-series")
+
+        lib_dir = File.join(root, "my-bike-series")
+        expect(File.directory?(File.join(lib_dir, "transcripts"))).to be true
+        expect(File.directory?(File.join(lib_dir, "summaries"))).to be true
+
+        data = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")), permitted_classes: [Date, Time])
+        expect(data["library_name"]).to eq("my-bike-series")
+        expect(data["language"]).to eq("English")
+        expect(data["language_code"]).to eq("en")
+        expect(data["transcript_refinement"]).to be true
+        expect(data["videos"].length).to eq(2)
+        expect(data["videos"].first["transcript"]).to eq("")
+        expect(data["videos"].first["visual_transcript"]).to eq("")
+        expect(data["videos"].first["summary"]).to eq("")
+      end
+    end
+  end
+
+  it "errors with library_exists when the slug already has a library.yaml" do
+    Dir.mktmpdir do |root|
+      FileUtils.mkdir_p(File.join(root, "demo"))
+      File.write(File.join(root, "demo", "library.yaml"), "library_name: demo")
+      creator = described_class.new(libraries_root: root)
+      expect {
+        creator.create!(name: "Demo", language: "English", language_code: "en", refinement: false, videos: [])
+      }.to raise_error(described_class::LibraryExists)
+    end
+  end
+
+  it "rolls back on partial failure (e.g. yaml write fails)" do
+    Dir.mktmpdir do |root|
+      creator = described_class.new(libraries_root: root)
+      allow(File).to receive(:write).and_call_original
+      allow(File).to receive(:write).with(/library\.yaml/, anything).and_raise(Errno::EACCES, "denied")
+
+      expect {
+        creator.create!(name: "rollback", language: "English", language_code: "en", refinement: false, videos: [])
+      }.to raise_error(Errno::EACCES)
+
+      expect(File.directory?(File.join(root, "rollback"))).to be false
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/library_creator.rb
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+require "yaml"
+require "date"
+
+module ButtercutUiSidecar
+  class LibraryCreator
+    class LibraryExists < StandardError; end
+
+    def initialize(libraries_root:)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      @root = Pathname.new(libraries_root)
+    end
+
+    def create!(name:, language:, language_code:, refinement:, videos:)
+      slug = slugify(name)
+      raise ArgumentError, "invalid name: #{name}" if slug.empty?
+
+      lib_dir = @root.join(slug)
+      raise LibraryExists, "library already exists: #{slug}" if lib_dir.join("library.yaml").file?
+
+      created = false
+      begin
+        FileUtils.mkdir_p(lib_dir.join("transcripts"))
+        FileUtils.mkdir_p(lib_dir.join("summaries"))
+        created = true
+
+        data = build_yaml(slug: slug, language: language, language_code: language_code,
+                          refinement: refinement, videos: videos)
+        File.write(lib_dir.join("library.yaml"), YAML.dump(data))
+        { name: slug }
+      rescue StandardError
+        FileUtils.rm_rf(lib_dir) if created
+        raise
+      end
+    end
+
+    private
+
+    def slugify(name)
+      name.to_s.downcase.gsub(/\s+/, "-").gsub(/[^a-z0-9\-]/, "").gsub(/-+/, "-").gsub(/\A-|-\z/, "")
+    end
+
+    def build_yaml(slug:, language:, language_code:, refinement:, videos:)
+      today = Date.today.iso8601
+      {
+        "library_name" => slug,
+        "created_date" => today,
+        "last_updated" => today,
+        "language" => language,
+        "language_code" => language_code,
+        "editor" => nil,
+        "transcript_refinement" => refinement,
+        "user_context" => "",
+        "footage_summary" => "No footage analyzed yet.",
+        "videos" => videos.map do |v|
+          {
+            "path" => v[:path] || v["path"],
+            "duration" => format_duration(v[:duration_seconds] || v["duration_seconds"]),
+            "transcript" => "",
+            "visual_transcript" => "",
+            "summary" => ""
+          }
+        end
+      }
+    end
+
+    def format_duration(seconds)
+      return "00:00:00" if seconds.nil?
+      s = seconds.to_i
+      format("%02d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Expected: 3 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/library_creator.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/library_creator_spec.rb
+git commit -m "M2: LibraryCreator atomically creates a library directory tree"
+```
+
+---
+
+### Task 2.3: Wire `inspect_video_paths`, `create_library`, `set_api_key`, `has_api_key` into the dispatcher
+
+**Files:**
+- Modify: `ui/sidecar/buttercut_ui_sidecar.rb`
+- Modify: `ui/sidecar/spec/buttercut_ui_sidecar_spec.rb`
+
+- [ ] **Step 1: Add specs to the existing top-level spec**
+
+Append to `ui/sidecar/spec/buttercut_ui_sidecar_spec.rb` (inside the existing `describe ButtercutUiSidecar do … end`):
+
+```ruby
+  describe "has_api_key" do
+    it "returns false when no key is configured" do
+      Dir.mktmpdir do |root|
+        result = call(root, "has_api_key")
+        expect(result["result"]).to eq({ "configured" => false })
+      end
+    end
+  end
+
+  describe "create_library" do
+    it "creates a library and returns its slug" do
+      Dir.mktmpdir do |root|
+        Dir.mktmpdir do |footage|
+          v = File.join(footage, "a.mp4")
+          File.write(v, "x")
+          result = call(root, "create_library", {
+            name: "My Lib",
+            language: "English",
+            language_code: "en",
+            refinement: true,
+            videos: [{ path: v, duration_seconds: 5 }]
+          })
+          expect(result["result"]).to eq({ "name" => "my-lib" })
+          expect(File.file?(File.join(root, "my-lib", "library.yaml"))).to be true
+        end
+      end
+    end
+  end
+
+  describe "inspect_video_paths" do
+    it "rejects nonexistent paths" do
+      Dir.mktmpdir do |root|
+        result = call(root, "inspect_video_paths", { paths: ["/no/such/file.mov"] })
+        expect(result["result"]["rejected"].first["reason"]).to eq("not_found")
+      end
+    end
+  end
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `bundle exec rspec spec/buttercut_ui_sidecar_spec.rb`
+Expected: failures on the three new contexts (`unknown method`).
+
+- [ ] **Step 3: Wire into dispatcher**
+
+Edit `ui/sidecar/buttercut_ui_sidecar.rb`. At the top, after existing requires:
+
+```ruby
+require_relative "lib/buttercut_ui_sidecar/limits"
+require_relative "lib/buttercut_ui_sidecar/notifier"
+require_relative "lib/buttercut_ui_sidecar/settings_store"
+require_relative "lib/buttercut_ui_sidecar/anthropic_client"
+require_relative "lib/buttercut_ui_sidecar/video_inspector"
+require_relative "lib/buttercut_ui_sidecar/library_creator"
+```
+
+In `initialize`, add:
+
+```ruby
+@settings = ButtercutUiSidecar::SettingsStore.new(libraries_root: @libraries_root.to_s)
+@notifier = ButtercutUiSidecar::Notifier.new(io: @io_out)
+@inspector = ButtercutUiSidecar::VideoInspector.new
+@creator = ButtercutUiSidecar::LibraryCreator.new(libraries_root: @libraries_root.to_s)
+```
+
+In `dispatch`, add cases:
+
+```ruby
+when "has_api_key"
+  { configured: @settings.configured? }
+when "set_api_key"
+  set_api_key(params.fetch("key"))
+when "inspect_video_paths"
+  @inspector.inspect(params.fetch("paths"))
+when "create_library"
+  @creator.create!(
+    name: params.fetch("name"),
+    language: params.fetch("language"),
+    language_code: params.fetch("language_code"),
+    refinement: params.fetch("refinement"),
+    videos: params.fetch("videos")
+  )
+```
+
+Add the `set_api_key` private method:
+
+```ruby
+def set_api_key(key)
+  client = ButtercutUiSidecar::AnthropicClient.new(api_key: key)
+  client.validate_key!
+  @settings.write_api_key!(key)
+  { ok: true }
+rescue ButtercutUiSidecar::AnthropicClient::InvalidApiKey => e
+  raise StandardError, "invalid_api_key: #{e.message}"
+end
+```
+
+Map `LibraryCreator::LibraryExists` to a specific RPC error code in `handle_line`:
+
+```ruby
+rescue ButtercutUiSidecar::LibraryCreator::LibraryExists => e
+  respond_error(id: id, code: -32011, message: "library_exists: #{e.message}")
+```
+
+(Place that rescue clause before the generic `StandardError` rescue.)
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd ui/sidecar && bundle exec rake spec`
+Expected: all M1 specs + the three new dispatcher contexts pass.
+
+- [ ] **Step 5: Smoke-test from a shell**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"has_api_key","params":{}}' | bundle exec ruby buttercut_ui_sidecar.rb /tmp
+```
+Expected: `{"jsonrpc":"2.0","id":1,"result":{"configured":false}}` (or `true` if you have ANTHROPIC_API_KEY exported).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/sidecar/buttercut_ui_sidecar.rb ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+git commit -m "M2: dispatch has_api_key, set_api_key, inspect_video_paths, create_library"
+```
+
+---
+
+## Phase 3 — Prompt extraction
+
+### Task 3.1: Extract analyze + summarize prompt content
+
+**Files:**
+- Create: `ui/sidecar/prompts/analyze_video.md`
+- Create: `ui/sidecar/prompts/summarize_video.md`
+- Modify: `.claude/skills/analyze-video/agent_prompt.md`
+- Modify: `.claude/skills/summarize-video/agent_prompt.md`
+
+- [ ] **Step 1: Create `ui/sidecar/prompts/analyze_video.md`**
+
+Pull out the *creative* sections from `.claude/skills/analyze-video/agent_prompt.md` — the description content, b-roll guidelines, dialogue/visual segment structure. **Do not** include Claude-Code-specific instructions ("use the Edit tool", "Read the JPG frames"). The shared prompt should describe **what** to produce, not the tooling. Concretely write:
+
+```markdown
+# Visual transcript instructions (shared)
+
+You analyze video frames and produce visual descriptions paired with audio segments to form a "visual transcript." This file is read by both the CLI agent (Claude Code) and the desktop sidecar (Anthropic SDK).
+
+## Output schema
+
+The visual transcript JSON has the same top-level shape as the audio transcript: `{language, video_path, segments: [...]}`. Each segment is one of:
+
+**Dialogue segment** — same shape as audio, plus a `visual` field:
+```json
+{
+  "start": 2.917,
+  "end": 7.586,
+  "text": "Hey, good afternoon everybody.",
+  "visual": "Man in red shirt speaking to camera in medium shot. Home office with bookshelf. Natural lighting.",
+  "words": [...]
+}
+```
+
+**B-roll segment** — inserted between dialogue when no one is speaking:
+```json
+{
+  "start": 35.474,
+  "end": 56.162,
+  "text": "",
+  "visual": "Green bicycle parked in front of building. Urban street with trees.",
+  "b_roll": true,
+  "words": []
+}
+```
+
+## Description guidelines
+
+- Maximum 3 sentences per `visual` field.
+- First segment: detailed (subject, setting, shot type, lighting, camera style).
+- Continuing shots: brief if similar; up to 3 sentences if drastically different.
+- Describe what is visible, not interpretation. Avoid speculation.
+
+## Frame sampling
+
+- Videos ≤30s: sample one frame near the middle.
+- Videos >30s: sample at start (~2s in), middle (duration/2), end (duration−2s).
+- Subdivide further if start/middle/end show different subjects, settings, or angle changes.
+- Stop subdividing when consecutive frames show only minor changes.
+- Never sample more frequently than once per 30 seconds.
+```
+
+- [ ] **Step 2: Create `ui/sidecar/prompts/summarize_video.md`**
+
+Same treatment for the summary content:
+
+```markdown
+# Video summary instructions (shared)
+
+You produce a short markdown summary of a video from its visual transcript. This file is read by both the CLI agent (Claude Code, via skeleton + Edit) and the desktop sidecar (Anthropic SDK, plain text output).
+
+## Output structure
+
+The summary file has four sections, in order:
+
+1. **Overview** — 2–3 sentences describing the narrative arc. Be specific. Avoid vague endings like "the clip ends with…" or "discusses something."
+2. **Key visuals** — 3–6 bullets covering locations, distinctive shots, visual changes.
+3. **Dialogue** — 0–3 quotes formatted as `> [MM:SS] "Quote"`. Skip filler ("um", "you know"). For clips under 30 seconds, often 0–1 quotes is enough; write `None` if nothing stands out.
+4. **B-roll** — cutaway descriptions distinct from the main subject. For single-shot clips, write `None`. Do not speculate about how the footage could be used as b-roll elsewhere.
+
+The CLI agent fills these into a pre-created skeleton via Edit; the sidecar emits them directly as a single markdown document.
+```
+
+- [ ] **Step 3: Update `.claude/skills/analyze-video/agent_prompt.md`**
+
+Replace the section "Add visual descriptions" through the b-roll example with:
+
+```markdown
+## 3. Add visual descriptions
+
+The output schema and description guidelines are defined in
+`ui/sidecar/prompts/analyze_video.md` — read it before continuing.
+
+**Read the JPG frames** from `tmp/frames/[video_name]/` using the Read tool, then **Edit** the file at `<visual_transcript_path>`. Do this incrementally — no script needed; just edit the JSON each time you read new frames.
+```
+
+Leave the rest of the file (frame extraction, cleanup, return) intact.
+
+- [ ] **Step 4: Update `.claude/skills/summarize-video/agent_prompt.md`**
+
+Replace the "Action 3 — Edit each placeholder" section's body with:
+
+```markdown
+## Action 3 — Edit each placeholder
+
+The four sections (Overview, Key visuals, Dialogue, B-roll) are defined in
+`ui/sidecar/prompts/summarize_video.md` — read it for the exact content rules.
+
+Use the **Edit** tool four times to replace each `<!-- FILL_X -->` marker with the corresponding section's content:
+
+- `<!-- FILL_OVERVIEW -->` → the Overview section.
+- `<!-- FILL_KEY_VISUALS -->` → the Key visuals bullets.
+- `<!-- FILL_DIALOGUE -->` → the Dialogue quotes (or `None`).
+- `<!-- FILL_BROLL -->` → the B-roll list (or `None`).
+```
+
+- [ ] **Step 5: Verify the existing agent prompts still parse / run a dry sanity check**
+
+Run: `head -30 .claude/skills/analyze-video/agent_prompt.md && head -30 .claude/skills/summarize-video/agent_prompt.md`
+Expected: still well-formed markdown, no broken anchor references.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/sidecar/prompts/ .claude/skills/analyze-video/agent_prompt.md .claude/skills/summarize-video/agent_prompt.md
+git commit -m "M2: extract analyze + summarize prompt content into shared files"
+```
+
+---
+
+## Phase 4 — Analysis pipeline
+
+### Task 4.1: JobRegistry
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/job_registry.rb`
+
+- [ ] **Step 1: Failing test**
+
+Create `ui/sidecar/spec/lib/buttercut_ui_sidecar/job_registry_spec.rb`:
+
+```ruby
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
+
+RSpec.describe ButtercutUiSidecar::JobRegistry do
+  it "stores, retrieves, and removes by job_id" do
+    registry = described_class.new
+    registry.put("j1", :payload)
+    expect(registry.get("j1")).to eq(:payload)
+    registry.delete("j1")
+    expect(registry.get("j1")).to be_nil
+  end
+
+  it "is concurrent-safe" do
+    registry = described_class.new
+    threads = 32.times.map do |i|
+      Thread.new { registry.put("j#{i}", i) }
+    end
+    threads.each(&:join)
+    32.times { |i| expect(registry.get("j#{i}")).to eq(i) }
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/job_registry.rb
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  class JobRegistry
+    def initialize
+      @mutex = Mutex.new
+      @jobs = {}
+    end
+
+    def put(id, job)
+      @mutex.synchronize { @jobs[id] = job }
+    end
+
+    def get(id)
+      @mutex.synchronize { @jobs[id] }
+    end
+
+    def delete(id)
+      @mutex.synchronize { @jobs.delete(id) }
+    end
+
+    def each(&block)
+      @mutex.synchronize { @jobs.values.dup }.each(&block)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass**. Expected: 2 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/job_registry.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/job_registry_spec.rb
+git commit -m "M2: JobRegistry — mutex-guarded job_id table"
+```
+
+---
+
+### Task 4.2: AnalysisJob (cancel token + child PID + abort handle registry)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_job_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_job_spec.rb
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::AnalysisJob do
+  it "starts uncanceled" do
+    job = described_class.new(id: "j1", library: "demo")
+    expect(job.canceled?).to be false
+  end
+
+  it "cancel! flips the token and is idempotent" do
+    job = described_class.new(id: "j1", library: "demo")
+    job.cancel!
+    job.cancel!
+    expect(job.canceled?).to be true
+  end
+
+  it "registers and signals child PIDs on cancel" do
+    job = described_class.new(id: "j1", library: "demo")
+    pid = Process.spawn("sleep", "60")
+    job.register_pid(pid)
+    job.cancel!
+    # Reap the child to avoid zombies; Process.wait blocks until done.
+    Process.wait(pid)
+    expect($?.success?).to be false
+  end
+
+  it "registers and aborts in-flight handles on cancel" do
+    job = described_class.new(id: "j1", library: "demo")
+    aborted = false
+    handle = Object.new
+    handle.define_singleton_method(:abort!) { aborted = true }
+    job.register_abortable(handle)
+    job.cancel!
+    expect(aborted).to be true
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb
+# frozen_string_literal: true
+
+require "concurrent"
+
+module ButtercutUiSidecar
+  class AnalysisJob
+    attr_reader :id, :library
+
+    def initialize(id:, library:)
+      @id = id
+      @library = library
+      @cancel_flag = Concurrent::AtomicBoolean.new(false)
+      @pids = Concurrent::Array.new
+      @abortables = Concurrent::Array.new
+      @library_yaml_mutex = Mutex.new
+    end
+
+    def canceled?
+      @cancel_flag.true?
+    end
+
+    def cancel!
+      return if @cancel_flag.true?
+      @cancel_flag.make_true
+      @pids.dup.each { |pid| terminate_pid(pid) }
+      @abortables.dup.each do |h|
+        h.abort! if h.respond_to?(:abort!)
+      end
+    end
+
+    def register_pid(pid)
+      @pids << pid
+    end
+
+    def unregister_pid(pid)
+      @pids.delete(pid)
+    end
+
+    def register_abortable(handle)
+      @abortables << handle
+    end
+
+    def unregister_abortable(handle)
+      @abortables.delete(handle)
+    end
+
+    # Yields with the per-library yaml mutex held. Use for read-modify-write of library.yaml.
+    def with_yaml_lock
+      @library_yaml_mutex.synchronize { yield }
+    end
+
+    private
+
+    def terminate_pid(pid)
+      Process.kill("TERM", pid)
+      sleep 2
+      Process.kill("KILL", pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # already gone
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: 4 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_job_spec.rb
+git commit -m "M2: AnalysisJob — cancel token, PID registry, abort handles, yaml mutex"
+```
+
+---
+
+### Task 4.3: Stage — transcribe (whisperx subprocess only, no refinement yet)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb`
+
+This stage shells out to `whisperx`, runs the existing `prepare_audio_script.rb`, and writes `<basename>.json` into `transcripts/`. We do **not** TDD it against the real whisperx (too slow, requires the model). Instead we expose a single `run` method that takes the dependencies as arguments and unit-test the orchestration with a fake.
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/transcribe"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Transcribe do
+  it "runs whisperx, prepares the JSON, registers the PID for cancellation" do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "tiny.mp4")
+      File.write(video, "x")
+      transcript_dir = File.join(dir, "transcripts")
+      FileUtils.mkdir_p(transcript_dir)
+      expected_output = File.join(transcript_dir, "tiny.json")
+
+      shell = lambda do |argv, on_pid:|
+        on_pid.call(12345)
+        # simulate whisperx writing the file
+        File.write(expected_output, JSON.generate({ language: "en", segments: [] }))
+        [true, ""]
+      end
+      prep = ->(_path, _video) { } # no-op; output already valid
+
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+      stage = described_class.new(shell: shell, prepare: prep)
+
+      result = stage.run(
+        job: job,
+        video_path: video,
+        transcript_output_dir: transcript_dir,
+        language_code: "en",
+        whisper_model: "small"
+      )
+
+      expect(result[:transcript_path]).to eq(expected_output)
+      expect(File.file?(expected_output)).to be true
+    end
+  end
+
+  it "raises if whisperx returns failure" do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "v.mp4"); File.write(video, "x")
+      transcript_dir = File.join(dir, "transcripts"); FileUtils.mkdir_p(transcript_dir)
+      shell = ->(_argv, on_pid:) { on_pid.call(1); [false, "boom"] }
+      stage = described_class.new(shell: shell, prepare: ->(*) {})
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+      expect {
+        stage.run(job: job, video_path: video, transcript_output_dir: transcript_dir,
+                  language_code: "en", whisper_model: "small")
+      }.to raise_error(/whisperx failed/)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+module ButtercutUiSidecar
+  module Stages
+    class Transcribe
+      DEFAULT_PREPARE_SCRIPT = File.expand_path("../../../../../.claude/skills/transcribe-audio/prepare_audio_script.rb", __dir__)
+
+      def initialize(shell: nil, prepare: nil, prepare_script: DEFAULT_PREPARE_SCRIPT)
+        @shell = shell || method(:default_shell)
+        @prepare = prepare || method(:default_prepare).curry[prepare_script]
+      end
+
+      # Returns { transcript_path: <abs path> } on success.
+      def run(job:, video_path:, transcript_output_dir:, language_code:, whisper_model:)
+        return cancel_result if job.canceled?
+
+        argv = [
+          "whisperx", video_path,
+          "--language", language_code,
+          "--model", whisper_model,
+          "--compute_type", "float32",
+          "--device", "cpu",
+          "--output_format", "json",
+          "--output_dir", transcript_output_dir
+        ]
+
+        ok, stderr = @shell.call(argv, on_pid: ->(pid) { job.register_pid(pid) })
+        raise "whisperx failed: #{stderr.strip}" unless ok
+        return cancel_result if job.canceled?
+
+        basename = File.basename(video_path, ".*")
+        json_path = File.join(transcript_output_dir, "#{basename}.json")
+        raise "whisperx produced no output at #{json_path}" unless File.file?(json_path)
+
+        @prepare.call(json_path, video_path)
+        { transcript_path: json_path }
+      end
+
+      private
+
+      def cancel_result
+        { canceled: true }
+      end
+
+      def default_shell(argv, on_pid:)
+        stdin, stdout_err, wait_thr = Open3.popen2e(*argv)
+        stdin.close
+        on_pid.call(wait_thr.pid)
+        out = stdout_err.read
+        wait_thr.value.success? ? [true, out] : [false, out]
+      end
+
+      def default_prepare(prepare_script, json_path, video_path)
+        ok, err = run_simple("ruby", prepare_script, json_path, video_path)
+        raise "prepare_audio_script failed: #{err.strip}" unless ok
+      end
+
+      def run_simple(*argv)
+        out, status = Open3.capture2e(*argv)
+        [status.success?, out]
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: 2 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
+git commit -m "M2: transcribe stage — whisperx + prepare with cancellation hooks"
+```
+
+---
+
+### Task 4.4: Stage — analyze (frame extraction + Anthropic vision call)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb`
+
+This stage:
+1. Copies the audio transcript to `<visual_transcript_path>`.
+2. Runs `prepare_visual_script.rb` to strip word-level timing.
+3. Decides which timestamps to sample.
+4. Shells out to ffmpeg to extract those frames.
+5. Sends one Anthropic Messages call with all frames + the prompt from `prompts/analyze_video.md`.
+6. Asks the model to return a JSON object mapping `{ "segments": [...] }` matching the prepared schema.
+7. Writes the merged result to `<visual_transcript_path>.tmp` and atomically renames.
+8. Cleans up frames.
+
+- [ ] **Step 1: Failing test (mocked vision call)**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/analyze"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Analyze do
+  let(:job) { ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo") }
+
+  def setup_audio(dir, name: "a.json")
+    path = File.join(dir, name)
+    File.write(path, JSON.generate(language: "en", video_path: "/x/a.mp4",
+      segments: [{ start: 0.0, end: 5.0, text: "hello", words: [] }]))
+    path
+  end
+
+  it "writes the visual transcript with model-supplied descriptions" do
+    Dir.mktmpdir do |dir|
+      audio = setup_audio(dir)
+      visual = File.join(dir, "visual_a.json")
+
+      ffmpeg = ->(_video, _ts, out_path, on_pid:) { on_pid.call(rand(2**16)); File.write(out_path, "fakejpg"); true }
+      vision = ->(_frames, _prompt) { { "segments" => [{ "start" => 0.0, "end" => 5.0, "text" => "hello", "visual" => "scene" }] } }
+
+      stage = described_class.new(ffmpeg: ffmpeg, vision: vision)
+      result = stage.run(job: job, video_path: "/x/a.mp4", audio_transcript_path: audio, visual_transcript_path: visual)
+
+      expect(result[:visual_transcript_path]).to eq(visual)
+      expect(File.file?(visual)).to be true
+      data = JSON.parse(File.read(visual))
+      expect(data["segments"].first["visual"]).to eq("scene")
+    end
+  end
+
+  it "respects cancellation between frame extraction and vision call" do
+    Dir.mktmpdir do |dir|
+      audio = setup_audio(dir)
+      visual = File.join(dir, "visual_a.json")
+
+      ffmpeg = ->(_, _, out_path, on_pid:) { on_pid.call(1); File.write(out_path, "fakejpg"); true }
+      vision = ->(_, _) { raise "should not call vision" }
+
+      stage = described_class.new(ffmpeg: ffmpeg, vision: vision)
+      job.cancel!
+      result = stage.run(job: job, video_path: "/x/a.mp4", audio_transcript_path: audio, visual_transcript_path: visual)
+      expect(result[:canceled]).to be true
+      expect(File.file?(visual)).to be false
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "base64"
+require "pathname"
+
+module ButtercutUiSidecar
+  module Stages
+    class Analyze
+      def initialize(ffmpeg: nil, vision: nil, prompt_path: default_prompt_path)
+        @ffmpeg = ffmpeg || method(:default_ffmpeg)
+        @vision = vision # required when not in test mode
+        @prompt_path = prompt_path
+      end
+
+      def run(job:, video_path:, audio_transcript_path:, visual_transcript_path:)
+        return cancel_result if job.canceled?
+
+        prepared = prepare_skeleton(audio_transcript_path)
+        timestamps = sample_timestamps(prepared)
+        frames = extract_frames(job, video_path, timestamps)
+        return cancel_result if job.canceled?
+
+        prompt = File.read(@prompt_path)
+        response = @vision.call(frames, prompt + "\n\nHere is the prepared transcript skeleton (JSON):\n" + JSON.pretty_generate(prepared))
+        return cancel_result if job.canceled?
+
+        merged = merge_segments(prepared, response.fetch("segments"))
+        atomic_write_json(visual_transcript_path, merged)
+
+        cleanup_frames(frames)
+        { visual_transcript_path: visual_transcript_path }
+      end
+
+      def self.default_prompt_path
+        File.expand_path("../../../prompts/analyze_video.md", __dir__)
+      end
+
+      private
+
+      def default_prompt_path
+        self.class.default_prompt_path
+      end
+
+      def prepare_skeleton(audio_path)
+        data = JSON.parse(File.read(audio_path))
+        # Strip word-level timing to keep the visual transcript small (mirrors
+        # .claude/skills/analyze-video/prepare_visual_script.rb).
+        if data["segments"]
+          data["segments"] = data["segments"].map do |s|
+            s.dup.tap { |c| c.delete("words") }
+          end
+        end
+        data
+      end
+
+      def sample_timestamps(prepared)
+        duration = (prepared.dig("segments", -1, "end") || 0).to_f
+        return [duration / 2.0] if duration <= 30
+        [2.0, duration / 2.0, [duration - 2.0, 2.0].max]
+      end
+
+      def extract_frames(job, video_path, timestamps)
+        tmp_dir = File.join(Dir.tmpdir, "buttercut-frames-#{job.id}-#{File.basename(video_path, ".*")}")
+        FileUtils.mkdir_p(tmp_dir)
+        frames = []
+        timestamps.each_with_index do |ts, i|
+          return frames if job.canceled?
+          out = File.join(tmp_dir, "frame_#{i}.jpg")
+          ok = @ffmpeg.call(video_path, ts, out, on_pid: ->(pid) { job.register_pid(pid) })
+          frames << out if ok && File.file?(out)
+        end
+        frames
+      end
+
+      def merge_segments(prepared, response_segments)
+        # Map response segments by start time to the skeleton; preserve any
+        # fields the model didn't touch.
+        by_start = response_segments.each_with_object({}) { |s, h| h[s["start"].to_f] = s }
+        prepared["segments"] = prepared["segments"].map do |skel|
+          rs = by_start[skel["start"].to_f] || {}
+          skel.merge(rs.slice("visual", "b_roll"))
+        end
+        # Append any b-roll-only segments from the response that weren't in the skeleton.
+        skel_starts = prepared["segments"].map { |s| s["start"].to_f }.to_set
+        extras = response_segments.reject { |s| skel_starts.include?(s["start"].to_f) }
+        prepared["segments"].concat(extras)
+        prepared
+      end
+
+      def atomic_write_json(path, data)
+        tmp = path + ".tmp"
+        File.write(tmp, JSON.pretty_generate(data))
+        File.rename(tmp, path)
+      end
+
+      def cleanup_frames(frames)
+        return if frames.empty?
+        FileUtils.rm_rf(File.dirname(frames.first))
+      end
+
+      def cancel_result
+        { canceled: true }
+      end
+
+      def default_ffmpeg(video_path, timestamp, out_path, on_pid:)
+        cmd = ["ffmpeg", "-ss", format_ts(timestamp), "-i", video_path,
+               "-vframes", "1", "-vf", "scale=1280:-1", "-y", out_path]
+        stdin, stdout_err, wait_thr = Open3.popen2e(*cmd)
+        stdin.close
+        on_pid.call(wait_thr.pid)
+        stdout_err.read
+        wait_thr.value.success?
+      end
+
+      def format_ts(seconds)
+        s = seconds.to_f
+        format("%02d:%02d:%06.3f", s / 3600, (s.to_i % 3600) / 60, s % 60)
+      end
+    end
+  end
+end
+```
+
+The `vision:` callable receives `(frames, prompt_with_skeleton)` and returns the parsed segments hash. The default production wiring passes a closure that calls `AnthropicClient.messages_create` with `model: VISION_MODEL`, `messages: [{ role: "user", content: <image blocks + text block> }]`, asks for JSON output, and parses the response. That wiring lives in the controller (Task 4.6) so the stage stays pure.
+
+- [ ] **Step 4: Run, verify pass.** Expected: 2 examples, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
+git commit -m "M2: analyze stage — frame sampling, vision call, atomic merge"
+```
+
+---
+
+### Task 4.5: Stage — summarize (Anthropic Haiku call)
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/stages/summarize.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/summarize_spec.rb`
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/summarize_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/summarize"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Summarize do
+  it "writes the markdown summary atomically using the supplied Haiku callable" do
+    Dir.mktmpdir do |dir|
+      visual = File.join(dir, "visual_a.json")
+      File.write(visual, JSON.generate(language: "en", video_path: "/x/a.mp4", segments: [
+        { start: 0.0, end: 5.0, text: "hello", visual: "scene" }
+      ]))
+      summary_path = File.join(dir, "summary_a.md")
+
+      haiku = ->(_prompt) { "## Overview\n\nMan says hello.\n\n## Key visuals\n- scene\n\n## Dialogue\n\nNone\n\n## B-roll\n\nNone\n" }
+      stage = described_class.new(haiku: haiku)
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+
+      result = stage.run(job: job, visual_transcript_path: visual, summary_output_path: summary_path)
+      expect(result[:summary_path]).to eq(summary_path)
+      expect(File.read(summary_path)).to include("## Overview")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/stages/summarize.rb
+# frozen_string_literal: true
+
+require "json"
+
+module ButtercutUiSidecar
+  module Stages
+    class Summarize
+      def initialize(haiku: nil, prompt_path: default_prompt_path)
+        @haiku = haiku
+        @prompt_path = prompt_path
+      end
+
+      def run(job:, visual_transcript_path:, summary_output_path:)
+        return cancel_result if job.canceled?
+        script = extract_script(visual_transcript_path)
+        prompt = File.read(@prompt_path) + "\n\n## Visual transcript\n\n" + script
+        markdown = @haiku.call(prompt)
+        return cancel_result if job.canceled?
+        atomic_write(summary_output_path, markdown)
+        { summary_path: summary_output_path }
+      end
+
+      def self.default_prompt_path
+        File.expand_path("../../../prompts/summarize_video.md", __dir__)
+      end
+
+      private
+
+      def default_prompt_path
+        self.class.default_prompt_path
+      end
+
+      def extract_script(visual_path)
+        data = JSON.parse(File.read(visual_path))
+        lines = []
+        (data["segments"] || []).each do |s|
+          ts = format_ts(s["start"].to_f)
+          lines << "[VISUAL] #{s['visual']}" if s["visual"]
+          lines << "[#{ts}] #{s['text']}" if s["text"] && !s["text"].empty?
+        end
+        lines.join("\n")
+      end
+
+      def format_ts(seconds)
+        format("[%02d:%02d]", seconds.to_i / 60, seconds.to_i % 60)
+      end
+
+      def atomic_write(path, body)
+        tmp = path + ".tmp"
+        File.write(tmp, body)
+        File.rename(tmp, path)
+      end
+
+      def cancel_result
+        { canceled: true }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: 1 example, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/stages/summarize.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/summarize_spec.rb
+git commit -m "M2: summarize stage — Haiku call writes summary markdown atomically"
+```
+
+---
+
+### Task 4.6: Analysis controller — pools, dispatch, yaml updates, notifications
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_controller_spec.rb`
+
+This is the orchestrator. Inputs: a `library_dir`, a `notifier`, an `AnthropicClient`, a `JobRegistry`. Outputs: starts a job, returns the `job_id`, drives the worker pools, emits notifications, updates `library.yaml` after each artifact. This is the biggest single piece — the test exercises the happy path with stub stages.
+
+- [ ] **Step 1: Failing test**
+
+```ruby
+# ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_controller_spec.rb
+require "spec_helper"
+require "tmpdir"
+require "json"
+require "stringio"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/notifier"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
+require_relative "../../../lib/buttercut_ui_sidecar/analysis_controller"
+
+RSpec.describe ButtercutUiSidecar::AnalysisController do
+  def make_library(root, name: "demo", videos:)
+    lib_dir = File.join(root, name)
+    FileUtils.mkdir_p(File.join(lib_dir, "transcripts"))
+    FileUtils.mkdir_p(File.join(lib_dir, "summaries"))
+    File.write(File.join(lib_dir, "library.yaml"), YAML.dump(
+      "library_name" => name, "language" => "English", "language_code" => "en",
+      "transcript_refinement" => false, "videos" => videos.map { |v| { "path" => v, "duration" => "00:00:05" } }
+    ))
+    lib_dir
+  end
+
+  it "runs all three stages for one video and updates library.yaml" do
+    Dir.mktmpdir do |root|
+      v = File.join(root, "a.mp4")
+      File.write(v, "x")
+      lib_dir = make_library(root, videos: [v])
+
+      io = StringIO.new
+      notifier = ButtercutUiSidecar::Notifier.new(io: io)
+      registry = ButtercutUiSidecar::JobRegistry.new
+
+      transcribe = double("transcribe")
+      analyze = double("analyze")
+      summarize = double("summarize")
+      allow(transcribe).to receive(:run) do |args|
+        path = File.join(args[:transcript_output_dir], "a.json")
+        File.write(path, JSON.generate(segments: []))
+        { transcript_path: path }
+      end
+      allow(analyze).to receive(:run) do |args|
+        File.write(args[:visual_transcript_path], JSON.generate(segments: []))
+        { visual_transcript_path: args[:visual_transcript_path] }
+      end
+      allow(summarize).to receive(:run) do |args|
+        File.write(args[:summary_output_path], "## Overview")
+        { summary_path: args[:summary_output_path] }
+      end
+
+      controller = described_class.new(
+        libraries_root: root, notifier: notifier, registry: registry,
+        transcribe: transcribe, analyze: analyze, summarize: summarize,
+        whisper_model: "small"
+      )
+      job_id = controller.start!(library: "demo")
+
+      controller.wait!(job_id)
+
+      data = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")))
+      v0 = data["videos"].first
+      expect(v0["transcript"]).to eq("a.json")
+      expect(v0["visual_transcript"]).to eq("visual_a.json")
+      expect(v0["summary"]).to eq("summary_a.md")
+
+      events = io.string.lines.map { |l| JSON.parse(l) }
+      methods = events.map { |e| e["method"] }
+      expect(methods).to include("job_started", "file_started", "artifact_ready", "file_done", "job_done")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify fail.** Expected: LoadError.
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
+# frozen_string_literal: true
+
+require "concurrent"
+require "fileutils"
+require "json"
+require "pathname"
+require "securerandom"
+require "yaml"
+require_relative "limits"
+require_relative "analysis_job"
+
+module ButtercutUiSidecar
+  class AnalysisController
+    def initialize(libraries_root:, notifier:, registry:,
+                   transcribe:, analyze:, summarize:,
+                   whisper_model: "small")
+      @libraries_root = Pathname.new(libraries_root)
+      @notifier = notifier
+      @registry = registry
+      @stages = { transcribe: transcribe, analyze: analyze, summarize: summarize }
+      @whisper_model = whisper_model
+    end
+
+    # Kicks off a job and returns its id immediately. Use #wait! in tests.
+    def start!(library:)
+      job_id = "job-#{SecureRandom.hex(6)}"
+      job = AnalysisJob.new(id: job_id, library: library)
+      @registry.put(job_id, job)
+
+      lib_dir = @libraries_root.join(library)
+      data = read_yaml(lib_dir)
+      videos = (data["videos"] || []).reject { |v| v["transcript"] && !v["transcript"].empty? && v["visual_transcript"] && !v["visual_transcript"].empty? && v["summary"] && !v["summary"].empty? }
+      total = videos.length
+      @notifier.notify("job_started", job_id: job_id, library: library, video_count: total)
+
+      pools = build_pools
+
+      done = Concurrent::AtomicFixnum.new(0)
+      failed = Concurrent::AtomicFixnum.new(0)
+
+      @completion_latch = Concurrent::CountDownLatch.new(1) unless total.positive?
+      @completion_latch ||= Concurrent::CountDownLatch.new(1)
+
+      remaining_units = Concurrent::AtomicFixnum.new(total * 3)
+
+      complete_unit = lambda do |succeeded|
+        succeeded ? done.increment : failed.increment
+        if remaining_units.decrement.zero?
+          @notifier.notify("job_done", job_id: job_id,
+                           succeeded_count: done.value, failed_count: failed.value)
+          shutdown_pools(pools)
+          @registry.delete(job_id)
+          @completion_latch.count_down
+        end
+      end
+
+      videos.each do |v|
+        chain_stages(job: job, video: v, lib_dir: lib_dir, pools: pools, on_complete: complete_unit, data: data)
+      end
+
+      @completion_latch.count_down if total.zero?
+
+      job_id
+    end
+
+    # Test helper.
+    def wait!(_job_id, timeout: 30)
+      @completion_latch.wait(timeout)
+    end
+
+    private
+
+    def build_pools
+      {
+        transcribe: Concurrent::FixedThreadPool.new(Limits::TRANSCRIBE_PARALLELISM),
+        analyze:    Concurrent::FixedThreadPool.new(Limits::ANALYZE_PARALLELISM),
+        summarize:  Concurrent::FixedThreadPool.new(Limits::SUMMARIZE_PARALLELISM)
+      }
+    end
+
+    def shutdown_pools(pools)
+      pools.values.each(&:shutdown)
+    end
+
+    def chain_stages(job:, video:, lib_dir:, pools:, on_complete:, data:)
+      basename = File.basename(video["path"])
+      stem = File.basename(basename, ".*")
+      transcripts_dir = lib_dir.join("transcripts").to_s
+      summaries_dir = lib_dir.join("summaries").to_s
+      audio_path   = File.join(transcripts_dir, "#{stem}.json")
+      visual_path  = File.join(transcripts_dir, "visual_#{stem}.json")
+      summary_path = File.join(summaries_dir,   "summary_#{stem}.md")
+
+      transcribe_step = lambda do
+        return if video["transcript"] && !video["transcript"].empty?
+        @stages[:transcribe].run(
+          job: job, video_path: video["path"], transcript_output_dir: transcripts_dir,
+          language_code: data["language_code"] || "en", whisper_model: @whisper_model
+        )
+        update_yaml_field(lib_dir, video["path"], "transcript", File.basename(audio_path))
+      end
+
+      analyze_step = lambda do
+        return if video["visual_transcript"] && !video["visual_transcript"].empty?
+        @stages[:analyze].run(
+          job: job, video_path: video["path"],
+          audio_transcript_path: audio_path, visual_transcript_path: visual_path
+        )
+        update_yaml_field(lib_dir, video["path"], "visual_transcript", File.basename(visual_path))
+      end
+
+      summarize_step = lambda do
+        return if video["summary"] && !video["summary"].empty?
+        @stages[:summarize].run(
+          job: job, visual_transcript_path: visual_path, summary_output_path: summary_path
+        )
+        update_yaml_field(lib_dir, video["path"], "summary", File.basename(summary_path))
+      end
+
+      # Sequential per video, parallel across videos. Each stage's `run_step`
+      # emits file_started / artifact_ready / file_done (or file_failed) and
+      # calls on_complete exactly once. On success, enqueues the next stage.
+      pools[:transcribe].post do
+        run_step(job: job, stage: :transcribe, video: basename,
+                 artifact_path: audio_path, on_complete: on_complete,
+                 on_success: -> { pools[:analyze].post { analyze_in_pool.call } }) { transcribe_step.call }
+      end
+
+      analyze_in_pool = lambda do
+        run_step(job: job, stage: :analyze, video: basename,
+                 artifact_path: visual_path, on_complete: on_complete,
+                 on_success: -> { pools[:summarize].post { summarize_in_pool.call } }) { analyze_step.call }
+      end
+
+      summarize_in_pool = lambda do
+        run_step(job: job, stage: :summarize, video: basename,
+                 artifact_path: summary_path, on_complete: on_complete,
+                 on_success: -> { }) { summarize_step.call }
+      end
+    end
+
+    # Per-stage worker body. Emits notifications and calls on_complete exactly
+    # once. On success, runs on_success (which typically enqueues the next stage).
+    def run_step(job:, stage:, video:, artifact_path:, on_complete:, on_success:)
+      if job.canceled?
+        on_complete.call(false)
+        return
+      end
+      @notifier.notify("file_started", job_id: job.id, video: video, stage: stage.to_s)
+      begin
+        yield
+        @notifier.notify("artifact_ready", job_id: job.id, video: video, stage: stage.to_s, artifact_path: artifact_path)
+        @notifier.notify("file_done", job_id: job.id, video: video, stage: stage.to_s)
+        on_complete.call(true)
+        on_success.call
+      rescue StandardError => e
+        @notifier.notify("file_failed", job_id: job.id, video: video, stage: stage.to_s,
+                         error_kind: classify_error(e), message: e.message)
+        on_complete.call(false)
+      end
+    end
+
+    def classify_error(error)
+      case error.message
+      when /invalid_api_key/i, /AuthenticationError/i then "auth"
+      when /whisperx failed/i then "transcribe"
+      when /ffmpeg/i then "ffmpeg"
+      else "unknown"
+      end
+    end
+
+    def read_yaml(lib_dir)
+      YAML.safe_load(File.read(lib_dir.join("library.yaml")), permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def update_yaml_field(lib_dir, video_path, field, value)
+      job_id = nil # reserved for log if needed
+      yaml_path = lib_dir.join("library.yaml")
+      lock_file = yaml_path.to_s + ".lock"
+      File.open(lock_file, File::RDWR | File::CREAT, 0o600) do |f|
+        f.flock(File::LOCK_EX)
+        data = YAML.safe_load(File.read(yaml_path), permitted_classes: [Date, Time], aliases: true) || {}
+        (data["videos"] || []).each do |v|
+          v[field] = value if v["path"] == video_path
+        end
+        data["last_updated"] = Date.today.iso8601
+        File.write(yaml_path.to_s + ".tmp", YAML.dump(data))
+        File.rename(yaml_path.to_s + ".tmp", yaml_path.to_s)
+      end
+    end
+  end
+end
+```
+
+**Note on `analyze_in_pool` / `summarize_in_pool`:** these are forward-referenced lambdas — Ruby allows this because the lambda variables aren't dereferenced until the outer `pools[:transcribe].post` block actually runs, by which time both inner lambdas are bound. If your linter complains about use-before-define, rearrange so all three lambdas are declared before the first `pools[:transcribe].post` call.
+
+- [ ] **Step 4: Run, verify pass.** Expected: 1 example, 0 failures.
+
+- [ ] **Step 5: Stress test cancellation manually**
+
+Add a second test that calls `controller.start!`, sleeps briefly, then `job.cancel!` and verifies a `job_done` event still arrives with `failed_count > 0`. Skip if implementation time is short — covered by the integration smoke phase.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_controller_spec.rb
+git commit -m "M2: AnalysisController orchestrates the three-stage pipeline with notifications"
+```
+
+---
+
+### Task 4.7: Wire `start_analysis`, `cancel_job`, `retry_unit` into the dispatcher
+
+**Files:**
+- Modify: `ui/sidecar/buttercut_ui_sidecar.rb`
+
+- [ ] **Step 1: Update dispatcher**
+
+In `initialize`, after the existing wiring, add:
+
+```ruby
+@registry = ButtercutUiSidecar::JobRegistry.new
+@anthropic = nil # lazy: only built when start_analysis fires and a key is configured
+```
+
+Add helper:
+
+```ruby
+def build_controller_or_raise!
+  api_key = @settings.api_key
+  raise StandardError, "missing_api_key" if api_key.nil?
+
+  client = ButtercutUiSidecar::AnthropicClient.new(api_key: api_key)
+
+  vision = ->(frames, prompt) {
+    content = frames.map { |f| { type: "image", source: { type: "base64", media_type: "image/jpeg", data: Base64.strict_encode64(File.binread(f)) } } }
+    content << { type: "text", text: prompt + "\n\nReturn ONLY a JSON object of the form {\"segments\": [...]}, no prose." }
+    response = client.messages_create(
+      model: ButtercutUiSidecar::AnthropicClient::VISION_MODEL,
+      max_tokens: 4096,
+      messages: [{ role: "user", content: content }]
+    )
+    text = (response["content"] || []).map { |c| c["text"] }.compact.join
+    JSON.parse(text[/\{.*\}/m])
+  }
+
+  haiku = ->(prompt) {
+    response = client.messages_create(
+      model: ButtercutUiSidecar::AnthropicClient::HAIKU_MODEL,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: prompt }]
+    )
+    (response["content"] || []).map { |c| c["text"] }.compact.join
+  }
+
+  ButtercutUiSidecar::AnalysisController.new(
+    libraries_root: @libraries_root.to_s,
+    notifier: @notifier,
+    registry: @registry,
+    transcribe: ButtercutUiSidecar::Stages::Transcribe.new,
+    analyze: ButtercutUiSidecar::Stages::Analyze.new(vision: vision),
+    summarize: ButtercutUiSidecar::Stages::Summarize.new(haiku: haiku),
+    whisper_model: read_whisper_model
+  )
+end
+
+def read_whisper_model
+  path = @libraries_root.join("settings.yaml")
+  return "small" unless path.file?
+  data = YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true) || {}
+  data["whisper_model"] || "small"
+end
+```
+
+In `dispatch`, add cases:
+
+```ruby
+when "start_analysis"
+  controller = build_controller_or_raise!
+  job_id = controller.start!(library: params.fetch("library"))
+  { job_id: job_id }
+when "cancel_job"
+  job = @registry.get(params.fetch("job_id"))
+  job&.cancel!
+  {}
+when "retry_unit"
+  raise StandardError, "retry_unit is not yet supported in M2 minimum scope; re-run start_analysis to resume."
+```
+
+In `handle_line`, add:
+
+```ruby
+rescue StandardError => e
+  case e.message
+  when /\Amissing_api_key/
+    respond_error(id: id, code: -32010, message: "missing_api_key")
+  when /\Ainvalid_api_key/
+    respond_error(id: id, code: -32012, message: e.message)
+  else
+    respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
+  end
+```
+
+(Adjust the existing `StandardError` rescue rather than adding a duplicate.)
+
+Also `require_relative` the new files at the top:
+
+```ruby
+require_relative "lib/buttercut_ui_sidecar/job_registry"
+require_relative "lib/buttercut_ui_sidecar/analysis_job"
+require_relative "lib/buttercut_ui_sidecar/analysis_controller"
+require_relative "lib/buttercut_ui_sidecar/stages/transcribe"
+require_relative "lib/buttercut_ui_sidecar/stages/analyze"
+require_relative "lib/buttercut_ui_sidecar/stages/summarize"
+require "base64"
+```
+
+- [ ] **Step 2: Run M0/M1 specs to make sure nothing regresses**
+
+Run: `bundle exec rake spec`
+Expected: all green.
+
+- [ ] **Step 3: Smoke-test the missing-key path**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"start_analysis","params":{"library":"demo"}}' | bundle exec ruby buttercut_ui_sidecar.rb /tmp
+```
+Expected: response with `error.code: -32010` and message `missing_api_key`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/sidecar/buttercut_ui_sidecar.rb
+git commit -m "M2: dispatch start_analysis, cancel_job, retry_unit (deferred)"
+```
+
+---
+
+### Task 4.8: Add Phase-4 dependencies to settings template
+
+**Files:**
+- Modify: `templates/settings_template.yaml`
+
+- [ ] **Step 1: Read the existing template**
+
+Run: `cat templates/settings_template.yaml`
+
+- [ ] **Step 2: Add the API key field placeholder**
+
+Append:
+```yaml
+# Anthropic API key for the desktop UI's analysis pipeline. The CLI flow
+# uses Claude Code's own auth and ignores this field. Optional — the env
+# var ANTHROPIC_API_KEY takes precedence when set.
+anthropic_api_key: ""
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/settings_template.yaml
+git commit -m "M2: document anthropic_api_key in settings template"
+```
+
+---
+
+## Phase 5 — Rust IPC layer
+
+### Task 5.1: Notification deserialization in the reader
+
+**Files:**
+- Modify: `ui/src-tauri/src/sidecar.rs`
+
+- [ ] **Step 1: Read the current state**
+
+Run: `cat ui/src-tauri/src/sidecar.rs | head -160`
+
+- [ ] **Step 2: Modify `init` to accept an `AppHandle`**
+
+Change the signature from:
+```rust
+pub fn init(ruby_bin: PathBuf, sidecar_script: PathBuf, libraries_root: PathBuf) -> std::io::Result<()>
+```
+to:
+```rust
+pub fn init(app: tauri::AppHandle, ruby_bin: PathBuf, sidecar_script: PathBuf, libraries_root: PathBuf) -> std::io::Result<()>
+```
+and pass `app` into the reader task closure (clone it before spawning).
+
+- [ ] **Step 3: Add a `Notification` deserializer**
+
+Below the existing `Response` struct, add:
+```rust
+#[derive(Deserialize)]
+struct Notification {
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+```
+
+- [ ] **Step 4: In the reader task, branch on `id`**
+
+Replace the inner `match serde_json::from_str::<Response>(&line)` block with:
+
+```rust
+match serde_json::from_str::<Response>(&line) {
+    Ok(resp) if resp.id.is_some() => {
+        let id = resp.id.unwrap();
+        let mut map = pending_for_reader.lock().await;
+        if let Some(tx) = map.remove(&id) {
+            let payload = if let Some(err) = resp.error {
+                Err(SidecarError::Rpc { code: err.code, message: err.message })
+            } else {
+                Ok(resp.result.unwrap_or(Value::Null))
+            };
+            let _ = tx.send(payload);
+        }
+    }
+    _ => {
+        match serde_json::from_str::<Notification>(&line) {
+            Ok(n) => {
+                let job_id = n.params.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
+                let event_name = if job_id.is_empty() {
+                    "sidecar-event".to_string()
+                } else {
+                    format!("sidecar-event:{}", job_id)
+                };
+                let payload = serde_json::json!({ "method": n.method, "params": n.params });
+                if let Err(e) = app_for_reader.emit(&event_name, payload) {
+                    eprintln!("[sidecar] emit error: {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!("[sidecar] parse error: {e}: {line}");
+            }
+        }
+    }
+}
+```
+
+(Clone `app` into `app_for_reader` before the `tokio::spawn` call. The trait import at the top of the file: `use tauri::Manager;` is already present in `lib.rs`; here we need `use tauri::Emitter;` — add it.)
+
+- [ ] **Step 5: Update `lib.rs` `setup` to pass the AppHandle**
+
+In `ui/src-tauri/src/lib.rs`, replace:
+```rust
+sidecar::init(ruby_bin, sidecar_script, libraries_root)
+```
+with:
+```rust
+sidecar::init(app.handle().clone(), ruby_bin, sidecar_script, libraries_root)
+```
+
+- [ ] **Step 6: Build**
+
+Run: `cd ui/src-tauri && cargo check`
+Expected: compiles clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src-tauri/src/sidecar.rs ui/src-tauri/src/lib.rs
+git commit -m "M2: forward sidecar JSON-RPC notifications as scoped Tauri events"
+```
+
+---
+
+### Task 5.2: New Tauri commands
+
+**Files:**
+- Modify: `ui/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Add command wrappers** at the top, alongside existing ones:
+
+```rust
+#[tauri::command]
+async fn inspect_video_paths(paths: Vec<String>) -> Result<Value, String> {
+    sidecar::call("inspect_video_paths", json!({ "paths": paths })).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn create_library(
+    name: String, language: String, language_code: String,
+    refinement: bool, videos: Value
+) -> Result<Value, String> {
+    sidecar::call("create_library", json!({
+        "name": name, "language": language, "language_code": language_code,
+        "refinement": refinement, "videos": videos
+    })).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn has_api_key() -> Result<Value, String> {
+    sidecar::call("has_api_key", json!({})).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn set_api_key(key: String) -> Result<Value, String> {
+    sidecar::call("set_api_key", json!({ "key": key })).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn start_analysis(library: String) -> Result<Value, String> {
+    sidecar::call("start_analysis", json!({ "library": library })).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn cancel_job(job_id: String) -> Result<Value, String> {
+    sidecar::call("cancel_job", json!({ "job_id": job_id })).await.map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 2: Add `open_new_project_window`** alongside `open_library_window`:
+
+```rust
+#[tauri::command]
+async fn open_new_project_window(app: tauri::AppHandle) -> Result<(), String> {
+    let label = "new-project";
+    if let Some(existing) = app.get_webview_window(label) {
+        existing.set_focus().map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(&app, label, WebviewUrl::App("index.html#/new-project".into()))
+        .title("New Project")
+        .inner_size(880.0, 720.0)
+        .min_inner_size(640.0, 540.0)
+        .build()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Register the new commands** in `tauri::generate_handler![...]`:
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    list_libraries,
+    get_library,
+    get_clip_transcripts,
+    get_or_generate_thumbnail,
+    allow_video_paths,
+    open_library_window,
+    open_new_project_window,
+    inspect_video_paths,
+    create_library,
+    has_api_key,
+    set_api_key,
+    start_analysis,
+    cancel_job
+])
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd ui/src-tauri && cargo check`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src-tauri/src/lib.rs
+git commit -m "M2: add Tauri commands for new RPCs and the New Project window"
+```
+
+---
+
+### Task 5.3: Capability for events
+
+**Files:**
+- Inspect: `ui/src-tauri/capabilities/default.json`
+
+- [ ] **Step 1: Read the capability file**
+
+Run: `cat ui/src-tauri/capabilities/default.json`
+
+- [ ] **Step 2: Ensure `core:event:default` is permitted**
+
+If it's not in the permissions list, add it:
+```json
+"core:event:default"
+```
+(Tauri 2's default permission set usually already grants `event:listen`. If `pnpm tauri dev` later complains about a missing permission for `listen`, return here.)
+
+- [ ] **Step 3: Build smoke**
+
+Run: `cd ui && pnpm build`
+Expected: clean.
+
+- [ ] **Step 4: Commit (skip if no change)**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "M2: ensure event listen permission is granted"
+```
+
+---
+
+## Phase 6 — Frontend wiring
+
+### Task 6.1: Typed RPC wrappers
+
+**Files:**
+- Modify: `ui/src/ipc/sidecar.ts`
+
+- [ ] **Step 1: Append the new wrappers**
+
+Add after the existing exports:
+
+```ts
+export interface AcceptedVideo { path: string; duration_seconds: number; size_bytes: number; }
+export interface RejectedVideo { path: string; reason: "not_found" | "not_video" | "unreadable" | "zero_duration"; }
+export interface InspectResult { accepted: AcceptedVideo[]; rejected: RejectedVideo[]; }
+
+export async function inspectVideoPaths(paths: string[]): Promise<InspectResult> {
+  return invoke<InspectResult>("inspect_video_paths", { paths });
+}
+
+export async function hasApiKey(): Promise<{ configured: boolean }> {
+  return invoke<{ configured: boolean }>("has_api_key");
+}
+
+export async function setApiKey(key: string): Promise<{ ok: true }> {
+  return invoke<{ ok: true }>("set_api_key", { key });
+}
+
+export interface CreateLibraryArgs {
+  name: string;
+  language: string;
+  language_code: string;
+  refinement: boolean;
+  videos: AcceptedVideo[];
+}
+
+export async function createLibrary(args: CreateLibraryArgs): Promise<{ name: string }> {
+  return invoke<{ name: string }>("create_library", args);
+}
+
+export async function startAnalysis(library: string): Promise<{ job_id: string }> {
+  return invoke<{ job_id: string }>("start_analysis", { library });
+}
+
+export async function cancelJob(jobId: string): Promise<void> {
+  await invoke("cancel_job", { job_id: jobId });
+}
+
+export async function openNewProjectWindow(): Promise<void> {
+  await invoke("open_new_project_window");
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd ui && pnpm build`
+Expected: clean (TypeScript happy).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/ipc/sidecar.ts
+git commit -m "M2: typed wrappers for the new sidecar RPCs"
+```
+
+---
+
+### Task 6.2: Typed event listener
+
+**Files:**
+- Create: `ui/src/ipc/events.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+// ui/src/ipc/events.ts
+import { listen, UnlistenFn } from "@tauri-apps/api/event";
+
+export type StageName = "transcribe" | "analyze" | "summarize";
+
+export type JobEvent =
+  | { method: "job_started"; params: { job_id: string; library: string; video_count: number; ts: string } }
+  | { method: "file_started"; params: { job_id: string; video: string; stage: StageName; ts: string } }
+  | { method: "file_progress"; params: { job_id: string; video: string; stage: StageName; message?: string; percent?: number; ts: string } }
+  | { method: "artifact_ready"; params: { job_id: string; video: string; stage: StageName; artifact_path: string; ts: string } }
+  | { method: "file_failed"; params: { job_id: string; video: string; stage: StageName; error_kind: string; message: string; ts: string } }
+  | { method: "file_done"; params: { job_id: string; video: string; stage: StageName; ts: string } }
+  | { method: "job_done"; params: { job_id: string; succeeded_count: number; failed_count: number; ts: string } }
+  | { method: "job_canceled"; params: { job_id: string; succeeded_count: number; failed_count: number; ts: string } };
+
+export async function listenJobEvents(
+  jobId: string,
+  handler: (event: JobEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<JobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/src/ipc/events.ts
+git commit -m "M2: typed JobEvent listener bound to sidecar-event:JOB"
+```
+
+---
+
+### Task 6.3: Routing — register `/new-project`
+
+**Files:**
+- Modify: `ui/src/main.tsx`
+
+- [ ] **Step 1: Edit**
+
+```tsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./styles/theme.css";
+import Projects from "./routes/projects";
+import Library from "./routes/library";
+import NewProject from "./routes/new-project";
+
+function pickRoute() {
+  const hash = window.location.hash || "";
+  const lib = hash.match(/^#\/library\/(.+)$/);
+  if (lib) {
+    try { return <Library name={decodeURIComponent(lib[1])} />; } catch { return <Projects />; }
+  }
+  if (hash === "#/new-project") {
+    return <NewProject />;
+  }
+  return <Projects />;
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>{pickRoute()}</React.StrictMode>,
+);
+```
+
+- [ ] **Step 2: Skip build until the component exists** — moves to next task.
+
+---
+
+### Task 6.4: New Project state machine
+
+**Files:**
+- Create: `ui/src/routes/new-project/state.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+// ui/src/routes/new-project/state.ts
+import { AcceptedVideo, RejectedVideo } from "../../ipc/sidecar";
+
+export type StepId = "footage" | "name" | "language" | "refinement" | "confirm";
+
+export interface SetupState {
+  step: StepId;
+  accepted: AcceptedVideo[];
+  rejected: RejectedVideo[];
+  name: string;
+  language: { name: string; code: string };
+  refinement: boolean;
+  collisionWith: string | null;
+}
+
+export const initialSetup: SetupState = {
+  step: "footage",
+  accepted: [],
+  rejected: [],
+  name: "",
+  language: { name: "English", code: "en" },
+  refinement: true,
+  collisionWith: null,
+};
+
+export type SetupAction =
+  | { type: "add_files"; accepted: AcceptedVideo[]; rejected: RejectedVideo[] }
+  | { type: "remove_file"; path: string }
+  | { type: "set_name"; value: string }
+  | { type: "set_collision"; value: string | null }
+  | { type: "set_language"; name: string; code: string }
+  | { type: "set_refinement"; value: boolean }
+  | { type: "go_step"; step: StepId };
+
+export function setupReducer(state: SetupState, action: SetupAction): SetupState {
+  switch (action.type) {
+    case "add_files": {
+      const existing = new Set(state.accepted.map((v) => v.path));
+      const merged = [...state.accepted, ...action.accepted.filter((v) => !existing.has(v.path))];
+      return { ...state, accepted: merged, rejected: [...state.rejected, ...action.rejected] };
+    }
+    case "remove_file":
+      return { ...state, accepted: state.accepted.filter((v) => v.path !== action.path) };
+    case "set_name":
+      return { ...state, name: action.value };
+    case "set_collision":
+      return { ...state, collisionWith: action.value };
+    case "set_language":
+      return { ...state, language: { name: action.name, code: action.code } };
+    case "set_refinement":
+      return { ...state, refinement: action.value };
+    case "go_step":
+      return { ...state, step: action.step };
+  }
+}
+
+export function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/src/routes/new-project/state.ts
+git commit -m "M2: setup-phase reducer + slugify helper"
+```
+
+---
+
+### Task 6.5: Step components (5 files)
+
+**Files:**
+- Create: `ui/src/routes/new-project/steps/pick-footage.tsx`
+- Create: `ui/src/routes/new-project/steps/name.tsx`
+- Create: `ui/src/routes/new-project/steps/language.tsx`
+- Create: `ui/src/routes/new-project/steps/refinement.tsx`
+- Create: `ui/src/routes/new-project/steps/confirm.tsx`
+
+- [ ] **Step 1: Implement `pick-footage.tsx`**
+
+```tsx
+import { useEffect } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { inspectVideoPaths, AcceptedVideo, RejectedVideo } from "../../../ipc/sidecar";
+import { SetupState, SetupAction } from "../state";
+
+export function PickFootage({ state, dispatch, onNext }: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onNext: () => void;
+}) {
+  useEffect(() => {
+    const unlistenP = getCurrentWebview().onDragDropEvent(async (event) => {
+      if (event.payload.type === "drop") {
+        const result = await inspectVideoPaths(event.payload.paths);
+        dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+      }
+    });
+    return () => { unlistenP.then((fn) => fn()); };
+  }, [dispatch]);
+
+  async function chooseFolder() {
+    const picked = await open({ directory: true });
+    if (!picked) return;
+    // For folders, we'd need a sidecar enumerate step. Simpler: read directory contents
+    // by calling inspect on the picked path; the sidecar treats a directory as not_video,
+    // so for v1 we use the multi-file picker for folder contents and document folder support
+    // as drop-only. Replace with a sidecar enumerate RPC in a follow-up.
+    const result = await inspectVideoPaths([picked as string]);
+    dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+  }
+
+  async function chooseFiles() {
+    const picked = await open({ multiple: true });
+    if (!picked) return;
+    const paths = Array.isArray(picked) ? (picked as string[]) : [picked as string];
+    const result = await inspectVideoPaths(paths);
+    dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+  }
+
+  return (
+    <section className="np-step">
+      <h2>Pick footage</h2>
+      <div className="np-dropzone">
+        <p>Drop a folder or video files here.</p>
+        <div className="np-dropzone__buttons">
+          <button onClick={chooseFolder}>Choose folder…</button>
+          <button onClick={chooseFiles}>Choose files…</button>
+        </div>
+      </div>
+
+      {state.accepted.length > 0 && (
+        <ul className="np-filelist">
+          {state.accepted.map((v) => (
+            <li key={v.path}>
+              <span className="np-filelist__name">{v.path.split("/").pop()}</span>
+              <span className="np-filelist__dur">{formatDuration(v.duration_seconds)}</span>
+              <button className="np-filelist__remove" onClick={() => dispatch({ type: "remove_file", path: v.path })}>×</button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {state.rejected.length > 0 && (
+        <details className="np-rejected">
+          <summary>{state.rejected.length} skipped</summary>
+          <ul>
+            {state.rejected.map((r) => (
+              <li key={r.path}>{r.path.split("/").pop()} — {r.reason}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      <footer className="np-footer">
+        <button disabled={state.accepted.length === 0} onClick={onNext}>Continue</button>
+      </footer>
+    </section>
+  );
+}
+
+function formatDuration(s: number) {
+  const m = Math.floor(s / 60); const r = Math.floor(s % 60);
+  return `${m}:${String(r).padStart(2, "0")}`;
+}
+```
+
+(*Folder picker note*: when the user picks a directory, the current implementation calls `inspect_video_paths` with the directory itself, which the sidecar will reject as `not_video`. The drag/drop path delivers individual files even when a folder is dropped (Tauri flattens). For v1 we lean on drag/drop for folders and document the folder button as "for v1, use drag/drop or the file picker." A follow-up adds an `enumerate_directory` sidecar RPC.)
+
+- [ ] **Step 2: Implement `name.tsx`**
+
+```tsx
+import { useEffect, useRef } from "react";
+import { listLibraries } from "../../../ipc/sidecar";
+import { SetupState, SetupAction, slugify } from "../state";
+
+export function Name({ state, dispatch, onBack, onNext }: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => { ref.current?.focus(); }, []);
+
+  useEffect(() => {
+    const slug = slugify(state.name);
+    if (!slug) { dispatch({ type: "set_collision", value: null }); return; }
+    let cancelled = false;
+    listLibraries().then((libs) => {
+      if (cancelled) return;
+      const hit = libs.find((l) => l.name === slug);
+      dispatch({ type: "set_collision", value: hit ? slug : null });
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [state.name, dispatch]);
+
+  const slug = slugify(state.name);
+  const blocked = !slug || state.collisionWith === slug;
+
+  return (
+    <section className="np-step">
+      <h2>Name</h2>
+      <input ref={ref} value={state.name} onChange={(e) => dispatch({ type: "set_name", value: e.target.value })} placeholder="My Bike Series" />
+      {slug && <p className="np-slug">→ <code>{slug}</code></p>}
+      {state.collisionWith && state.collisionWith === slug && (
+        <p className="np-error">A library named <code>{slug}</code> already exists. Choose a different name.</p>
+      )}
+      <footer className="np-footer">
+        <button onClick={onBack}>Back</button>
+        <button disabled={blocked} onClick={onNext}>Continue</button>
+      </footer>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `language.tsx`**
+
+```tsx
+import { useState } from "react";
+import { SetupState, SetupAction } from "../state";
+
+const PRESETS = [
+  { name: "English", code: "en" },
+  { name: "Spanish", code: "es" },
+];
+
+export function Language({ state, dispatch, onBack, onNext }: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const [other, setOther] = useState(state.language.code);
+  const isPreset = PRESETS.some((p) => p.code === state.language.code);
+
+  return (
+    <section className="np-step">
+      <h2>Language</h2>
+      <div className="np-cards">
+        {PRESETS.map((p) => (
+          <button
+            key={p.code}
+            className={"np-card" + (state.language.code === p.code ? " np-card--active" : "")}
+            onClick={() => dispatch({ type: "set_language", name: p.name, code: p.code })}
+          >
+            {p.name}
+          </button>
+        ))}
+        <button
+          className={"np-card" + (!isPreset ? " np-card--active" : "")}
+          onClick={() => dispatch({ type: "set_language", name: "Other", code: other })}
+        >
+          Other…
+        </button>
+      </div>
+      {!isPreset && (
+        <label className="np-other">
+          ISO 639-1 code
+          <input value={other} onChange={(e) => { setOther(e.target.value); dispatch({ type: "set_language", name: "Other", code: e.target.value }); }} />
+        </label>
+      )}
+      <footer className="np-footer">
+        <button onClick={onBack}>Back</button>
+        <button disabled={!state.language.code} onClick={onNext}>Continue</button>
+      </footer>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `refinement.tsx`**
+
+```tsx
+import { SetupState, SetupAction } from "../state";
+
+export function Refinement({ state, dispatch, onBack, onNext }: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <section className="np-step">
+      <h2>Can I proofread the transcripts after they're generated?</h2>
+      <p>I'll use the video's context to fix mistakes.</p>
+      <div className="np-cards">
+        <button className={"np-card" + (state.refinement ? " np-card--active" : "")}
+                onClick={() => dispatch({ type: "set_refinement", value: true })}>
+          <strong>Yes — Recommended</strong>
+          <span>Use Claude to refine video understanding.</span>
+        </button>
+        <button className={"np-card" + (!state.refinement ? " np-card--active" : "")}
+                onClick={() => dispatch({ type: "set_refinement", value: false })}>
+          <strong>No</strong>
+        </button>
+      </div>
+      <footer className="np-footer">
+        <button onClick={onBack}>Back</button>
+        <button onClick={onNext}>Continue</button>
+      </footer>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5: Implement `confirm.tsx`**
+
+```tsx
+import { SetupState, slugify } from "../state";
+
+export function Confirm({ state, apiKeyConfigured, onBack, onStart, onSetupKey }: {
+  state: SetupState;
+  apiKeyConfigured: boolean;
+  onBack: () => void;
+  onStart: () => void;
+  onSetupKey: () => void;
+}) {
+  const totalDuration = state.accepted.reduce((s, v) => s + v.duration_seconds, 0);
+  const minutes = Math.round(totalDuration / 60);
+
+  return (
+    <section className="np-step">
+      <h2>Confirm</h2>
+      <ul className="np-summary">
+        <li><strong>Project:</strong> <code>{slugify(state.name)}</code></li>
+        <li><strong>Videos:</strong> {state.accepted.length} ({minutes}m total)</li>
+        <li><strong>Language:</strong> {state.language.name} ({state.language.code})</li>
+        <li><strong>Refinement:</strong> {state.refinement ? "Yes" : "No"}</li>
+      </ul>
+
+      {!apiKeyConfigured && (
+        <div className="np-banner">
+          <p>ButterCut needs your Anthropic API key to analyze footage.</p>
+          <button onClick={onSetupKey}>Set up</button>
+        </div>
+      )}
+
+      <footer className="np-footer">
+        <button onClick={onBack}>Back</button>
+        <button onClick={onStart} disabled={!apiKeyConfigured}>Start analysis</button>
+      </footer>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/routes/new-project/steps/
+git commit -m "M2: New Project five-step wizard components"
+```
+
+---
+
+### Task 6.6: API key modal
+
+**Files:**
+- Create: `ui/src/routes/new-project/api-key-modal.tsx`
+
+- [ ] **Step 1: Implement**
+
+```tsx
+import { useState } from "react";
+import { setApiKey } from "../../ipc/sidecar";
+
+export function ApiKeyModal({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+  const [key, setKey] = useState("");
+  const [status, setStatus] = useState<"idle" | "validating" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    setStatus("validating"); setError(null);
+    try {
+      await setApiKey(key);
+      onSaved();
+    } catch (e) {
+      setStatus("error");
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="np-modal-backdrop">
+      <div className="np-modal">
+        <h3>Connect your Anthropic API key</h3>
+        <p>ButterCut uses Claude to analyze footage. <a href="https://console.anthropic.com" target="_blank" rel="noreferrer">Get a key →</a></p>
+        <input type="password" value={key} onChange={(e) => setKey(e.target.value)} placeholder="sk-ant-…" autoFocus />
+        {error && <p className="np-error">{error}</p>}
+        <div className="np-modal-buttons">
+          <button onClick={onClose} disabled={status === "validating"}>Cancel</button>
+          <button onClick={save} disabled={!key || status === "validating"}>
+            {status === "validating" ? "Validating…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/src/routes/new-project/api-key-modal.tsx
+git commit -m "M2: API key modal — validates via set_api_key"
+```
+
+---
+
+### Task 6.7: Job reducer (progress state)
+
+**Files:**
+- Create: `ui/src/routes/new-project/jobReducer.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+import { JobEvent, StageName } from "../../ipc/events";
+
+export type StageState = "idle" | "queued" | "in_progress" | "done" | "failed";
+
+export interface ClipState {
+  video: string;
+  stages: Record<StageName, StageState>;
+  failure?: { stage: StageName; message: string; error_kind: string };
+  artifacts: Partial<Record<StageName, string>>;
+}
+
+export interface JobState {
+  job_id: string | null;
+  videos: Record<string, ClipState>;
+  totals: { done: number; failed: number; total: number };
+  status: "running" | "canceling" | "canceled" | "complete";
+}
+
+export const initialJobState: JobState = {
+  job_id: null,
+  videos: {},
+  totals: { done: 0, failed: 0, total: 0 },
+  status: "running",
+};
+
+export function jobReducer(state: JobState, evt: JobEvent | { method: "_internal_canceling" }): JobState {
+  switch (evt.method) {
+    case "job_started":
+      return { ...state, job_id: evt.params.job_id, totals: { ...state.totals, total: evt.params.video_count } };
+    case "file_started":
+      return updateClip(state, evt.params.video, (c) => ({ ...c, stages: { ...c.stages, [evt.params.stage]: "in_progress" } }));
+    case "file_done":
+      return updateClip(state, evt.params.video, (c) => ({ ...c, stages: { ...c.stages, [evt.params.stage]: "done" } }));
+    case "artifact_ready":
+      return updateClip(state, evt.params.video, (c) => ({ ...c, artifacts: { ...c.artifacts, [evt.params.stage]: evt.params.artifact_path } }));
+    case "file_failed":
+      return updateClip(state, evt.params.video, (c) => ({
+        ...c,
+        stages: { ...c.stages, [evt.params.stage]: "failed" },
+        failure: { stage: evt.params.stage, message: evt.params.message, error_kind: evt.params.error_kind },
+      }));
+    case "job_done":
+      return { ...state, status: "complete", totals: { ...state.totals, done: evt.params.succeeded_count, failed: evt.params.failed_count } };
+    case "job_canceled":
+      return { ...state, status: "canceled", totals: { ...state.totals, done: evt.params.succeeded_count, failed: evt.params.failed_count } };
+    case "_internal_canceling":
+      return { ...state, status: "canceling" };
+    case "file_progress":
+      return state;
+  }
+}
+
+function updateClip(state: JobState, video: string, fn: (c: ClipState) => ClipState): JobState {
+  const existing = state.videos[video] ?? { video, stages: { transcribe: "idle", analyze: "idle", summarize: "idle" }, artifacts: {} };
+  return { ...state, videos: { ...state.videos, [video]: fn(existing) } };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/src/routes/new-project/jobReducer.ts
+git commit -m "M2: jobReducer accumulates per-clip per-stage state from events"
+```
+
+---
+
+### Task 6.8: Progress view + clip row + artifact preview
+
+**Files:**
+- Create: `ui/src/routes/new-project/progress/progress-view.tsx`
+- Create: `ui/src/routes/new-project/progress/clip-row.tsx`
+- Create: `ui/src/routes/new-project/progress/artifact-preview.tsx`
+
+- [ ] **Step 1: Implement `clip-row.tsx`**
+
+```tsx
+import { ClipState } from "../jobReducer";
+import { StageName } from "../../../ipc/events";
+import { ArtifactPreview } from "./artifact-preview";
+
+const GLYPH: Record<string, string> = { idle: "○", queued: "⏳", in_progress: "◐", done: "✓", failed: "✗" };
+
+export function ClipRow({ clip, library, onRetry, expanded, onToggle }: {
+  clip: ClipState;
+  library: string;
+  onRetry: (stage: StageName) => void;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const stages: StageName[] = ["transcribe", "analyze", "summarize"];
+
+  return (
+    <div className={"np-row " + (clip.failure ? "np-row--failed " : "") + (expanded ? "np-row--expanded" : "")}>
+      <button className="np-row__head" onClick={onToggle}>
+        <span className="np-row__name">{clip.video}</span>
+        {stages.map((s) => (
+          <span key={s} className={`np-chip np-chip--${clip.stages[s]}`}>{GLYPH[clip.stages[s]]} {s}</span>
+        ))}
+      </button>
+
+      {expanded && (
+        <div className="np-row__body">
+          {clip.failure ? (
+            <div className="np-failure">
+              <strong>✗ {clip.failure.stage} stage failed</strong>
+              <pre>{clip.failure.message}</pre>
+              <div className="np-failure-buttons">
+                <button onClick={() => onRetry(clip.failure!.stage)}>Retry {clip.failure.stage}</button>
+              </div>
+            </div>
+          ) : (
+            <ArtifactPreview clip={clip} library={library} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `artifact-preview.tsx`**
+
+```tsx
+import { useEffect, useState } from "react";
+import { getClipTranscripts } from "../../../ipc/sidecar";
+import { ClipState } from "../jobReducer";
+
+export function ArtifactPreview({ clip, library }: { clip: ClipState; library: string }) {
+  const [data, setData] = useState<{ audio: string | null; visual: string | null; summary: string | null }>({ audio: null, visual: null, summary: null });
+
+  useEffect(() => {
+    getClipTranscripts(library, clip.video).then((t) => {
+      setData({
+        audio: previewAudio(t.audio),
+        visual: previewVisual(t.visual),
+        summary: t.summary ?? null,
+      });
+    }).catch(() => {});
+  }, [clip.artifacts.transcribe, clip.artifacts.analyze, clip.artifacts.summarize, library, clip.video]);
+
+  return (
+    <div className="np-preview">
+      {data.summary && <section><h4>Summary</h4><pre className="np-md">{data.summary}</pre></section>}
+      {data.visual && <section><h4>Visual transcript</h4><pre>{data.visual}</pre></section>}
+      {data.audio && <section><h4>Transcript</h4><pre>{data.audio}</pre></section>}
+    </div>
+  );
+}
+
+function previewAudio(t: any | null): string | null {
+  if (!t || !t.segments) return null;
+  return t.segments.slice(0, 6).map((s: any) => s.text).join(" ").trim() || null;
+}
+function previewVisual(t: any | null): string | null {
+  if (!t || !t.segments) return null;
+  return t.segments.slice(0, 6).map((s: any) => s.visual || s.text).filter(Boolean).join("\n");
+}
+```
+
+- [ ] **Step 3: Implement `progress-view.tsx`**
+
+```tsx
+import { useEffect, useReducer, useState } from "react";
+import { JobState, jobReducer, initialJobState } from "../jobReducer";
+import { ClipRow } from "./clip-row";
+import { listenJobEvents, JobEvent } from "../../../ipc/events";
+import { cancelJob, openLibraryWindow } from "../../../ipc/sidecar";
+
+export function ProgressView({ jobId, library, onComplete }: {
+  jobId: string;
+  library: string;
+  onComplete: () => void;
+}) {
+  const [state, dispatch] = useReducer(jobReducer, initialJobState);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    listenJobEvents(jobId, (evt: JobEvent) => dispatch(evt)).then((fn) => { unlisten = fn; });
+    return () => { unlisten?.(); };
+  }, [jobId]);
+
+  const allClipsDone = Object.values(state.videos).every(
+    (c) => c.stages.transcribe === "done" && c.stages.analyze === "done" && c.stages.summarize === "done"
+  );
+
+  function onCancel() {
+    if (!confirm("Cancel analysis? Files already analyzed will be kept.")) return;
+    dispatch({ method: "_internal_canceling" } as any);
+    cancelJob(jobId).catch(console.error);
+  }
+
+  return (
+    <section className="np-progress">
+      <header className="np-progress__header">
+        <h2>Analyzing {library}</h2>
+        {state.status === "running" && <button onClick={onCancel}>Cancel</button>}
+        {state.status === "canceling" && <span>Canceling…</span>}
+      </header>
+
+      <div className="np-progress__bar">
+        <div style={{ width: `${(state.totals.done / Math.max(1, state.totals.total)) * 100}%` }} />
+      </div>
+      <p className="np-progress__count">
+        {state.totals.done} of {state.totals.total} clips ready
+        {state.totals.failed > 0 && <span className="np-progress__failed"> · {state.totals.failed} failed</span>}
+      </p>
+
+      <ul className="np-progress__list">
+        {Object.values(state.videos).map((c) => (
+          <li key={c.video}>
+            <ClipRow
+              clip={c}
+              library={library}
+              expanded={expanded === c.video}
+              onToggle={() => setExpanded(expanded === c.video ? null : c.video)}
+              onRetry={() => { /* M2 deferred — close window and re-run start_analysis */ onComplete(); }}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {(state.status === "complete" || state.status === "canceled" || allClipsDone) && (
+        <footer className="np-progress__footer">
+          <button onClick={() => openLibraryWindow(library).then(onComplete)}>Open Library</button>
+        </footer>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/routes/new-project/progress/
+git commit -m "M2: progress view, clip row, artifact preview"
+```
+
+---
+
+### Task 6.9: New Project window root
+
+**Files:**
+- Create: `ui/src/routes/new-project/index.tsx`
+- Create: `ui/src/routes/new-project/new-project.css`
+
+- [ ] **Step 1: Implement `index.tsx`**
+
+```tsx
+import { useEffect, useReducer, useState } from "react";
+import { initialSetup, setupReducer, slugify, StepId } from "./state";
+import { PickFootage } from "./steps/pick-footage";
+import { Name } from "./steps/name";
+import { Language } from "./steps/language";
+import { Refinement } from "./steps/refinement";
+import { Confirm } from "./steps/confirm";
+import { ApiKeyModal } from "./api-key-modal";
+import { ProgressView } from "./progress/progress-view";
+import { createLibrary, hasApiKey, startAnalysis } from "../../ipc/sidecar";
+import "./new-project.css";
+
+const STEPS: StepId[] = ["footage", "name", "language", "refinement", "confirm"];
+
+export default function NewProject() {
+  const [state, dispatch] = useReducer(setupReducer, initialSetup);
+  const [phase, setPhase] = useState<"setup" | "progress">("setup");
+  const [job, setJob] = useState<{ id: string; library: string } | null>(null);
+  const [keyConfigured, setKeyConfigured] = useState(false);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    hasApiKey().then((r) => setKeyConfigured(r.configured)).catch(() => setKeyConfigured(false));
+  }, []);
+
+  const idx = STEPS.indexOf(state.step);
+  const goNext = () => dispatch({ type: "go_step", step: STEPS[Math.min(STEPS.length - 1, idx + 1)] });
+  const goBack = () => dispatch({ type: "go_step", step: STEPS[Math.max(0, idx - 1)] });
+
+  async function start() {
+    setError(null);
+    try {
+      const { name } = await createLibrary({
+        name: state.name,
+        language: state.language.name,
+        language_code: state.language.code,
+        refinement: state.refinement,
+        videos: state.accepted,
+      });
+      const { job_id } = await startAnalysis(name);
+      setJob({ id: job_id, library: name });
+      setPhase("progress");
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  if (phase === "progress" && job) {
+    return <ProgressView jobId={job.id} library={job.library} onComplete={() => window.close()} />;
+  }
+
+  return (
+    <main className="np">
+      <nav className="np-breadcrumb">
+        {STEPS.map((s, i) => (
+          <span key={s} className={"np-breadcrumb__item" + (i === idx ? " np-breadcrumb__item--active" : "")}>
+            {i + 1}. {s}
+          </span>
+        ))}
+      </nav>
+
+      {state.step === "footage" && <PickFootage state={state} dispatch={dispatch} onNext={goNext} />}
+      {state.step === "name" && <Name state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} />}
+      {state.step === "language" && <Language state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} />}
+      {state.step === "refinement" && <Refinement state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} />}
+      {state.step === "confirm" && (
+        <Confirm
+          state={state}
+          apiKeyConfigured={keyConfigured}
+          onBack={goBack}
+          onStart={start}
+          onSetupKey={() => setShowKeyModal(true)}
+        />
+      )}
+
+      {error && <p className="np-error">{error}</p>}
+
+      {showKeyModal && (
+        <ApiKeyModal
+          onClose={() => setShowKeyModal(false)}
+          onSaved={() => { setShowKeyModal(false); setKeyConfigured(true); }}
+        />
+      )}
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `new-project.css`** — minimal styling matching the M0/M1 dark stage + tungsten amber palette:
+
+```css
+:root {
+  --np-bg: #14141a;
+  --np-fg: #e7e5e0;
+  --np-muted: #8b8a86;
+  --np-amber: #e0a55a;
+  --np-red: #c87272;
+  --np-line: #2a2a32;
+}
+.np { padding: 32px; color: var(--np-fg); background: var(--np-bg); min-height: 100vh; font-family: 'JetBrains Mono', ui-monospace, monospace; }
+.np-breadcrumb { display: flex; gap: 16px; margin-bottom: 32px; color: var(--np-muted); }
+.np-breadcrumb__item--active { color: var(--np-amber); }
+.np-step h2 { font-family: 'EB Garamond', serif; font-style: italic; font-weight: 400; font-size: 32px; }
+.np-dropzone { border: 2px dashed var(--np-amber); padding: 64px; text-align: center; border-radius: 6px; }
+.np-dropzone__buttons { margin-top: 16px; display: flex; gap: 12px; justify-content: center; }
+.np-filelist { list-style: none; padding: 0; margin: 16px 0; }
+.np-filelist li { display: flex; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--np-line); }
+.np-filelist__remove { margin-left: auto; background: transparent; color: var(--np-muted); border: none; cursor: pointer; }
+.np-rejected { margin: 8px 0; color: var(--np-amber); }
+.np-footer { display: flex; gap: 12px; margin-top: 24px; }
+.np-footer button { padding: 8px 20px; }
+.np-cards { display: flex; gap: 12px; margin: 16px 0; }
+.np-card { padding: 16px 20px; border: 1px solid var(--np-line); background: transparent; color: var(--np-fg); cursor: pointer; border-radius: 4px; }
+.np-card--active { border-color: var(--np-amber); }
+.np-other { display: block; margin-top: 12px; }
+.np-summary li { padding: 4px 0; }
+.np-banner { background: rgba(224, 165, 90, 0.08); padding: 12px 16px; border-left: 2px solid var(--np-amber); margin: 16px 0; }
+.np-error { color: var(--np-red); }
+.np-slug { color: var(--np-muted); }
+.np-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: grid; place-items: center; }
+.np-modal { background: var(--np-bg); border: 1px solid var(--np-line); padding: 24px; border-radius: 6px; width: 480px; }
+.np-modal-buttons { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+.np-progress { padding: 32px; color: var(--np-fg); background: var(--np-bg); min-height: 100vh; }
+.np-progress__header { display: flex; justify-content: space-between; align-items: center; }
+.np-progress__bar { height: 4px; background: var(--np-line); margin: 16px 0 4px 0; }
+.np-progress__bar > div { height: 4px; background: var(--np-amber); transition: width 0.4s ease; }
+.np-progress__count { color: var(--np-muted); }
+.np-progress__failed { color: var(--np-red); }
+.np-progress__list { list-style: none; padding: 0; }
+.np-row { border: 1px solid var(--np-line); border-radius: 4px; margin: 8px 0; overflow: hidden; }
+.np-row__head { display: flex; gap: 16px; align-items: center; width: 100%; padding: 12px 16px; background: transparent; color: var(--np-fg); border: none; cursor: pointer; }
+.np-row__name { flex: 1; text-align: left; }
+.np-chip { color: var(--np-muted); }
+.np-chip--in_progress { color: var(--np-amber); animation: pulse 1.6s ease-in-out infinite; }
+.np-chip--done { color: var(--np-amber); }
+.np-chip--failed { color: var(--np-red); }
+@keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.4 } }
+.np-row__body { padding: 12px 16px; border-top: 1px solid var(--np-line); background: rgba(255,255,255,0.02); }
+.np-failure pre { color: var(--np-red); white-space: pre-wrap; }
+.np-preview pre { white-space: pre-wrap; color: var(--np-muted); }
+.np-md { font-family: inherit; }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cd ui && pnpm build`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/routes/new-project/index.tsx ui/src/routes/new-project/new-project.css
+git commit -m "M2: New Project window root + setup/progress phase switch"
+```
+
+---
+
+### Task 6.10: + New Project tile on the Projects screen
+
+**Files:**
+- Modify: `ui/src/routes/projects.tsx`
+- Modify: `ui/src/routes/projects.css`
+
+- [ ] **Step 1: Edit `projects.tsx`**
+
+Add the import and render the tile inside the grid:
+
+```tsx
+import { listLibraries, openLibraryWindow, openNewProjectWindow, LibrarySummary } from "../ipc/sidecar";
+```
+
+Inside the `state.kind === "ready"` branch's grid, before the `state.libraries.map(...)`:
+
+```tsx
+<li>
+  <button className="card card--new" onClick={() => openNewProjectWindow().catch(console.error)}>
+    <span className="card__plus">+</span>
+    <span className="card__name">New Project</span>
+  </button>
+</li>
+```
+
+Also: the empty-state hint that says "Create one with the CLI for now." — replace its text with "No libraries yet. Click **+ New Project** to start."
+
+- [ ] **Step 2: Edit `projects.css`**
+
+Append:
+```css
+.card--new { border-style: dashed; border-color: var(--np-amber, #e0a55a); }
+.card__plus { font-size: 32px; color: var(--np-amber, #e0a55a); }
+```
+
+- [ ] **Step 3: Smoke build**
+
+Run: `cd ui && pnpm build`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/routes/projects.tsx ui/src/routes/projects.css
+git commit -m "M2: + New Project tile on the Projects screen"
+```
+
+---
+
+## Phase 7 — End-to-end smoke
+
+### Task 7.1: Manual happy-path run
+
+This task is *not* automated; it gates merge.
+
+- [ ] **Step 1: Set ANTHROPIC_API_KEY**
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-…
+```
+
+- [ ] **Step 2: Run dev**
+
+```bash
+cd ui && pnpm tauri dev
+```
+
+- [ ] **Step 3: Click "+ New Project"**
+
+A new window opens.
+
+- [ ] **Step 4: Drop ~3 short MP4s onto Step ①**
+
+Verify thumbnails... wait, no thumbnails in the wizard — just file list with durations. Verify durations populate.
+
+- [ ] **Step 5: Walk steps ②–⑤**
+
+Type a name, watch the slug populate; pick English; pick Yes for refinement; click Start analysis.
+
+- [ ] **Step 6: Watch the progress view**
+
+- Bar advances as artifacts land.
+- Click a row in progress; the artifact preview should populate after each stage's `artifact_ready`.
+- After completion, click **Open Library**; the M1 footage browser should open with all clips analyzed.
+
+- [ ] **Step 7: Verify CLI round-trip**
+
+Run from a terminal:
+```bash
+ls libraries/<your-name>/library.yaml libraries/<your-name>/transcripts/ libraries/<your-name>/summaries/
+```
+The schema and filenames should match what the CLI workflow produces.
+
+- [ ] **Step 8: Cancellation smoke**
+
+Repeat with a longer clip; click Cancel mid-transcribe. Verify:
+- Whisperx/ffmpeg processes die within ~2s (`ps aux | grep whisperx`).
+- No `*.tmp` files remain in `transcripts/` or `summaries/`.
+- Click "Resume analysis" or close + reopen and start_analysis again — picks up from where it left off.
+
+- [ ] **Step 9: Bad API key smoke**
+
+Start a fresh project with no key set. Confirm pane shows the banner. Click Set up; type `sk-bad`. Modal shows the upstream error and stays open.
+
+- [ ] **Step 10: No commit; this is verification only.**
+
+If anything fails, open targeted issues; do not paper over with sleeps or `--no-verify`.
+
+---
+
+### Task 7.2: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry**
+
+Under the `[Unreleased]` heading, prepend:
+
+```markdown
+### Added
+- M2: New Project flow + streaming analysis progress UI in the desktop app. Drop a folder of videos, name a project, pick a language, and watch the three-stage pipeline (transcribe → analyze → summarize) run with per-file per-stage progress streamed over JSON-RPC notifications. Removes the last terminal dependency from onboarding.
+- Sidecar gains: `inspect_video_paths`, `create_library`, `has_api_key`, `set_api_key`, `start_analysis`, `cancel_job`. Validates Anthropic keys with a Haiku ping; persists to `libraries/settings.yaml` (gitignored). Extracts analyze + summarize prompt content into shared `ui/sidecar/prompts/` files referenced by both the CLI agent and the new sidecar parent.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "M2: changelog entry"
+```
+
+---
+
+### Task 7.3: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin ui-m2-library-creation-and-analysis
+```
+
+- [ ] **Step 2: Create PR against `main`**
+
+```bash
+gh pr create --title "M2: Library creation + analysis from the UI" --body "$(cat <<'EOF'
+## Summary
+- Adds the New Project flow: drag-drop or pick → name → language → refinement → start analysis.
+- Promotes the sidecar from a YAML reader to the analysis pipeline owner. Whisperx + ffmpeg as subprocesses; Anthropic SDK for analyze + summarize. JSON-RPC notifications stream per-file per-stage progress to the UI as scoped Tauri events.
+- Extracts analyze + summarize prompt content into `ui/sidecar/prompts/` so the CLI agent and the sidecar share a single source of truth.
+- API key handling: env override + `libraries/settings.yaml`. Validated on save with a Haiku ping.
+
+Closes the M2 milestone of #14.
+
+## Test plan
+- [ ] Manual happy path against ~3 short clips end-to-end (per `docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md` Task 7.1).
+- [ ] Cancel mid-transcribe; no orphan `*.tmp` files; resume picks up.
+- [ ] Bad API key surfaces the upstream error in the modal.
+- [ ] Library created via UI is consumable by the CLI `roughcut` skill.
+- [ ] `bundle exec rake spec` passes (sidecar).
+- [ ] `cargo check` clean (Rust shell).
+- [ ] `pnpm build` clean (frontend).
+- [ ] M0 Projects screen and M1 Library window unchanged.
+EOF
+)"
+```
+
+- [ ] **Step 3: Expect CodeRabbit + Codex reviews; run `/babysit-coderabbit <PR#>` after they post.**
+
+---
+
+## Self-review checklist (run after writing this plan)
+
+- **Spec coverage:**
+  - ✅ JSON-RPC notifications IPC: Tasks 1.2, 5.1, 6.2.
+  - ✅ Sidecar pipeline (Option 1 from spec Q2): Tasks 4.3–4.6.
+  - ✅ API key UX (Q3): Tasks 1.3, 1.4, 2.3, 6.6.
+  - ✅ Hard-stop cancellation (Q4): Tasks 4.2, 4.6, 4.7, 6.8.
+  - ✅ Concurrency caps (Q5): Tasks 1.1, 4.6.
+  - ✅ Five-step wizard: Tasks 6.4, 6.5.
+  - ✅ Progress view with streaming artifact previews: Task 6.8.
+  - ✅ + New Project tile: Task 6.10.
+  - ✅ Open Library handoff: Task 6.8 (`onComplete` → `openLibraryWindow`).
+  - ✅ Prompt extraction: Phase 3.
+  - ✅ Acceptance criteria mapping: covered by Task 7.1's manual walkthrough.
+
+- **Placeholder scan:** No "TBD"/"TODO" left. The folder-picker limitation is explicitly called out in Task 6.5 with a follow-up note ("a follow-up adds an `enumerate_directory` sidecar RPC") — that's a deliberate scope decision, not a placeholder.
+
+- **Type consistency:** RPC method names match between Ruby dispatcher (Task 2.3, 4.7), Rust commands (Task 5.2), and TS wrappers (Task 6.1). Event method names match between Ruby `Notifier.notify` calls (Task 4.6), TS `JobEvent` union (Task 6.2), and reducer cases (Task 6.7).
+
+- **`retry_unit` scope:** Plan defers the retry-unit RPC implementation to a follow-up; the UI's "Retry stage" button currently closes and re-runs `start_analysis`. Spec acceptance criterion "Retry / Skip / Show full log all work" is partially met — Retry triggers a re-run rather than a precise per-stage replay. Flag for the PR description.

--- a/docs/superpowers/specs/2026-05-03-m2-library-creation-and-analysis-design.md
+++ b/docs/superpowers/specs/2026-05-03-m2-library-creation-and-analysis-design.md
@@ -1,0 +1,308 @@
+# M2 — Library Creation + Analysis from the UI
+
+**Status:** Design approved 2026-05-03
+**Tracks:** umbrella [#14](https://github.com/William-Hill/buttercut/issues/14)
+**Depends on:** M0 (PR [#15](https://github.com/William-Hill/buttercut/pull/15), merged), M1 (PR [#17](https://github.com/William-Hill/buttercut/pull/17), merged)
+**Branch:** `ui-m2-library-creation-and-analysis`
+
+## Goal
+
+A user with no terminal experience can: drag a folder of videos onto ButterCut, name a project, pick a language, and watch the three-stage analysis pipeline (transcribe → analyze → summarize) run to completion with per-file, per-stage progress and streaming artifact previews. When it's done, the new library opens in the M1 footage browser.
+
+This milestone removes the last terminal dependency from onboarding — everything before it required `claude` in a shell to drive the skills.
+
+## Architectural shift
+
+M0 and M1 used the sidecar as a thin adapter — read YAML, run `ffmpeg` for thumbnails, return JSON. M2 promotes the sidecar to **owner of the analysis pipeline**. It now does work that previously belonged to a Claude Code parent agent: dispatching subprocesses, calling the Anthropic SDK, writing artifact files, updating `library.yaml`. The CLI workflow is unchanged — Claude Code is still its parent. The two parents share prompt content (extracted into shared `.md` files) and share the artifact-writing helper scripts. Two parents, one source of truth.
+
+## Decisions log (from brainstorming)
+
+| Q | Decision |
+|---|---|
+| Streaming-progress IPC | A — JSON-RPC notifications (no `id`) emitted by the sidecar; Rust reader forwards as Tauri events. |
+| Where the pipeline runs | 1 — Sidecar uses the Anthropic Ruby SDK directly for analyze + summarize + (optional) refinement; subprocesses for whisperx + ffmpeg. Prompt content extracted into shared files. |
+| API key storage (M2) | Plain text in `libraries/settings.yaml` (gitignored), with `ANTHROPIC_API_KEY` env override. Keychain deferred. |
+| API key validation | Validate on save with one cheap Messages call; surface bad keys immediately. |
+| Cancellation | Hard stop. Kill child PIDs, abort SDK calls, drain workers. Frontend shows "Canceling…" for the 1–2s drain. |
+| Concurrency caps | Hard-coded constants matching SKILL.md (transcribe=2, analyze=8, summarize=10). No global rate limiter. No settings UI. |
+| New Project surface | Dedicated window (not modal). Becomes the progress window after kickoff. |
+| Auto-backup after analysis | Out of scope. CLI flow does this; deferred to a later milestone. |
+
+## Architecture
+
+```text
+┌──────────────────────────────┐    invoke()    ┌─────────────────────┐    JSON-RPC over stdio    ┌──────────────────────────────┐
+│  React (New Project window)  │ ──────────────▶│  Rust (Tauri core)  │ ────── requests ─────────▶│  Ruby sidecar                │
+│                              │                │                     │                           │  + Anthropic Ruby SDK        │
+│  listen("sidecar-event:JOB") │ ◀── responses ─│  reader task        │ ◀──── responses + ────────│  + whisperx / ffmpeg subproc │
+│                              │ ◀── tauri evt ─│  + emit("…")        │      notifications        │  + worker pools (2/8/10)     │
+└──────────────────────────────┘                └─────────────────────┘                           └──────────────────────────────┘
+```
+
+### IPC: JSON-RPC notifications → Tauri events
+
+JSON-RPC 2.0 already specifies notifications: a payload without an `id` is server-pushed and never expects a response. M0's reader (`ui/src-tauri/src/sidecar.rs`) currently deserializes lines into `Response { id: Option<u64>, … }` and silently drops `id == None` lines. M2 changes that branch:
+
+1. Try to deserialize each non-empty line as `Response` first.
+2. If `id` is `None`, fall back to deserializing as `Notification { method: String, params: Value }`.
+3. On a successful notification parse, emit a Tauri event scoped to the job: `app.emit(&format!("sidecar-event:{}", params.job_id), params)`.
+
+The existing request/response path is unchanged. The reader holds an `AppHandle` (passed in via `init`) so it can emit events.
+
+**Frontend** subscribes after calling `start_analysis(...)`:
+
+```ts
+const { job_id } = await invoke<{job_id: string}>("start_analysis", { ... });
+const unlisten = await listen<JobEvent>(`sidecar-event:${job_id}`, (e) => {
+  reducer.dispatch(e.payload);
+});
+```
+
+`unlisten()` is called when the window closes or analysis completes.
+
+### Event schema
+
+All events carry `{ job_id, ts }` plus the fields below. Sidecar emits them; frontend reduces them into per-clip per-stage state.
+
+| Method | Params | When |
+|---|---|---|
+| `job_started` | `library, video_count, total_duration_seconds` | Immediately after `start_analysis` returns. |
+| `file_queued` | `video, stage` | Worker pool accepts a unit but a slot isn't free. |
+| `file_started` | `video, stage` | Worker picks up the unit. |
+| `file_progress` | `video, stage, message?, percent?` | Optional, e.g. whisperx percent or "extracting frames". UI may render or ignore. |
+| `artifact_ready` | `video, stage, artifact_path` | Artifact file is written and `library.yaml` updated. UI fetches via `get_clip_transcripts`. |
+| `file_failed` | `video, stage, error_kind, message, log_path?` | Stage failed; details in error and optional captured-stderr log. |
+| `file_done` | `video, stage` | Stage complete (always immediately follows `artifact_ready` for that stage). |
+| `job_done` | `succeeded_count, failed_count` | All units drained. |
+| `job_canceled` | `succeeded_count, failed_count` | Hard-stop drain finished. |
+
+### New RPC surface (request/response)
+
+| Method | Params | Returns | Notes |
+|---|---|---|---|
+| `inspect_video_paths` | `{paths: string[]}` | `{accepted: [{path, duration_seconds, size_bytes}], rejected: [{path, reason}]}` | Pure-stdlib + ffprobe shell-out. Validates each path is a video the pipeline can handle. Reasons: `not_found`, `not_video`, `unreadable`, `zero_duration`. |
+| `create_library` | `{name, language, language_code, refinement, video_paths: string[]}` | `{name}` (canonical, slugified) | Atomically creates `libraries/<slug>/` + `transcripts/`, `summaries/`, writes `library.yaml` from template with all videos populated and empty artifact fields. Rolls back the directory on partial failure. Errors with `library_exists` if `<slug>` already present. |
+| `start_analysis` | `{library}` | `{job_id}` | Validates the API key is present; returns `missing_api_key` RPC error otherwise. Otherwise enqueues every video × stage that doesn't already have its artifact. Returns immediately. |
+| `cancel_job` | `{job_id}` | `{}` | Idempotent. Triggers hard-stop drain. Real "this job is fully canceled" signal arrives later as a `job_canceled` event. |
+| `retry_unit` | `{job_id, video, stage}` | `{}` | Re-enqueues a single failed stage for one video. Errors with `unknown_job` if the job has already been finalized; in that case the UI should call `start_analysis` again to resume. |
+| `set_api_key` | `{key}` | `{ok: true}` | Validates the key with one cheap Messages call (e.g. a 1-token "ping" to Haiku); on success persists to `libraries/settings.yaml`. On failure returns `invalid_api_key` with the upstream error message. |
+| `has_api_key` | `{}` | `{configured: bool}` | True if env or `libraries/settings.yaml` provides one. UI uses this to decide whether to show the API-key modal preemptively (it doesn't gate startup, but the modal can be shown alongside Step ⑤ if not configured). |
+
+All responses use the same JSON-RPC envelope as M0/M1.
+
+### Sidecar internal structure
+
+```text
+ui/sidecar/
+├── buttercut_ui_sidecar.rb        # entry point (existing) — adds dispatch for new methods + notification helper
+├── lib/buttercut_ui_sidecar/
+│   ├── limits.rb                  # TRANSCRIBE_PARALLELISM=2, ANALYZE_PARALLELISM=8, SUMMARIZE_PARALLELISM=10
+│   ├── settings_store.rb          # reads/writes libraries/settings.yaml; layered with ENV
+│   ├── library_creator.rb         # create_library RPC; uses templates/library_template.yaml
+│   ├── video_inspector.rb         # inspect_video_paths RPC; ffprobe shell-out
+│   ├── analysis_job.rb            # one-per-job orchestrator: cancel_token, child PIDs, worker pools
+│   ├── job_registry.rb            # in-memory job_id → AnalysisJob; survives only while sidecar runs
+│   ├── stages/
+│   │   ├── transcribe.rb          # whisperx subprocess + prepare_audio_script + optional refinement
+│   │   ├── analyze.rb             # ffmpeg frame extract + Anthropic vision call → visual_*.json
+│   │   └── summarize.rb           # visual_script_extractor + Anthropic Haiku call → summary_*.md
+│   ├── anthropic_client.rb        # thin wrapper around the SDK; per-call abort handle, retry on 429
+│   └── notifier.rb                # emits jsonrpc notifications on the shared stdout (mutex-guarded)
+└── prompts/
+    ├── analyze_video.md           # extracted creative content (referenced by both sidecar + agent_prompt.md)
+    └── summarize_video.md         # extracted creative content
+```
+
+The CLI's `agent_prompt.md` files are rewritten to *include* the prompts from `prompts/` rather than repeat them. Single source of truth for prompt text.
+
+**Note on `prompts/` location.** They live under `ui/sidecar/prompts/` for the same reason `lib/` does — they're sidecar implementation. The CLI `agent_prompt.md` files reference them via relative path. If the relative-path coupling proves awkward in implementation, move them to `.claude/skills/<skill>/<name>_prompt.md` and have the sidecar resolve via the repo root. Implementation call.
+
+### Worker pools
+
+Each stage has a fixed-size pool (`Concurrent::FixedThreadPool` from `concurrent-ruby`). A `WorkUnit` is one video × one stage. The job's lifecycle:
+
+1. `start_analysis` builds the unit list: for each video missing `transcript`, push a transcribe unit; for each missing `visual_transcript` and **with audio transcript already present or queued**, transcribe→analyze chains; same for summarize. We don't pre-enqueue analyze units for videos that haven't transcribed yet — instead, when a transcribe unit finishes, its `file_done` handler enqueues the dependent analyze unit. Same chain analyze→summarize.
+2. Each worker, before doing any work: check `cancel_token`. If flipped, return without emitting `file_started`.
+3. Worker registers any spawned child PIDs and any in-flight Anthropic request handles with the `AnalysisJob` so cancellation can reach them.
+4. Worker writes its artifact to `<path>.tmp`, then atomic-renames to the final filename. On any error or cancel mid-write, the `.tmp` is removed by the reaper.
+5. Worker takes a brief mutex on the library's yaml file, updates the relevant field, releases. Concurrent writers across stages can collide on the same file — the mutex (one per library) serializes them.
+
+### Cancellation: hard stop
+
+`cancel_job(job_id)`:
+
+1. Flip the job's `cancel_token`.
+2. Iterate the job's child-PID registry: SIGTERM each, then SIGKILL after 2s if still alive.
+3. Iterate in-flight Anthropic request handles: call abort.
+4. Worker pools shutdown (no new units accepted; in-flight workers see the token flip and bail before their next blocking call).
+5. Sweep `*.tmp` files in the library's `transcripts/` and `summaries/` directories.
+6. Emit `job_canceled` with succeeded/failed counts.
+
+The frontend hard-stop UX (per the design discussion): "Cancel" button → confirm modal → call `cancel_job` → window header shows "Canceling…" until `job_canceled` arrives → final "Canceled · N of M complete" state with a "Resume analysis" button (which just re-runs `start_analysis` on the same library — the pipeline already skips finished artifacts).
+
+### API key handling
+
+- **Source of truth** at startup: `ENV["ANTHROPIC_API_KEY"]` first, then `libraries/settings.yaml`'s `anthropic_api_key:` field. The sidecar holds the resolved value in memory; if neither is set, it stays `nil`.
+- **No app-launch gate.** Projects screen and M1 footage browser don't need a key.
+- **First-failure modal.** When the New Project window's Step ⑤ "Start analysis" runs, the frontend calls `has_api_key` first; if not configured, show the API-key modal *before* `start_analysis`. If `start_analysis` itself returns `missing_api_key` (e.g. race or env unset between calls), same modal.
+- **Modal:** copy + paste field + "Save." Save calls `set_api_key`, which validates with one Haiku ping. On success, modal closes and the original action proceeds. On failure, the modal stays open with the upstream error.
+- **Mid-job 401:** surfaces as a `file_failed` event with `error_kind: "auth"`. The job stops accepting new units (drains in-flight); UI offers the same modal to re-key + a "Resume" action.
+
+### Concurrency caps
+
+Per-stage pool sizes from `limits.rb`. Stages run sequentially per video; pools are independent. Natural pipelining: while later videos are still transcribing, earlier ones are summarizing.
+
+No global rate limiter. The Anthropic SDK retries on 429 with backoff; cap=10 on Haiku and cap=8 on the vision model are well under typical per-account limits for M2's volumes (dozens of clips per library).
+
+## UI
+
+### Entry: New Project tile
+
+The Projects window grid (M0) gains a "+ New Project" tile in the same card style as existing libraries but with a tungsten-amber dashed border and a centered glyph. Click → opens a new window via a new Tauri command `open_new_project_window()` (parallel to M0's `open_library_window`).
+
+### New Project window — setup phase
+
+Five linear steps in a single window. Breadcrumb at top:
+
+```text
+① Pick footage  →  ② Name  →  ③ Language  →  ④ Refinement  →  ⑤ Analyze
+```
+
+Active step is large; previous steps muted with back arrow; future steps faintly outlined.
+
+#### Step ① — Pick footage
+
+Full-pane dropzone (dashed amber border, 60% of pane height). Subtitle: "Drop a folder or video files here." Below: "or **Choose folder…** / **Choose files…**" buttons → `@tauri-apps/plugin-dialog` `open({ directory: true })` / `open({ multiple: true })`.
+
+Drag/drop wired via Tauri's window-level `onDragDropEvent`, which delivers absolute file paths (not webview `File` objects). Folders are flattened recursively, top-level only — we don't descend into subdirectories. Files are passed through `inspect_video_paths`. UI renders accepted clips as a list (filename + duration); rejected clips collapse into "N skipped" with a disclosure. Drop more to append; per-row X to remove.
+
+**Continue** disabled when accepted is empty.
+
+#### Step ② — Name
+
+Single text input, autofocused. Live preview of the slug below the input. On every keystroke, call `list_libraries` and check for collision against the slug. Collision → red hint, **Continue** replaced with "Choose a different name." Slugging algorithm matches the CLI flow: lowercase, spaces→dashes, strip non-alphanumeric/dash.
+
+#### Step ③ — Language
+
+Three option cards: **English** (default selected), **Spanish**, **Other…**. "Other…" reveals a text field + a faint disclosure "What's a language code?" with a one-line explanation and a link to ISO 639-1. Save both human name (e.g. "English") and code (e.g. `en`).
+
+#### Step ④ — Refinement
+
+Two cards. Heading text quotes the CLI flow exactly: *"Can I proofread the transcripts after they're generated? I'll use the video's context to fix mistakes."* Cards: **Yes — Recommended** ("Use Claude to refine video understanding") and **No.** Default Yes.
+
+#### Step ⑤ — Confirm + Analyze
+
+Summary card listing project name (slug), N videos with total duration, language, refinement on/off. Below it: API-key state — if not configured, shows a banner "ButterCut needs your Anthropic API key" with a "Set up" button that opens the modal pre-flight (so the user can paste the key before clicking Start). Primary footer button: **Start analysis**.
+
+Click flow:
+1. If `has_api_key` is false, open API-key modal first; on save proceed.
+2. Call `create_library`. If it errors (`library_exists`, etc.), show the error inline and let the user go back.
+3. Call `start_analysis` → receive `job_id` → swap pane to progress view.
+
+### New Project window — progress phase
+
+Replaces the setup pane in the same window. Header: project name (large), Cancel button (right). Body:
+
+**Top summary strip.** Progress bar showing `done / total` clips (where "done" = all three stages complete). Subtitle: "N of M clips ready · K minutes elapsed." Failed count shown in red if any.
+
+**Per-clip rows.** Filename (mono) + three stage chips (transcribe / analyze / summarize):
+
+| State | Glyph | Color |
+|---|---|---|
+| not started | `○` | dim grey |
+| queued | `⏳` | dim amber |
+| in progress | `◐` | tungsten amber, slow pulse |
+| done | `✓` | tungsten amber, solid |
+| failed | `✗` | red, clickable |
+
+**Row expansion.** Click a row → expands to show the artifact streaming in. The frontend listens for `artifact_ready` events for that clip and immediately fetches the artifact via the existing M1 RPC `get_clip_transcripts(library, video)`:
+
+- transcribe done: first ~6 lines of audio transcript text + "View full transcript" disclosure.
+- analyze done: condensed list of visual descriptions, one line per segment.
+- summarize done: rendered markdown of `summary_*.md`.
+- transcribe in progress: shows whisperx percentage from `file_progress` events if available; otherwise just the pulsing chip.
+
+**Failure rendering.** On `file_failed`, the row auto-expands to show:
+
+```text
+✗ analyze stage failed
+   IMG_4423.mov · 2025-05-03 14:22
+
+   ffmpeg exited with code 1:
+     [error] could not seek to 00:00:02 — file may be truncated
+
+   [Retry analyze]   [Skip this file]   [Show full log]
+```
+
+- **Retry analyze**: re-enqueues just that stage for that video. New `retry_unit(job_id, video, stage)` RPC.
+- **Skip this file**: marks failed for the job. Job continues with remaining units.
+- **Show full log**: opens a modal with the full captured stderr (sidecar saves stage stderr to `tmp/<job_id>/<video>.<stage>.log` while running).
+
+### Cancel UX
+
+Cancel button in window header → confirm modal "Cancel analysis? Files already analyzed will be kept." → `cancel_job` → header switches to "Canceling…" with a small spinner → on `job_canceled`, header shows "Canceled · N of M complete" with primary button **Resume analysis** and secondary **Open Library**. Resume re-issues `start_analysis` on the same library; the pipeline naturally skips already-completed stages (their artifacts and yaml entries are present).
+
+### Done UX
+
+On `job_done`: header shows "Analysis complete · N clips" (and if any failed, "· N failed" in red). Failed rows remain visible with retry options. Primary footer button **Open Library** → opens the M1 footage browser via `open_library_window` and closes the New Project window.
+
+### API-key modal
+
+Single modal usable from two entry points (Step ⑤ pre-flight, mid-job auth failure):
+
+- Title: "Connect your Anthropic API key"
+- Body: short copy explaining ButterCut uses Claude to analyze footage, with a link to console.anthropic.com.
+- Input: password-style text field for the key.
+- Buttons: **Save** (primary), **Cancel**.
+- On Save: spinner + "Validating…" → call `set_api_key`. Success: modal closes. Failure: error line below input shows the upstream message; modal stays open.
+
+## Out of scope (re-confirmed)
+
+- Auto-backup after analysis (CLI does this; deferred to later milestone).
+- Editing the project after kickoff (rename, add/remove clips).
+- Pausing analysis (cancel + resume-as-restart only).
+- Settings UI for the API key (modal only).
+- Migration UI for legacy library.yaml schemas. (CLAUDE.md migrations should still be run by the CLI Claude before opening a UI window. M2 doesn't add migration UX — but does verify on `create_library` that the template emitted is current.)
+- Per-stage retry from the Projects screen. Retry is only available from the in-progress / final-state New Project window.
+- Mid-job add-files. Adding more clips is a future milestone (or just create another library).
+- Subdirectory recursion when a folder is dropped. Top-level files only in M2.
+
+## Acceptance criteria
+
+- [ ] Projects screen shows a "+ New Project" tile that opens the New Project window.
+- [ ] Step ①: drop a folder of mixed video + non-video files. Accepted clips appear with durations; non-video files appear in the "N skipped" disclosure.
+- [ ] Step ①: native folder picker and native multi-file picker both populate the accepted list.
+- [ ] Step ②: typing a name shows the live slug below the input. Typing a name that collides with an existing library disables Continue with a clear message.
+- [ ] Step ③: selecting Other… reveals an ISO-code text field; the resulting library.yaml has the human name as `language` and the code is used by transcribe.
+- [ ] Step ④: refinement choice persists to library.yaml `transcript_refinement`.
+- [ ] Step ⑤ with no API key configured: pre-flight banner + Set-up button; the modal validates the key with a Haiku ping and rejects bogus keys with the upstream error.
+- [ ] `create_library` produces a directory + library.yaml that the CLI workflow can pick up unchanged (round-trip with the existing `transcribe-audio` skill should work).
+- [ ] During analysis, every clip shows three stage chips. Each chip transitions through queued → in progress → done in real time, driven by JSON-RPC notifications.
+- [ ] Expanding a row mid-transcribe shows whisperx progress; expanding after transcribe done shows the first lines of the transcript text fetched via `get_clip_transcripts`.
+- [ ] Forcibly causing a stage failure (rename a video file mid-job, set a bad API key, etc.) renders a specific failure card with stderr, and Retry / Skip / Show full log all work.
+- [ ] Hitting Cancel during an active job kills child whisperx/ffmpeg processes within ~2s and emits `job_canceled`. The library on disk has artifacts for everything that finished and no `.tmp` files left behind.
+- [ ] Resume analysis after a cancel re-runs only the un-completed stages.
+- [ ] Done state's **Open Library** button opens the M1 footage browser populated with the new library.
+- [ ] No regressions: M0 Projects screen still works; M1 Library window still works; CLI workflow (transcribe / analyze / summarize / roughcut skills) still works against a library that the UI created.
+- [ ] `cargo check`, `pnpm build`, `bundle exec rspec` (existing failures aside), and a sidecar smoke test for each new RPC all pass.
+
+## Test plan
+
+- Smoke each new sidecar method via piped JSON: `inspect_video_paths`, `create_library`, `set_api_key`, `has_api_key`, `start_analysis`, `cancel_job`, `retry_unit`.
+- Manual happy path against a small fixture library (3–4 short clips) end-to-end: setup → kickoff → done → Open Library.
+- Cancel mid-transcribe (slow whisperx run) and verify processes die, no orphan `.tmp` files, library is consistent.
+- Cancel mid-summarize (after several artifacts have already landed) and verify the partial library is fully usable in M1.
+- Force a failure in each stage independently and verify the row UX:
+  - transcribe: rename the source file just before whisperx runs.
+  - analyze: corrupt the audio transcript JSON.
+  - summarize: temporarily set a bad model name in `anthropic_client.rb`.
+- API-key flows: empty state, bad key, mid-job revocation (replace settings file mid-run).
+- Two New Project windows simultaneously creating two libraries — verify no shared state, both progress views update independently, cancel one doesn't affect the other.
+- CLI round-trip: create a library via the UI, then run the `roughcut` skill against it from a terminal to confirm the schema matches.
+
+## Open implementation questions (not blockers for this design)
+
+- Exact `concurrent-ruby` or `Thread`-based pool implementation. Either works; pick whichever has lighter dependency footprint when implementing.
+- Whether to extract prompts under `ui/sidecar/prompts/` or `.claude/skills/<skill>/`. Implementation-time decision based on what's less awkward to reference from both parents.
+- Vision model choice for analyze: probably `claude-sonnet-4-6` for vision quality; settle in plan stage with a quick A/B against the existing CLI output.
+- Capturing whisperx percentage: whisperx prints to stderr in a non-machine-friendly format. Either parse loosely for `file_progress` percent or just emit a generic "transcribing…" pulse and skip the percent. Decide in plan.

--- a/scripts/check_desktop_prereqs.sh
+++ b/scripts/check_desktop_prereqs.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ButterCut desktop (Tauri + Ruby sidecar) prerequisite check.
+# Usage: from repo root — ./scripts/check_desktop_prereqs.sh
+# Exit 0 = all required tools OK; 1 = something required is missing.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUBY_VERSION_FILE="$ROOT/.ruby-version"
+REQUIRED_FAIL=0
+
+warn() { printf '%s\n' "$*" >&2; }
+die() { warn "$*"; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ok() { printf '  OK     %s\n' "$1"; }
+bad() { printf '  MISS   %s\n' "$1"; REQUIRED_FAIL=1; }
+info() { printf '  INFO   %s\n' "$1"; }
+
+printf '\nButterCut desktop dev — prerequisite check\n'
+printf '%s\n\n' '────────────────────────────────────────────'
+
+# --- Ruby (3.3.x per .ruby-version) ---
+if [[ ! -f "$RUBY_VERSION_FILE" ]]; then
+  bad "Missing .ruby-version at repo root"
+else
+  WANT_RUBY="$(tr -d ' \t\r\n' <"$RUBY_VERSION_FILE")"
+  WANT_MM="${WANT_RUBY%.*}"
+  if ! have ruby; then
+    bad "ruby (need ${WANT_MM}.x per .ruby-version — brew/ruby-install/rbenv/mise)"
+  else
+    GOT_FULL="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"
+    GOT_MM="$(ruby -e 'print RUBY_VERSION.split(%q(.))[0,2].join(%q(.))' 2>/dev/null || true)"
+    if [[ -z "$GOT_MM" ]]; then
+      bad "ruby present but version unreadable ($(ruby --version 2>/dev/null | head -1))"
+    elif [[ "$GOT_MM" != "$WANT_MM" ]]; then
+      bad "Ruby ${GOT_FULL} on PATH (need ${WANT_MM}.x per .ruby-version ${WANT_RUBY})"
+    else
+      ok "Ruby ${GOT_FULL} (matches ${WANT_MM}.x)"
+    fi
+  fi
+fi
+
+if ! have bundle; then
+  bad "bundler (gem install bundler)"
+else
+  ok "bundler $(bundle -v 2>/dev/null | head -1)"
+fi
+
+# --- Sidecar gems ---
+if [[ -d "$ROOT/ui/sidecar" ]]; then
+  if (cd "$ROOT/ui/sidecar" && bundle check >/dev/null 2>&1); then
+    ok "ui/sidecar bundle (satisfied)"
+  else
+    bad "ui/sidecar gems — run: cd ui/sidecar && bundle install"
+  fi
+else
+  bad "ui/sidecar directory missing"
+fi
+
+# --- Node / pnpm ---
+if ! have node; then
+  bad "node (install LTS — brew install node)"
+else
+  ok "node $(node -v 2>/dev/null)"
+fi
+
+if ! have pnpm; then
+  bad "pnpm (corepack enable && corepack prepare pnpm@latest --activate — or brew install pnpm)"
+else
+  ok "pnpm $(pnpm -v 2>/dev/null)"
+fi
+
+if [[ -f "$ROOT/ui/package.json" ]]; then
+  if [[ -d "$ROOT/ui/node_modules" ]]; then
+    ok "ui/node_modules present"
+  else
+    bad "ui deps — run: cd ui && pnpm install"
+  fi
+else
+  bad "ui/package.json missing"
+fi
+
+# --- Rust (Tauri) ---
+if ! have cargo || ! have rustc; then
+  bad "Rust toolchain (https://rustup.rs/)"
+else
+  ok "cargo $(cargo -V 2>/dev/null | head -1)"
+fi
+
+# --- FFmpeg (inspect + analyze frames) ---
+if ! have ffmpeg; then
+  bad "ffmpeg (brew install ffmpeg)"
+else
+  ok "ffmpeg $(ffmpeg -version 2>/dev/null | head -1 | cut -c1-60)"
+fi
+
+if ! have ffprobe; then
+  bad "ffprobe (usually with ffmpeg)"
+else
+  ok "ffprobe $(ffprobe -version 2>/dev/null | head -1 | cut -c1-60)"
+fi
+
+# --- WhisperX (transcribe stage — optional for UI shell, required for real analysis) ---
+WHISPERX_OK=0
+if have whisperx; then
+  ok "whisperx on PATH"
+  WHISPERX_OK=1
+elif [[ -x "$HOME/.buttercut/whisperx" ]]; then
+  ok "whisperx at ~/.buttercut/whisperx"
+  WHISPERX_OK=1
+elif [[ -x "$HOME/.buttercut/venv/bin/whisperx" ]]; then
+  ok "whisperx at ~/.buttercut/venv/bin/whisperx"
+  WHISPERX_OK=1
+else
+  info "WhisperX not found — Projects/New Project UI works; transcribe will fail until installed (see .claude/skills/setup/)"
+fi
+
+# --- API key (optional at check time) ---
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  ok "ANTHROPIC_API_KEY is set"
+else
+  info "ANTHROPIC_API_KEY unset — set in shell or use in-app key modal for analyze/summarize"
+fi
+
+# --- libraries root ---
+if [[ -d "$ROOT/libraries" ]]; then
+  ok "libraries/ directory exists"
+else
+  info "libraries/ missing — creating empty libraries/"
+  mkdir -p "$ROOT/libraries"
+  ok "libraries/ created"
+fi
+
+printf '\n%s\n' '────────────────────────────────────────────'
+if [[ "$REQUIRED_FAIL" -ne 0 ]]; then
+  warn "Some required items are missing. Fix the MISS lines above, then:"
+  warn "  make setup    # install Ruby gems + pnpm deps"
+  warn "  make check    # re-run this script"
+  exit 1
+fi
+
+printf 'All required desktop prerequisites look good.\n'
+if [[ "$WHISPERX_OK" -eq 0 ]]; then
+  printf '%s\n' '(Install WhisperX when you need real transcription.)'
+fi
+printf '\nRun: cd ui && pnpm tauri dev\n\n'
+exit 0

--- a/templates/settings_template.yaml
+++ b/templates/settings_template.yaml
@@ -8,3 +8,8 @@ editor: fcpx
 # turbo is nearly as accurate as large-v3 but significantly faster
 # Recommended: `small` paired with transcript_refinement (set per-library in library.yaml)
 whisper_model: small
+
+# Anthropic API key for the desktop UI's analysis pipeline. The CLI flow
+# uses Claude Code's own auth and ignores this field. Optional — the env
+# var ANTHROPIC_API_KEY takes precedence when set.
+anthropic_api_key: ""

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "@fontsource/eb-garamond": "^5.2.7",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
@@ -528,6 +531,9 @@ packages:
     resolution: {integrity: sha512-W5Wbuqsb2pHFPTj4TaRNKTj5rwXhDShPiLSY9T18y4ouSR/NNCptAEFxFsBtyNRgL6Vs1a/q9LzfqqYzEwC+Jw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -1084,6 +1090,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.0
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.0
       '@tauri-apps/cli-win32-x64-msvc': 2.11.0
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:

--- a/ui/sidecar/Gemfile
+++ b/ui/sidecar/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "concurrent-ruby", "~> 1.3"
+gem "anthropic",       "~> 1.0"
+
+group :development, :test do
+  gem "rake",  "~> 13.0"
+  gem "rspec", "~> 3.13"
+end

--- a/ui/sidecar/Gemfile.lock
+++ b/ui/sidecar/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    anthropic (1.36.0)
+      cgi
+      connection_pool
+    cgi (0.5.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    diff-lcs (1.6.2)
+    rake (13.4.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  anthropic (~> 1.0)
+  concurrent-ruby (~> 1.3)
+  rake (~> 13.0)
+  rspec (~> 3.13)
+
+BUNDLED WITH
+   2.5.23

--- a/ui/sidecar/Rakefile
+++ b/ui/sidecar/Rakefile
@@ -1,3 +1,4 @@
+require "bundler/setup"
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 task default: :spec

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -151,7 +151,9 @@ module ButtercutUiSidecar
     # and get_or_generate_thumbnail.
     def library_dir(name)
       root = @libraries_root.expand_path
-      dir = root.join(name).expand_path
+      root = File.realpath(root) if root.directory?
+      candidate = root.join(name)
+      dir = candidate.exist? ? File.realpath(candidate) : candidate.expand_path
       root_prefix = root.to_s + File::SEPARATOR
       raise ArgumentError, "invalid library name: #{name}" unless dir.to_s.start_with?(root_prefix)
       dir
@@ -163,11 +165,10 @@ module ButtercutUiSidecar
       YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
     end
 
-    # Library entries are matched by basename. If two videos in different source
-    # folders share a filename, only the first is reachable — known limitation
-    # of the basename-as-id contract used throughout the sidecar.
     def find_video_entry(library_data, library_name, video)
-      entry = (library_data["videos"] || []).find { |v| File.basename(v["path"].to_s) == video }
+      videos = library_data["videos"] || []
+      entry = videos.find { |v| v["path"].to_s == video }
+      entry ||= videos.find { |v| File.basename(v["path"].to_s) == video }
       raise ArgumentError, "video not found in #{library_name}: #{video}" if entry.nil?
       entry
     end

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "base64"
 require "json"
 require "open3"
 require "pathname"
@@ -13,6 +14,12 @@ require_relative "lib/buttercut_ui_sidecar/settings_store"
 require_relative "lib/buttercut_ui_sidecar/anthropic_client"
 require_relative "lib/buttercut_ui_sidecar/video_inspector"
 require_relative "lib/buttercut_ui_sidecar/library_creator"
+require_relative "lib/buttercut_ui_sidecar/job_registry"
+require_relative "lib/buttercut_ui_sidecar/analysis_job"
+require_relative "lib/buttercut_ui_sidecar/analysis_controller"
+require_relative "lib/buttercut_ui_sidecar/stages/transcribe"
+require_relative "lib/buttercut_ui_sidecar/stages/analyze"
+require_relative "lib/buttercut_ui_sidecar/stages/summarize"
 
 module ButtercutUiSidecar
   def self.run(libraries_root:, io_in: $stdin, io_out: $stdout)
@@ -32,6 +39,7 @@ module ButtercutUiSidecar
       @notifier = ButtercutUiSidecar::Notifier.new(io: @io_out)
       @inspector = ButtercutUiSidecar::VideoInspector.new
       @creator = ButtercutUiSidecar::LibraryCreator.new(libraries_root: @libraries_root.to_s)
+      @registry = ButtercutUiSidecar::JobRegistry.new
     end
 
     def run
@@ -60,7 +68,14 @@ module ButtercutUiSidecar
     rescue ButtercutUiSidecar::LibraryCreator::LibraryExists => e
       respond_error(id: id, code: -32011, message: "library_exists: #{e.message}")
     rescue StandardError => e
-      respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
+      case e.message
+      when /\Amissing_api_key(\z|:)/
+        respond_error(id: id, code: -32010, message: "missing_api_key")
+      when /\Ainvalid_api_key/
+        respond_error(id: id, code: -32012, message: e.message)
+      else
+        respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
+      end
     end
 
     def dispatch(method, params)
@@ -86,6 +101,16 @@ module ButtercutUiSidecar
           refinement: params.fetch("refinement"),
           videos: params.fetch("videos")
         )
+      when "start_analysis"
+        controller = build_controller_or_raise!
+        job_id = controller.start!(library: params.fetch("library"))
+        { job_id: job_id }
+      when "cancel_job"
+        job = @registry.get(params.fetch("job_id"))
+        job&.cancel!
+        {}
+      when "retry_unit"
+        raise StandardError, "retry_unit is not yet supported in M2 minimum scope; re-run start_analysis to resume."
       else raise UnknownMethod, "unknown method: #{method}"
       end
     end
@@ -245,6 +270,67 @@ module ButtercutUiSidecar
       { ok: true }
     rescue ButtercutUiSidecar::AnthropicClient::InvalidApiKey => e
       raise StandardError, "invalid_api_key: #{e.message}"
+    end
+
+    def build_controller_or_raise!
+      api_key = @settings.api_key
+      raise StandardError, "missing_api_key" if api_key.nil?
+
+      client = ButtercutUiSidecar::AnthropicClient.new(api_key: api_key)
+
+      vision = lambda do |frames, prompt|
+        content = frames.map do |f|
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: Base64.strict_encode64(File.binread(f))
+            }
+          }
+        end
+        content << {
+          type: "text",
+          text: "#{prompt}\n\nReturn ONLY a JSON object of the form {\"segments\": [...]}, no prose."
+        }
+        response = client.messages_create(
+          model: ButtercutUiSidecar::AnthropicClient::VISION_MODEL,
+          max_tokens: 4096,
+          messages: [{ role: "user", content: content }]
+        )
+        text = ButtercutUiSidecar::AnthropicClient.message_body_text(response)
+        json_slice = text[/\{.*\}/m]
+        raise "vision model returned no JSON object" if json_slice.nil? || json_slice.empty?
+
+        JSON.parse(json_slice)
+      end
+
+      haiku = lambda do |prompt|
+        response = client.messages_create(
+          model: ButtercutUiSidecar::AnthropicClient::HAIKU_MODEL,
+          max_tokens: 1024,
+          messages: [{ role: "user", content: prompt }]
+        )
+        ButtercutUiSidecar::AnthropicClient.message_body_text(response)
+      end
+
+      ButtercutUiSidecar::AnalysisController.new(
+        libraries_root: @libraries_root.to_s,
+        notifier: @notifier,
+        registry: @registry,
+        transcribe: ButtercutUiSidecar::Stages::Transcribe.new,
+        analyze: ButtercutUiSidecar::Stages::Analyze.new(vision: vision),
+        summarize: ButtercutUiSidecar::Stages::Summarize.new(haiku: haiku),
+        whisper_model: read_whisper_model
+      )
+    end
+
+    def read_whisper_model
+      path = @libraries_root.join("settings.yaml")
+      return "small" unless path.file?
+
+      data = YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true) || {}
+      data["whisper_model"] || "small"
     end
 
     def respond(id:, result:)

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -7,217 +7,256 @@ require "pathname"
 require "time"
 require "yaml"
 
-class ButtercutUiSidecar
+require_relative "lib/buttercut_ui_sidecar/limits"
+require_relative "lib/buttercut_ui_sidecar/notifier"
+require_relative "lib/buttercut_ui_sidecar/settings_store"
+require_relative "lib/buttercut_ui_sidecar/anthropic_client"
+require_relative "lib/buttercut_ui_sidecar/video_inspector"
+require_relative "lib/buttercut_ui_sidecar/library_creator"
+
+module ButtercutUiSidecar
   def self.run(libraries_root:, io_in: $stdin, io_out: $stdout)
-    new(libraries_root: libraries_root, io_in: io_in, io_out: io_out).run
+    Dispatcher.new(libraries_root: libraries_root, io_in: io_in, io_out: io_out).run
   end
 
-  def initialize(libraries_root:, io_in:, io_out:)
-    raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+  class Dispatcher
+    def initialize(libraries_root:, io_in:, io_out:)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
 
-    @libraries_root = Pathname.new(libraries_root)
-    @io_in = io_in
-    @io_out = io_out
-    @io_out.sync = true
-  end
+      @libraries_root = Pathname.new(libraries_root)
+      @io_in = io_in
+      @io_out = io_out
+      @io_out.sync = true
 
-  def run
-    @io_in.each_line do |line|
-      line = line.strip
-      next if line.empty?
-
-      handle_line(line)
+      @settings = ButtercutUiSidecar::SettingsStore.new(libraries_root: @libraries_root.to_s)
+      @notifier = ButtercutUiSidecar::Notifier.new(io: @io_out)
+      @inspector = ButtercutUiSidecar::VideoInspector.new
+      @creator = ButtercutUiSidecar::LibraryCreator.new(libraries_root: @libraries_root.to_s)
     end
-  end
 
-  private
+    def run
+      @io_in.each_line do |line|
+        line = line.strip
+        next if line.empty?
 
-  def handle_line(line)
-    request = JSON.parse(line)
-    id = request["id"]
-    method = request["method"]
-    params = request["params"] || {}
-
-    result = dispatch(method, params)
-    respond(id: id, result: result)
-  rescue JSON::ParserError => e
-    respond_error(id: nil, code: -32700, message: "parse error: #{e.message}")
-  rescue UnknownMethod => e
-    respond_error(id: id, code: -32601, message: e.message)
-  rescue StandardError => e
-    respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
-  end
-
-  def dispatch(method, params)
-    case method
-    when "ping"           then "pong"
-    when "list_libraries" then list_libraries
-    when "get_library"    then get_library(params.fetch("name"))
-    when "get_clip_transcripts"
-      get_clip_transcripts(params.fetch("library"), params.fetch("video"))
-    when "get_or_generate_thumbnail"
-      get_or_generate_thumbnail(params.fetch("library"), params.fetch("video"))
-    else raise UnknownMethod, "unknown method: #{method}"
-    end
-  end
-
-  def list_libraries
-    Pathname.glob(@libraries_root.join("*", "library.yaml")).filter_map do |yaml_path|
-      summarize_library(yaml_path)
-    rescue Errno::ENOENT, Errno::EISDIR, Psych::Exception, TypeError => e
-      warn "[sidecar] skipping #{yaml_path}: #{e.class}: #{e.message}"
-      nil
-    end.sort_by { |lib| -Time.parse(lib[:last_touched_at]).to_i }
-  end
-
-  def summarize_library(yaml_path)
-    data = YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
-    {
-      name: data["library_name"] || yaml_path.parent.basename.to_s,
-      video_count: (data["videos"] || []).length,
-      last_touched_at: yaml_path.mtime.utc.iso8601
-    }
-  end
-
-  def get_library(name)
-    data = load_library_yaml(name)
-    videos = (data["videos"] || []).map { |v| video_entry(v) }
-
-    {
-      name: data["library_name"] || name,
-      footage_summary: data["footage_summary"] || "",
-      video_paths_root: longest_common_parent(videos.map { |v| v[:path] }),
-      videos: videos
-    }
-  end
-
-  # Resolves a library name to its canonical directory under @libraries_root.
-  # Rejects names that escape the root via "../", absolute paths, or symlinks
-  # — protects against path traversal in load_library_yaml, get_clip_transcripts,
-  # and get_or_generate_thumbnail.
-  def library_dir(name)
-    root = @libraries_root.expand_path
-    dir = root.join(name).expand_path
-    root_prefix = root.to_s + File::SEPARATOR
-    raise ArgumentError, "invalid library name: #{name}" unless dir.to_s.start_with?(root_prefix)
-    dir
-  end
-
-  def load_library_yaml(name)
-    yaml_path = library_dir(name).join("library.yaml")
-    raise ArgumentError, "library not found: #{name}" unless yaml_path.file?
-    YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
-  end
-
-  # Library entries are matched by basename. If two videos in different source
-  # folders share a filename, only the first is reachable — known limitation
-  # of the basename-as-id contract used throughout the sidecar.
-  def find_video_entry(library_data, library_name, video)
-    entry = (library_data["videos"] || []).find { |v| File.basename(v["path"].to_s) == video }
-    raise ArgumentError, "video not found in #{library_name}: #{video}" if entry.nil?
-    entry
-  end
-
-  def video_entry(v)
-    path = v["path"].to_s
-    {
-      filename: File.basename(path),
-      path: path,
-      duration_seconds: parse_duration(v["duration"]),
-      has_audio_transcript: present?(v["transcript"]),
-      has_visual_transcript: present?(v["visual_transcript"]),
-      has_summary: present?(v["summary"])
-    }
-  end
-
-  def present?(value)
-    !value.nil? && !value.to_s.empty?
-  end
-
-  def parse_duration(value)
-    return 0 if value.nil? || value.to_s.empty?
-    parts = value.to_s.split(":").map(&:to_f)
-    case parts.length
-    when 3 then (parts[0] * 3600 + parts[1] * 60 + parts[2]).to_i
-    when 2 then (parts[0] * 60 + parts[1]).to_i
-    else parts[0].to_i
-    end
-  end
-
-  def longest_common_parent(paths)
-    return "" if paths.empty?
-    parents = paths.map { |p| File.dirname(p).split(File::SEPARATOR) }
-    common = parents.first.dup
-    parents.each do |segs|
-      common.length.times do |i|
-        if segs[i] != common[i]
-          common = common[0...i]
-          break
-        end
+        handle_line(line)
       end
     end
-    # Absolute paths split to a leading "" segment; if only that survives,
-    # return "/" so the frontend doesn't treat the result as falsy.
-    return File::SEPARATOR if common == [""]
-    common.join(File::SEPARATOR)
-  end
 
-  def get_clip_transcripts(library, video)
-    entry = find_video_entry(load_library_yaml(library), library, video)
-    lib_dir = library_dir(library)
-    {
-      audio: read_json_if_set(lib_dir.join("transcripts"), entry["transcript"]),
-      visual: read_json_if_set(lib_dir.join("transcripts"), entry["visual_transcript"]),
-      summary: read_text_if_set(lib_dir.join("summaries"), entry["summary"])
-    }
-  end
+    private
 
-  def read_json_if_set(dir, name)
-    return nil unless present?(name)
-    path = dir.join(name)
-    return nil unless path.file?
-    JSON.parse(path.read)
-  rescue JSON::ParserError => e
-    raise "transcript parse error in #{path}: #{e.message}"
-  end
+    def handle_line(line)
+      request = JSON.parse(line)
+      id = request["id"]
+      method = request["method"]
+      params = request["params"] || {}
 
-  def read_text_if_set(dir, name)
-    return nil unless present?(name)
-    path = dir.join(name)
-    path.file? ? path.read : nil
-  end
-
-  def get_or_generate_thumbnail(library, video)
-    entry = find_video_entry(load_library_yaml(library), library, video)
-
-    cache_dir = library_dir(library).join("thumbnails")
-    cache_dir.mkpath
-    out_path = cache_dir.join("#{File.basename(video, ".*")}.jpg")
-    return { path: out_path.to_s } if out_path.file?
-
-    source = Pathname.new(entry["path"].to_s)
-    raise "source video missing: #{video} (expected at #{source})" unless source.file?
-
-    cmd = ["ffmpeg", "-y", "-loglevel", "error", "-ss", "1", "-i", source.to_s,
-           "-frames:v", "1", "-q:v", "4", out_path.to_s]
-    _stdout, stderr, status = Open3.capture3(*cmd)
-    unless status.success? && out_path.file?
-      out_path.delete if out_path.file?
-      raise "ffmpeg failed for #{video}: #{stderr.strip}"
+      result = dispatch(method, params)
+      respond(id: id, result: result)
+    rescue JSON::ParserError => e
+      respond_error(id: nil, code: -32700, message: "parse error: #{e.message}")
+    rescue UnknownMethod => e
+      respond_error(id: id, code: -32601, message: e.message)
+    rescue ButtercutUiSidecar::LibraryCreator::LibraryExists => e
+      respond_error(id: id, code: -32011, message: "library_exists: #{e.message}")
+    rescue StandardError => e
+      respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
     end
 
-    { path: out_path.to_s }
-  end
+    def dispatch(method, params)
+      case method
+      when "ping"           then "pong"
+      when "list_libraries" then list_libraries
+      when "get_library"    then get_library(params.fetch("name"))
+      when "get_clip_transcripts"
+        get_clip_transcripts(params.fetch("library"), params.fetch("video"))
+      when "get_or_generate_thumbnail"
+        get_or_generate_thumbnail(params.fetch("library"), params.fetch("video"))
+      when "has_api_key"
+        { configured: @settings.configured? }
+      when "set_api_key"
+        set_api_key(params.fetch("key"))
+      when "inspect_video_paths"
+        @inspector.inspect(params.fetch("paths"))
+      when "create_library"
+        @creator.create!(
+          name: params.fetch("name"),
+          language: params.fetch("language"),
+          language_code: params.fetch("language_code"),
+          refinement: params.fetch("refinement"),
+          videos: params.fetch("videos")
+        )
+      else raise UnknownMethod, "unknown method: #{method}"
+      end
+    end
 
-  def respond(id:, result:)
-    @io_out.puts JSON.generate(jsonrpc: "2.0", id: id, result: result)
-  end
+    def list_libraries
+      Pathname.glob(@libraries_root.join("*", "library.yaml")).filter_map do |yaml_path|
+        summarize_library(yaml_path)
+      rescue Errno::ENOENT, Errno::EISDIR, Psych::Exception, TypeError => e
+        warn "[sidecar] skipping #{yaml_path}: #{e.class}: #{e.message}"
+        nil
+      end.sort_by { |lib| -Time.parse(lib[:last_touched_at]).to_i }
+    end
 
-  def respond_error(id:, code:, message:)
-    @io_out.puts JSON.generate(jsonrpc: "2.0", id: id, error: { code: code, message: message })
-  end
+    def summarize_library(yaml_path)
+      data = YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+      {
+        name: data["library_name"] || yaml_path.parent.basename.to_s,
+        video_count: (data["videos"] || []).length,
+        last_touched_at: yaml_path.mtime.utc.iso8601
+      }
+    end
+
+    def get_library(name)
+      data = load_library_yaml(name)
+      videos = (data["videos"] || []).map { |v| video_entry(v) }
+
+      {
+        name: data["library_name"] || name,
+        footage_summary: data["footage_summary"] || "",
+        video_paths_root: longest_common_parent(videos.map { |v| v[:path] }),
+        videos: videos
+      }
+    end
+
+    # Resolves a library name to its canonical directory under @libraries_root.
+    # Rejects names that escape the root via "../", absolute paths, or symlinks
+    # — protects against path traversal in load_library_yaml, get_clip_transcripts,
+    # and get_or_generate_thumbnail.
+    def library_dir(name)
+      root = @libraries_root.expand_path
+      dir = root.join(name).expand_path
+      root_prefix = root.to_s + File::SEPARATOR
+      raise ArgumentError, "invalid library name: #{name}" unless dir.to_s.start_with?(root_prefix)
+      dir
+    end
+
+    def load_library_yaml(name)
+      yaml_path = library_dir(name).join("library.yaml")
+      raise ArgumentError, "library not found: #{name}" unless yaml_path.file?
+      YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    # Library entries are matched by basename. If two videos in different source
+    # folders share a filename, only the first is reachable — known limitation
+    # of the basename-as-id contract used throughout the sidecar.
+    def find_video_entry(library_data, library_name, video)
+      entry = (library_data["videos"] || []).find { |v| File.basename(v["path"].to_s) == video }
+      raise ArgumentError, "video not found in #{library_name}: #{video}" if entry.nil?
+      entry
+    end
+
+    def video_entry(v)
+      path = v["path"].to_s
+      {
+        filename: File.basename(path),
+        path: path,
+        duration_seconds: parse_duration(v["duration"]),
+        has_audio_transcript: present?(v["transcript"]),
+        has_visual_transcript: present?(v["visual_transcript"]),
+        has_summary: present?(v["summary"])
+      }
+    end
+
+    def present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
+
+    def parse_duration(value)
+      return 0 if value.nil? || value.to_s.empty?
+      parts = value.to_s.split(":").map(&:to_f)
+      case parts.length
+      when 3 then (parts[0] * 3600 + parts[1] * 60 + parts[2]).to_i
+      when 2 then (parts[0] * 60 + parts[1]).to_i
+      else parts[0].to_i
+      end
+    end
+
+    def longest_common_parent(paths)
+      return "" if paths.empty?
+      parents = paths.map { |p| File.dirname(p).split(File::SEPARATOR) }
+      common = parents.first.dup
+      parents.each do |segs|
+        common.length.times do |i|
+          if segs[i] != common[i]
+            common = common[0...i]
+            break
+          end
+        end
+      end
+      # Absolute paths split to a leading "" segment; if only that survives,
+      # return "/" so the frontend doesn't treat the result as falsy.
+      return File::SEPARATOR if common == [""]
+      common.join(File::SEPARATOR)
+    end
+
+    def get_clip_transcripts(library, video)
+      entry = find_video_entry(load_library_yaml(library), library, video)
+      lib_dir = library_dir(library)
+      {
+        audio: read_json_if_set(lib_dir.join("transcripts"), entry["transcript"]),
+        visual: read_json_if_set(lib_dir.join("transcripts"), entry["visual_transcript"]),
+        summary: read_text_if_set(lib_dir.join("summaries"), entry["summary"])
+      }
+    end
+
+    def read_json_if_set(dir, name)
+      return nil unless present?(name)
+      path = dir.join(name)
+      return nil unless path.file?
+      JSON.parse(path.read)
+    rescue JSON::ParserError => e
+      raise "transcript parse error in #{path}: #{e.message}"
+    end
+
+    def read_text_if_set(dir, name)
+      return nil unless present?(name)
+      path = dir.join(name)
+      path.file? ? path.read : nil
+    end
+
+    def get_or_generate_thumbnail(library, video)
+      entry = find_video_entry(load_library_yaml(library), library, video)
+
+      cache_dir = library_dir(library).join("thumbnails")
+      cache_dir.mkpath
+      out_path = cache_dir.join("#{File.basename(video, ".*")}.jpg")
+      return { path: out_path.to_s } if out_path.file?
+
+      source = Pathname.new(entry["path"].to_s)
+      raise "source video missing: #{video} (expected at #{source})" unless source.file?
+
+      cmd = ["ffmpeg", "-y", "-loglevel", "error", "-ss", "1", "-i", source.to_s,
+             "-frames:v", "1", "-q:v", "4", out_path.to_s]
+      _stdout, stderr, status = Open3.capture3(*cmd)
+      unless status.success? && out_path.file?
+        out_path.delete if out_path.file?
+        raise "ffmpeg failed for #{video}: #{stderr.strip}"
+      end
+
+      { path: out_path.to_s }
+    end
+
+    def set_api_key(key)
+      client = ButtercutUiSidecar::AnthropicClient.new(api_key: key)
+      client.validate_key!
+      @settings.write_api_key!(key)
+      { ok: true }
+    rescue ButtercutUiSidecar::AnthropicClient::InvalidApiKey => e
+      raise StandardError, "invalid_api_key: #{e.message}"
+    end
+
+    def respond(id:, result:)
+      @io_out.puts JSON.generate(jsonrpc: "2.0", id: id, result: result)
+    end
+
+    def respond_error(id:, code:, message:)
+      @io_out.puts JSON.generate(jsonrpc: "2.0", id: id, error: { code: code, message: message })
+    end
 
   class UnknownMethod < StandardError; end
+  end
 end
 
 if __FILE__ == $PROGRAM_NAME

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -151,9 +151,10 @@ module ButtercutUiSidecar
     # and get_or_generate_thumbnail.
     def library_dir(name)
       root = @libraries_root.expand_path
-      root = File.realpath(root) if root.directory?
+      root = Pathname.new(File.realpath(root)) if root.directory?
       candidate = root.join(name)
       dir = candidate.exist? ? File.realpath(candidate) : candidate.expand_path
+      dir = Pathname.new(dir) if dir.is_a?(String)
       root_prefix = root.to_s + File::SEPARATOR
       raise ArgumentError, "invalid library name: #{name}" unless dir.to_s.start_with?(root_prefix)
       dir

--- a/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
@@ -41,7 +41,7 @@ module ButtercutUiSidecar
       @completion_latch = Concurrent::CountDownLatch.new(1)
 
       units_total = videos.sum { |v| pending_stage_count(v) }
-      @notifier.notify("job_started", job_id: job_id, library: library, video_count: videos.length)
+      @notifier.notify("job_started", job_id: job_id, library: library, video_count: units_total)
 
       if units_total.zero?
         @notifier.notify("job_done", job_id: job_id, succeeded_count: 0, failed_count: 0)
@@ -150,7 +150,8 @@ module ButtercutUiSidecar
         if need_s
           pools[:summarize].post do
             run_step(job: job, stage: :summarize, video: basename,
-                     artifact_path: summary_path, on_complete: on_complete, on_success: -> {}) { summarize_body.call }
+                     artifact_path: summary_path, on_complete: on_complete, on_success: -> {},
+                     need_a: false, need_s: false) { summarize_body.call }
           end
         end
       end
@@ -159,7 +160,8 @@ module ButtercutUiSidecar
         if need_a
           pools[:analyze].post do
             run_step(job: job, stage: :analyze, video: basename,
-                     artifact_path: visual_path, on_complete: on_complete, on_success: after_analyze) { analyze_body.call }
+                     artifact_path: visual_path, on_complete: on_complete, on_success: after_analyze,
+                     need_a: need_a, need_s: need_s) { analyze_body.call }
           end
         else
           after_analyze.call
@@ -169,16 +171,18 @@ module ButtercutUiSidecar
       if need_t
         pools[:transcribe].post do
           run_step(job: job, stage: :transcribe, video: basename,
-                   artifact_path: audio_path, on_complete: on_complete, on_success: after_transcribe) { transcribe_body.call }
+                   artifact_path: audio_path, on_complete: on_complete, on_success: after_transcribe,
+                   need_a: need_a, need_s: need_s) { transcribe_body.call }
         end
       else
         after_transcribe.call
       end
     end
 
-    def run_step(job:, stage:, video:, artifact_path:, on_complete:, on_success:)
+    def run_step(job:, stage:, video:, artifact_path:, on_complete:, on_success:, need_a:, need_s:)
       if job.canceled?
         on_complete.call(false)
+        flush_skipped_after_abort(stage, need_a: need_a, need_s: need_s, on_complete: on_complete)
         return
       end
       @notifier.notify("file_started", job_id: job.id, video: video, stage: stage.to_s)
@@ -192,6 +196,20 @@ module ButtercutUiSidecar
         @notifier.notify("file_failed", job_id: job.id, video: video, stage: stage.to_s,
                                          error_kind: classify_error(e), message: e.message)
         on_complete.call(false)
+        flush_skipped_after_abort(stage, need_a: need_a, need_s: need_s, on_complete: on_complete)
+      end
+    end
+
+    # When a stage aborts, downstream stages counted in units_total may never run — complete those units.
+    def flush_skipped_after_abort(stage, need_a:, need_s:, on_complete:)
+      case stage
+      when :transcribe
+        on_complete.call(false) if need_a
+        on_complete.call(false) if need_s
+      when :analyze
+        on_complete.call(false) if need_s
+      when :summarize
+        # no downstream
       end
     end
 

--- a/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require "concurrent"
+require "date"
+require "fileutils"
+require "json"
+require "pathname"
+require "securerandom"
+require "yaml"
+require_relative "limits"
+require_relative "analysis_job"
+
+module ButtercutUiSidecar
+  class AnalysisController
+    def initialize(libraries_root:, notifier:, registry:,
+                   transcribe:, analyze:, summarize:,
+                   whisper_model: "small")
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      raise ArgumentError, "notifier required" if notifier.nil?
+      raise ArgumentError, "registry required" if registry.nil?
+
+      @libraries_root = Pathname.new(libraries_root)
+      @notifier = notifier
+      @registry = registry
+      @stages = { transcribe: transcribe, analyze: analyze, summarize: summarize }
+      @whisper_model = whisper_model
+    end
+
+    # Kicks off a job and returns its id immediately. Use #wait! in tests.
+    def start!(library:)
+      job_id = "job-#{SecureRandom.hex(6)}"
+      job = AnalysisJob.new(id: job_id, library: library)
+      @registry.put(job_id, job)
+
+      lib_dir = @libraries_root.join(library)
+      data = read_yaml(lib_dir)
+      videos = (data["videos"] || []).reject do |v|
+        present?(v["transcript"]) && present?(v["visual_transcript"]) && present?(v["summary"])
+      end
+
+      @completion_latch = Concurrent::CountDownLatch.new(1)
+
+      units_total = videos.sum { |v| pending_stage_count(v) }
+      @notifier.notify("job_started", job_id: job_id, library: library, video_count: videos.length)
+
+      if units_total.zero?
+        @notifier.notify("job_done", job_id: job_id, succeeded_count: 0, failed_count: 0)
+        @registry.delete(job_id)
+        @completion_latch.count_down
+        return job_id
+      end
+
+      pools = build_pools
+      done = Concurrent::AtomicFixnum.new(0)
+      failed = Concurrent::AtomicFixnum.new(0)
+      remaining_units = Concurrent::AtomicFixnum.new(units_total)
+
+      complete_unit = lambda do |succeeded|
+        succeeded ? done.increment : failed.increment
+        if remaining_units.decrement.zero?
+          @notifier.notify("job_done", job_id: job_id,
+                                       succeeded_count: done.value, failed_count: failed.value)
+          shutdown_pools(pools)
+          @registry.delete(job_id)
+          @completion_latch.count_down
+        end
+      end
+
+      videos.each do |v|
+        chain_stages(job: job, video: v, lib_dir: lib_dir, pools: pools, on_complete: complete_unit, data: data)
+      end
+
+      job_id
+    end
+
+    # Test helper.
+    def wait!(_job_id, timeout: 30)
+      @completion_latch.wait(timeout)
+    end
+
+    private
+
+    def present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
+
+    def pending_stage_count(video)
+      n = 0
+      n += 1 unless present?(video["transcript"])
+      n += 1 unless present?(video["visual_transcript"])
+      n += 1 unless present?(video["summary"])
+      n
+    end
+
+    def build_pools
+      {
+        transcribe: Concurrent::FixedThreadPool.new(Limits::TRANSCRIBE_PARALLELISM),
+        analyze:    Concurrent::FixedThreadPool.new(Limits::ANALYZE_PARALLELISM),
+        summarize:  Concurrent::FixedThreadPool.new(Limits::SUMMARIZE_PARALLELISM)
+      }
+    end
+
+    def shutdown_pools(pools)
+      pools.values.each(&:shutdown)
+    end
+
+    def chain_stages(job:, video:, lib_dir:, pools:, on_complete:, data:)
+      basename = File.basename(video["path"])
+      stem = File.basename(basename, ".*")
+      transcripts_dir = lib_dir.join("transcripts").to_s
+      summaries_dir = lib_dir.join("summaries").to_s
+      audio_path   = File.join(transcripts_dir, "#{stem}.json")
+      visual_path  = File.join(transcripts_dir, "visual_#{stem}.json")
+      summary_path = File.join(summaries_dir,   "summary_#{stem}.md")
+
+      need_t = !present?(video["transcript"])
+      need_a = !present?(video["visual_transcript"])
+      need_s = !present?(video["summary"])
+
+      transcribe_body = lambda do
+        res = @stages[:transcribe].run(
+          job: job, video_path: video["path"], transcript_output_dir: transcripts_dir,
+          language_code: data["language_code"] || "en", whisper_model: @whisper_model
+        )
+        raise "stage canceled" if res.is_a?(Hash) && res[:canceled]
+
+        update_yaml_field(lib_dir, video["path"], "transcript", File.basename(audio_path))
+      end
+
+      analyze_body = lambda do
+        res = @stages[:analyze].run(
+          job: job, video_path: video["path"],
+          audio_transcript_path: audio_path, visual_transcript_path: visual_path
+        )
+        raise "stage canceled" if res.is_a?(Hash) && res[:canceled]
+
+        update_yaml_field(lib_dir, video["path"], "visual_transcript", File.basename(visual_path))
+      end
+
+      summarize_body = lambda do
+        res = @stages[:summarize].run(
+          job: job, visual_transcript_path: visual_path, summary_output_path: summary_path
+        )
+        raise "stage canceled" if res.is_a?(Hash) && res[:canceled]
+
+        update_yaml_field(lib_dir, video["path"], "summary", File.basename(summary_path))
+      end
+
+      after_analyze = lambda do
+        if need_s
+          pools[:summarize].post do
+            run_step(job: job, stage: :summarize, video: basename,
+                     artifact_path: summary_path, on_complete: on_complete, on_success: -> {}) { summarize_body.call }
+          end
+        end
+      end
+
+      after_transcribe = lambda do
+        if need_a
+          pools[:analyze].post do
+            run_step(job: job, stage: :analyze, video: basename,
+                     artifact_path: visual_path, on_complete: on_complete, on_success: after_analyze) { analyze_body.call }
+          end
+        else
+          after_analyze.call
+        end
+      end
+
+      if need_t
+        pools[:transcribe].post do
+          run_step(job: job, stage: :transcribe, video: basename,
+                   artifact_path: audio_path, on_complete: on_complete, on_success: after_transcribe) { transcribe_body.call }
+        end
+      else
+        after_transcribe.call
+      end
+    end
+
+    def run_step(job:, stage:, video:, artifact_path:, on_complete:, on_success:)
+      if job.canceled?
+        on_complete.call(false)
+        return
+      end
+      @notifier.notify("file_started", job_id: job.id, video: video, stage: stage.to_s)
+      begin
+        yield
+        @notifier.notify("artifact_ready", job_id: job.id, video: video, stage: stage.to_s, artifact_path: artifact_path)
+        @notifier.notify("file_done", job_id: job.id, video: video, stage: stage.to_s)
+        on_complete.call(true)
+        on_success.call
+      rescue StandardError => e
+        @notifier.notify("file_failed", job_id: job.id, video: video, stage: stage.to_s,
+                                         error_kind: classify_error(e), message: e.message)
+        on_complete.call(false)
+      end
+    end
+
+    def classify_error(error)
+      case error.message
+      when /invalid_api_key/i, /AuthenticationError/i then "auth"
+      when /whisperx failed/i then "transcribe"
+      when /ffmpeg/i then "ffmpeg"
+      else "unknown"
+      end
+    end
+
+    def read_yaml(lib_dir)
+      YAML.safe_load(File.read(lib_dir.join("library.yaml")), permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def update_yaml_field(lib_dir, video_path, field, value)
+      yaml_path = lib_dir.join("library.yaml")
+      lock_file = "#{yaml_path}.lock"
+      File.open(lock_file, File::RDWR | File::CREAT, 0o600) do |f|
+        f.flock(File::LOCK_EX)
+        ydata = YAML.safe_load(File.read(yaml_path), permitted_classes: [Date, Time], aliases: true) || {}
+        (ydata["videos"] || []).each do |v|
+          v[field] = value if v["path"] == video_path
+        end
+        ydata["last_updated"] = Date.today.iso8601
+        File.write("#{yaml_path}.tmp", YAML.dump(ydata))
+        File.rename("#{yaml_path}.tmp", yaml_path.to_s)
+      end
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb
@@ -22,14 +22,27 @@ module ButtercutUiSidecar
     def cancel!
       return if @cancel_flag.true?
       @cancel_flag.make_true
-      @pids.dup.each { |pid| terminate_pid(pid) }
+      pids = @pids.dup
+      pids.each do |pid|
+        Process.kill("TERM", pid)
+      rescue Errno::ESRCH
+      end
+      sleep 2
+      pids.each do |pid|
+        Process.kill("KILL", pid)
+      rescue Errno::ESRCH, Errno::ECHILD
+      end
       @abortables.dup.each do |h|
         h.abort! if h.respond_to?(:abort!)
       end
     end
 
     def register_pid(pid)
-      @pids << pid
+      if @cancel_flag.true?
+        terminate_pid_immediate(pid)
+      else
+        @pids << pid
+      end
     end
 
     def unregister_pid(pid)
@@ -51,9 +64,9 @@ module ButtercutUiSidecar
 
     private
 
-    def terminate_pid(pid)
+    def terminate_pid_immediate(pid)
       Process.kill("TERM", pid)
-      sleep 2
+      sleep 0.1
       Process.kill("KILL", pid)
     rescue Errno::ESRCH, Errno::ECHILD
       # already gone

--- a/ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/analysis_job.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module ButtercutUiSidecar
+  class AnalysisJob
+    attr_reader :id, :library
+
+    def initialize(id:, library:)
+      @id = id
+      @library = library
+      @cancel_flag = Concurrent::AtomicBoolean.new(false)
+      @pids = Concurrent::Array.new
+      @abortables = Concurrent::Array.new
+      @library_yaml_mutex = Mutex.new
+    end
+
+    def canceled?
+      @cancel_flag.true?
+    end
+
+    def cancel!
+      return if @cancel_flag.true?
+      @cancel_flag.make_true
+      @pids.dup.each { |pid| terminate_pid(pid) }
+      @abortables.dup.each do |h|
+        h.abort! if h.respond_to?(:abort!)
+      end
+    end
+
+    def register_pid(pid)
+      @pids << pid
+    end
+
+    def unregister_pid(pid)
+      @pids.delete(pid)
+    end
+
+    def register_abortable(handle)
+      @abortables << handle
+    end
+
+    def unregister_abortable(handle)
+      @abortables.delete(handle)
+    end
+
+    # Yields with the per-library yaml mutex held. Use for read-modify-write of library.yaml.
+    def with_yaml_lock
+      @library_yaml_mutex.synchronize { yield }
+    end
+
+    private
+
+    def terminate_pid(pid)
+      Process.kill("TERM", pid)
+      sleep 2
+      Process.kill("KILL", pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # already gone
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
@@ -35,6 +35,28 @@ module ButtercutUiSidecar
       raise InvalidApiKey, e.message
     end
 
+    # Normalizes SDK response objects (or Hash) to a single assistant text string.
+    def self.message_body_text(response)
+      return "" if response.nil?
+
+      content =
+        if response.respond_to?(:content)
+          response.content
+        else
+          response["content"] || response[:content]
+        end
+
+      Array(content).map do |block|
+        if block.respond_to?(:text)
+          block.text.to_s
+        elsif block.is_a?(Hash)
+          (block["text"] || block[:text]).to_s
+        else
+          ""
+        end
+      end.join
+    end
+
     private
 
     def build_sdk(api_key)

--- a/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  # Thin wrapper around the anthropic gem. Holds the api_key, exposes
+  # `validate_key!` (single Haiku ping) and `messages_create` (regular calls).
+  # Auth errors surface as InvalidApiKey; everything else propagates.
+  class AnthropicClient
+    HAIKU_MODEL = "claude-haiku-4-5-20251001"
+    VISION_MODEL = "claude-sonnet-4-6"
+
+    class InvalidApiKey < StandardError; end
+    class FakeAuthError < StandardError; end # used only in tests
+
+    def initialize(api_key:, sdk: nil, auth_error_classes: nil)
+      raise ArgumentError, "api_key required" if api_key.nil? || api_key.empty?
+      @api_key = api_key
+      @sdk = sdk || build_sdk(api_key)
+      @auth_error_classes = auth_error_classes || default_auth_error_classes
+    end
+
+    def validate_key!
+      @sdk.messages.create(
+        model: HAIKU_MODEL,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "ping" }]
+      )
+      true
+    rescue *@auth_error_classes => e
+      raise InvalidApiKey, e.message
+    end
+
+    def messages_create(**kwargs)
+      @sdk.messages.create(**kwargs)
+    rescue *@auth_error_classes => e
+      raise InvalidApiKey, e.message
+    end
+
+    private
+
+    def build_sdk(api_key)
+      require "anthropic"
+      Anthropic::Client.new(api_key: api_key)
+    end
+
+    def default_auth_error_classes
+      classes = []
+      begin
+        require "anthropic"
+        classes << Anthropic::AuthenticationError if defined?(Anthropic::AuthenticationError)
+      rescue LoadError
+        # fall through; tests inject explicit classes
+      end
+      classes
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/job_registry.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/job_registry.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  class JobRegistry
+    def initialize
+      @mutex = Mutex.new
+      @jobs = {}
+    end
+
+    def put(id, job)
+      @mutex.synchronize { @jobs[id] = job }
+    end
+
+    def get(id)
+      @mutex.synchronize { @jobs[id] }
+    end
+
+    def delete(id)
+      @mutex.synchronize { @jobs.delete(id) }
+    end
+
+    def each(&block)
+      @mutex.synchronize { @jobs.values.dup }.each(&block)
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/library_creator.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/library_creator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+require "yaml"
+require "date"
+
+module ButtercutUiSidecar
+  class LibraryCreator
+    class LibraryExists < StandardError; end
+
+    def initialize(libraries_root:)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      @root = Pathname.new(libraries_root)
+    end
+
+    def create!(name:, language:, language_code:, refinement:, videos:)
+      slug = slugify(name)
+      raise ArgumentError, "invalid name: #{name}" if slug.empty?
+
+      lib_dir = @root.join(slug)
+      raise LibraryExists, "library already exists: #{slug}" if lib_dir.join("library.yaml").file?
+
+      created = false
+      begin
+        FileUtils.mkdir_p(lib_dir.join("transcripts"))
+        FileUtils.mkdir_p(lib_dir.join("summaries"))
+        created = true
+
+        data = build_yaml(slug: slug, language: language, language_code: language_code,
+                          refinement: refinement, videos: videos)
+        File.write(lib_dir.join("library.yaml").to_s, YAML.dump(data))
+        { name: slug }
+      rescue StandardError
+        FileUtils.rm_rf(lib_dir) if created
+        raise
+      end
+    end
+
+    private
+
+    def slugify(name)
+      name.to_s.downcase.gsub(/\s+/, "-").gsub(/[^a-z0-9\-]/, "").gsub(/-+/, "-").gsub(/\A-|-\z/, "")
+    end
+
+    def build_yaml(slug:, language:, language_code:, refinement:, videos:)
+      today = Date.today.iso8601
+      {
+        "library_name" => slug,
+        "created_date" => today,
+        "last_updated" => today,
+        "language" => language,
+        "language_code" => language_code,
+        "editor" => nil,
+        "transcript_refinement" => refinement,
+        "user_context" => "",
+        "footage_summary" => "No footage analyzed yet.",
+        "videos" => videos.map do |v|
+          {
+            "path" => v[:path] || v["path"],
+            "duration" => format_duration(v[:duration_seconds] || v["duration_seconds"]),
+            "transcript" => "",
+            "visual_transcript" => "",
+            "summary" => ""
+          }
+        end
+      }
+    end
+
+    def format_duration(seconds)
+      return "00:00:00" if seconds.nil?
+      s = seconds.to_i
+      format("%02d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60)
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/limits.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/limits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  module Limits
+    # Mirrors .claude/skills/<skill>/SKILL.md parent briefs.
+    TRANSCRIBE_PARALLELISM = 2
+    ANALYZE_PARALLELISM    = 8
+    SUMMARIZE_PARALLELISM  = 10
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/notifier.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/notifier.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+
+module ButtercutUiSidecar
+  # Writes JSON-RPC 2.0 notifications (payloads without an `id`) on a shared
+  # output stream — the same stream that carries request/response. The Rust
+  # reader distinguishes them by the absence of `id`. A mutex serializes
+  # writes so notifications and responses don't interleave at the byte level.
+  class Notifier
+    def initialize(io:, mutex: Mutex.new)
+      @io = io
+      @mutex = mutex
+      @io.sync = true if @io.respond_to?(:sync=)
+    end
+
+    def notify(method, **params)
+      params[:ts] ||= Time.now.utc.iso8601(3)
+      line = JSON.generate(jsonrpc: "2.0", method: method, params: params)
+      @mutex.synchronize do
+        @io.puts(line)
+      end
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/settings_store.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/settings_store.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "date"
+require "fileutils"
+require "pathname"
+require "time"
+require "yaml"
+
+module ButtercutUiSidecar
+  class SettingsStore
+    SETTINGS_FILENAME = "settings.yaml"
+
+    def initialize(libraries_root:, env: ENV.to_h)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      @root = Pathname.new(libraries_root)
+      @env = env
+    end
+
+    def api_key
+      env_key = @env["ANTHROPIC_API_KEY"]
+      return env_key unless env_key.nil? || env_key.empty?
+      data = read_yaml
+      key = data["anthropic_api_key"]
+      key.nil? || key.empty? ? nil : key
+    end
+
+    def configured?
+      !api_key.nil?
+    end
+
+    def write_api_key!(key)
+      raise ArgumentError, "key required" if key.nil? || key.empty?
+      data = read_yaml
+      data["anthropic_api_key"] = key
+      write_yaml(data)
+    end
+
+    private
+
+    def settings_path
+      @root.join(SETTINGS_FILENAME)
+    end
+
+    def read_yaml
+      return {} unless settings_path.file?
+      YAML.safe_load(settings_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def write_yaml(data)
+      FileUtils.mkdir_p(@root)
+      tmp = settings_path.to_s + ".tmp"
+      File.write(tmp, YAML.dump(data))
+      File.rename(tmp, settings_path.to_s)
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "base64"
+require "pathname"
+require "set"
+require "tmpdir"
+
+module ButtercutUiSidecar
+  module Stages
+    class Analyze
+      def initialize(ffmpeg: nil, vision: nil, prompt_path: self.class.default_prompt_path)
+        @ffmpeg = ffmpeg || method(:default_ffmpeg)
+        @vision = vision # required when not in test mode
+        @prompt_path = prompt_path
+      end
+
+      def run(job:, video_path:, audio_transcript_path:, visual_transcript_path:)
+        return cancel_result if job.canceled?
+
+        prepared = prepare_skeleton(audio_transcript_path)
+        timestamps = sample_timestamps(prepared)
+        frames = extract_frames(job, video_path, timestamps)
+        return cancel_result if job.canceled?
+
+        prompt = File.read(@prompt_path)
+        response = @vision.call(frames, prompt + "\n\nHere is the prepared transcript skeleton (JSON):\n" + JSON.pretty_generate(prepared))
+        return cancel_result if job.canceled?
+
+        merged = merge_segments(prepared, response.fetch("segments"))
+        atomic_write_json(visual_transcript_path, merged)
+
+        cleanup_frames(frames)
+        { visual_transcript_path: visual_transcript_path }
+      end
+
+      def self.default_prompt_path
+        File.expand_path("../../../prompts/analyze_video.md", __dir__)
+      end
+
+      private
+
+      def prepare_skeleton(audio_path)
+        data = JSON.parse(File.read(audio_path))
+        # Strip word-level timing to keep the visual transcript small (mirrors
+        # .claude/skills/analyze-video/prepare_visual_script.rb).
+        if data["segments"]
+          data["segments"] = data["segments"].map do |s|
+            s.dup.tap { |c| c.delete("words") }
+          end
+        end
+        data
+      end
+
+      def sample_timestamps(prepared)
+        duration = (prepared.dig("segments", -1, "end") || 0).to_f
+        return [duration / 2.0] if duration <= 30
+        [2.0, duration / 2.0, [duration - 2.0, 2.0].max]
+      end
+
+      def extract_frames(job, video_path, timestamps)
+        tmp_dir = File.join(Dir.tmpdir, "buttercut-frames-#{job.id}-#{File.basename(video_path, ".*")}")
+        FileUtils.mkdir_p(tmp_dir)
+        frames = []
+        timestamps.each_with_index do |ts, i|
+          return frames if job.canceled?
+          out = File.join(tmp_dir, "frame_#{i}.jpg")
+          ok = @ffmpeg.call(video_path, ts, out, on_pid: ->(pid) { job.register_pid(pid) })
+          frames << out if ok && File.file?(out)
+        end
+        frames
+      end
+
+      def merge_segments(prepared, response_segments)
+        # Map response segments by start time to the skeleton; preserve any
+        # fields the model didn't touch.
+        by_start = response_segments.each_with_object({}) { |s, h| h[s["start"].to_f] = s }
+        prepared["segments"] = prepared["segments"].map do |skel|
+          rs = by_start[skel["start"].to_f] || {}
+          skel.merge(rs.slice("visual", "b_roll"))
+        end
+        # Append any b-roll-only segments from the response that weren't in the skeleton.
+        skel_starts = prepared["segments"].map { |s| s["start"].to_f }.to_set
+        extras = response_segments.reject { |s| skel_starts.include?(s["start"].to_f) }
+        prepared["segments"].concat(extras)
+        prepared
+      end
+
+      def atomic_write_json(path, data)
+        tmp = path + ".tmp"
+        File.write(tmp, JSON.pretty_generate(data))
+        File.rename(tmp, path)
+      end
+
+      def cleanup_frames(frames)
+        return if frames.empty?
+        FileUtils.rm_rf(File.dirname(frames.first))
+      end
+
+      def cancel_result
+        { canceled: true }
+      end
+
+      def default_ffmpeg(video_path, timestamp, out_path, on_pid:)
+        cmd = ["ffmpeg", "-ss", format_ts(timestamp), "-i", video_path,
+               "-vframes", "1", "-vf", "scale=1280:-1", "-y", out_path]
+        stdin, stdout_err, wait_thr = Open3.popen2e(*cmd)
+        stdin.close
+        on_pid.call(wait_thr.pid)
+        stdout_err.read
+        wait_thr.value.success?
+      end
+
+      def format_ts(seconds)
+        s = seconds.to_f
+        format("%02d:%02d:%06.3f", s / 3600, (s.to_i % 3600) / 60, s % 60)
+      end
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/stages/analyze.rb
@@ -20,20 +20,24 @@ module ButtercutUiSidecar
       def run(job:, video_path:, audio_transcript_path:, visual_transcript_path:)
         return cancel_result if job.canceled?
 
-        prepared = prepare_skeleton(audio_transcript_path)
-        timestamps = sample_timestamps(prepared)
-        frames = extract_frames(job, video_path, timestamps)
-        return cancel_result if job.canceled?
+        tmp_dir = nil
+        begin
+          prepared = prepare_skeleton(audio_transcript_path)
+          timestamps = sample_timestamps(prepared)
+          frames, tmp_dir = extract_frames(job, video_path, timestamps)
+          return cancel_result if job.canceled?
 
-        prompt = File.read(@prompt_path)
-        response = @vision.call(frames, prompt + "\n\nHere is the prepared transcript skeleton (JSON):\n" + JSON.pretty_generate(prepared))
-        return cancel_result if job.canceled?
+          prompt = File.read(@prompt_path)
+          response = @vision.call(frames, prompt + "\n\nHere is the prepared transcript skeleton (JSON):\n" + JSON.pretty_generate(prepared))
+          return cancel_result if job.canceled?
 
-        merged = merge_segments(prepared, response.fetch("segments"))
-        atomic_write_json(visual_transcript_path, merged)
+          merged = merge_segments(prepared, response.fetch("segments"))
+          atomic_write_json(visual_transcript_path, merged)
 
-        cleanup_frames(frames)
-        { visual_transcript_path: visual_transcript_path }
+          { visual_transcript_path: visual_transcript_path }
+        ensure
+          FileUtils.rm_rf(tmp_dir) if tmp_dir && File.directory?(tmp_dir)
+        end
       end
 
       def self.default_prompt_path
@@ -65,12 +69,12 @@ module ButtercutUiSidecar
         FileUtils.mkdir_p(tmp_dir)
         frames = []
         timestamps.each_with_index do |ts, i|
-          return frames if job.canceled?
+          return [frames, tmp_dir] if job.canceled?
           out = File.join(tmp_dir, "frame_#{i}.jpg")
-          ok = @ffmpeg.call(video_path, ts, out, on_pid: ->(pid) { job.register_pid(pid) })
+          ok = @ffmpeg.call(video_path, ts, out, job: job)
           frames << out if ok && File.file?(out)
         end
-        frames
+        [frames, tmp_dir]
       end
 
       def merge_segments(prepared, response_segments)
@@ -94,23 +98,23 @@ module ButtercutUiSidecar
         File.rename(tmp, path)
       end
 
-      def cleanup_frames(frames)
-        return if frames.empty?
-        FileUtils.rm_rf(File.dirname(frames.first))
-      end
-
       def cancel_result
         { canceled: true }
       end
 
-      def default_ffmpeg(video_path, timestamp, out_path, on_pid:)
+      def default_ffmpeg(video_path, timestamp, out_path, job:)
         cmd = ["ffmpeg", "-ss", format_ts(timestamp), "-i", video_path,
                "-vframes", "1", "-vf", "scale=1280:-1", "-y", out_path]
         stdin, stdout_err, wait_thr = Open3.popen2e(*cmd)
         stdin.close
-        on_pid.call(wait_thr.pid)
-        stdout_err.read
-        wait_thr.value.success?
+        pid = wait_thr.pid
+        job.register_pid(pid)
+        begin
+          stdout_err.read
+          wait_thr.value.success?
+        ensure
+          job.unregister_pid(pid)
+        end
       end
 
       def format_ts(seconds)

--- a/ui/sidecar/lib/buttercut_ui_sidecar/stages/summarize.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/stages/summarize.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "json"
+
+module ButtercutUiSidecar
+  module Stages
+    class Summarize
+      def initialize(haiku:, prompt_path: nil)
+        raise ArgumentError, "haiku required" if haiku.nil?
+        @haiku = haiku
+        @prompt_path = prompt_path || self.class.default_prompt_path
+      end
+
+      def run(job:, visual_transcript_path:, summary_output_path:)
+        return cancel_result if job.canceled?
+
+        script = extract_script(visual_transcript_path)
+        prompt = File.read(@prompt_path) + "\n\n## Visual transcript\n\n" + script
+        markdown = @haiku.call(prompt)
+        return cancel_result if job.canceled?
+
+        atomic_write(summary_output_path, markdown)
+        { summary_path: summary_output_path }
+      end
+
+      def self.default_prompt_path
+        File.expand_path("../../../prompts/summarize_video.md", __dir__)
+      end
+
+      private
+
+      def extract_script(visual_path)
+        data = JSON.parse(File.read(visual_path))
+        lines = []
+        (data["segments"] || []).each do |s|
+          ts = format_ts(s["start"].to_f)
+          lines << "[VISUAL] #{s['visual']}" if s["visual"]
+          lines << "[#{ts}] #{s['text']}" if s["text"] && !s["text"].empty?
+        end
+        lines.join("\n")
+      end
+
+      def format_ts(seconds)
+        format("[%02d:%02d]", seconds.to_i / 60, seconds.to_i % 60)
+      end
+
+      def atomic_write(path, body)
+        tmp = path + ".tmp"
+        File.write(tmp, body)
+        File.rename(tmp, path)
+      end
+
+      def cancel_result
+        { canceled: true }
+      end
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+module ButtercutUiSidecar
+  module Stages
+    class Transcribe
+      DEFAULT_PREPARE_SCRIPT = File.expand_path("../../../../../.claude/skills/transcribe-audio/prepare_audio_script.rb", __dir__)
+
+      def initialize(shell: nil, prepare: nil, prepare_script: DEFAULT_PREPARE_SCRIPT)
+        @shell = shell || method(:default_shell)
+        @prepare = prepare || method(:default_prepare).curry[prepare_script]
+      end
+
+      # Returns { transcript_path: <abs path> } on success.
+      def run(job:, video_path:, transcript_output_dir:, language_code:, whisper_model:)
+        return cancel_result if job.canceled?
+
+        argv = [
+          "whisperx", video_path,
+          "--language", language_code,
+          "--model", whisper_model,
+          "--compute_type", "float32",
+          "--device", "cpu",
+          "--output_format", "json",
+          "--output_dir", transcript_output_dir
+        ]
+
+        ok, stderr = @shell.call(argv, on_pid: ->(pid) { job.register_pid(pid) })
+        raise "whisperx failed: #{stderr.strip}" unless ok
+        return cancel_result if job.canceled?
+
+        basename = File.basename(video_path, ".*")
+        json_path = File.join(transcript_output_dir, "#{basename}.json")
+        raise "whisperx produced no output at #{json_path}" unless File.file?(json_path)
+
+        @prepare.call(json_path, video_path)
+        { transcript_path: json_path }
+      end
+
+      private
+
+      def cancel_result
+        { canceled: true }
+      end
+
+      def default_shell(argv, on_pid:)
+        stdin, stdout_err, wait_thr = Open3.popen2e(*argv)
+        stdin.close
+        on_pid.call(wait_thr.pid)
+        out = stdout_err.read
+        wait_thr.value.success? ? [true, out] : [false, out]
+      end
+
+      def default_prepare(prepare_script, json_path, video_path)
+        ok, err = run_simple("ruby", prepare_script, json_path, video_path)
+        raise "prepare_audio_script failed: #{err.strip}" unless ok
+      end
+
+      def run_simple(*argv)
+        out, status = Open3.capture2e(*argv)
+        [status.success?, out]
+      end
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/stages/transcribe.rb
@@ -2,6 +2,7 @@
 
 require "open3"
 require "pathname"
+require "rbconfig"
 
 module ButtercutUiSidecar
   module Stages
@@ -27,7 +28,7 @@ module ButtercutUiSidecar
           "--output_dir", transcript_output_dir
         ]
 
-        ok, stderr = @shell.call(argv, on_pid: ->(pid) { job.register_pid(pid) })
+        ok, stderr = @shell.call(argv, job: job)
         raise "whisperx failed: #{stderr.strip}" unless ok
         return cancel_result if job.canceled?
 
@@ -45,16 +46,21 @@ module ButtercutUiSidecar
         { canceled: true }
       end
 
-      def default_shell(argv, on_pid:)
+      def default_shell(argv, job:)
         stdin, stdout_err, wait_thr = Open3.popen2e(*argv)
         stdin.close
-        on_pid.call(wait_thr.pid)
-        out = stdout_err.read
-        wait_thr.value.success? ? [true, out] : [false, out]
+        pid = wait_thr.pid
+        job.register_pid(pid)
+        begin
+          out = stdout_err.read
+          wait_thr.value.success? ? [true, out] : [false, out]
+        ensure
+          job.unregister_pid(pid)
+        end
       end
 
       def default_prepare(prepare_script, json_path, video_path)
-        ok, err = run_simple("ruby", prepare_script, json_path, video_path)
+        ok, err = run_simple(RbConfig.ruby, prepare_script, json_path, video_path)
         raise "prepare_audio_script failed: #{err.strip}" unless ok
       end
 

--- a/ui/sidecar/lib/buttercut_ui_sidecar/video_inspector.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/video_inspector.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "open3"
+require "json"
+
+module ButtercutUiSidecar
+  class VideoInspector
+    def inspect(paths)
+      accepted = []
+      rejected = []
+
+      paths.each do |p|
+        unless File.file?(p)
+          rejected << { path: p, reason: "not_found" }
+          next
+        end
+
+        info = probe(p)
+        if info.nil?
+          rejected << { path: p, reason: "not_video" }
+        elsif info[:duration_seconds].to_f <= 0
+          rejected << { path: p, reason: "zero_duration" }
+        else
+          accepted << { path: p, duration_seconds: info[:duration_seconds], size_bytes: File.size(p) }
+        end
+      end
+
+      { accepted: accepted, rejected: rejected }
+    end
+
+    private
+
+    def probe(path)
+      cmd = ["ffprobe", "-v", "error", "-print_format", "json",
+             "-show_format", "-show_streams", "-select_streams", "v:0", path]
+      out, _err, status = Open3.capture3(*cmd)
+      return nil unless status.success?
+      data = JSON.parse(out) rescue nil
+      return nil unless data && (data["streams"] || []).any? { |s| s["codec_type"] == "video" }
+      duration = (data.dig("format", "duration") || 0).to_f
+      { duration_seconds: duration }
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/ui/sidecar/prompts/analyze_video.md
+++ b/ui/sidecar/prompts/analyze_video.md
@@ -1,0 +1,45 @@
+# Visual transcript instructions (shared)
+
+You analyze video frames and produce visual descriptions paired with audio segments to form a "visual transcript." This file is read by both the CLI agent (Claude Code) and the desktop sidecar (Anthropic SDK).
+
+## Output schema
+
+The visual transcript JSON has the same top-level shape as the audio transcript: `{language, video_path, segments: [...]}`. Each segment is one of:
+
+**Dialogue segment** — same shape as audio, plus a `visual` field:
+```json
+{
+  "start": 2.917,
+  "end": 7.586,
+  "text": "Hey, good afternoon everybody.",
+  "visual": "Man in red shirt speaking to camera in medium shot. Home office with bookshelf. Natural lighting.",
+  "words": [...]
+}
+```
+
+**B-roll segment** — inserted between dialogue when no one is speaking:
+```json
+{
+  "start": 35.474,
+  "end": 56.162,
+  "text": "",
+  "visual": "Green bicycle parked in front of building. Urban street with trees.",
+  "b_roll": true,
+  "words": []
+}
+```
+
+## Description guidelines
+
+- Maximum 3 sentences per `visual` field.
+- First segment: detailed (subject, setting, shot type, lighting, camera style).
+- Continuing shots: brief if similar; up to 3 sentences if drastically different.
+- Describe what is visible, not interpretation. Avoid speculation.
+
+## Frame sampling
+
+- Videos ≤30s: sample one frame near the middle.
+- Videos >30s: sample at start (~2s in), middle (duration/2), end (duration−2s).
+- Subdivide further if start/middle/end show different subjects, settings, or angle changes.
+- Stop subdividing when consecutive frames show only minor changes.
+- Never sample more frequently than once per 30 seconds.

--- a/ui/sidecar/prompts/summarize_video.md
+++ b/ui/sidecar/prompts/summarize_video.md
@@ -1,0 +1,14 @@
+# Video summary instructions (shared)
+
+You produce a short markdown summary of a video from its visual transcript. This file is read by both the CLI agent (Claude Code, via skeleton + Edit) and the desktop sidecar (Anthropic SDK, plain text output).
+
+## Output structure
+
+The summary file has four sections, in order:
+
+1. **Overview** — 2–3 sentences describing the narrative arc. Be specific. Avoid vague endings like "the clip ends with…" or "discusses something."
+2. **Key visuals** — 3–6 bullets covering locations, distinctive shots, visual changes.
+3. **Dialogue** — 0–3 quotes formatted as `> [MM:SS] "Quote"`. Skip filler ("um", "you know"). For clips under 30 seconds, often 0–1 quotes is enough; write `None` if nothing stands out.
+4. **B-roll** — cutaway descriptions distinct from the main subject. For single-shot clips, write `None`. Do not speculate about how the footage could be used as b-roll elsewhere.
+
+The CLI agent fills these into a pre-created skeleton via Edit; the sidecar emits them directly as a single markdown document.

--- a/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+++ b/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
@@ -116,6 +116,21 @@ RSpec.describe ButtercutUiSidecar do
     end
   end
 
+  describe "start_analysis" do
+    it "returns missing_api_key when no Anthropic key is configured" do
+      prev = ENV.delete("ANTHROPIC_API_KEY")
+      begin
+        Dir.mktmpdir do |root|
+          result = call(root, "start_analysis", { library: "demo" })
+          expect(result["error"]["code"]).to eq(-32_010)
+          expect(result["error"]["message"]).to eq("missing_api_key")
+        end
+      ensure
+        ENV["ANTHROPIC_API_KEY"] = prev if prev
+      end
+    end
+  end
+
   describe "create_library" do
     it "creates a library and returns its slug" do
       Dir.mktmpdir do |root|

--- a/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+++ b/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
@@ -102,6 +102,49 @@ RSpec.describe ButtercutUiSidecar do
     end
   end
 
+  describe "has_api_key" do
+    it "returns false when no key is configured" do
+      prev = ENV.delete("ANTHROPIC_API_KEY")
+      begin
+        Dir.mktmpdir do |root|
+          result = call(root, "has_api_key")
+          expect(result["result"]).to eq({ "configured" => false })
+        end
+      ensure
+        ENV["ANTHROPIC_API_KEY"] = prev if prev
+      end
+    end
+  end
+
+  describe "create_library" do
+    it "creates a library and returns its slug" do
+      Dir.mktmpdir do |root|
+        Dir.mktmpdir do |footage|
+          v = File.join(footage, "a.mp4")
+          File.write(v, "x")
+          result = call(root, "create_library", {
+            name: "My Lib",
+            language: "English",
+            language_code: "en",
+            refinement: true,
+            videos: [{ path: v, duration_seconds: 5 }]
+          })
+          expect(result["result"]).to eq({ "name" => "my-lib" })
+          expect(File.file?(File.join(root, "my-lib", "library.yaml"))).to be true
+        end
+      end
+    end
+  end
+
+  describe "inspect_video_paths" do
+    it "rejects nonexistent paths" do
+      Dir.mktmpdir do |root|
+        result = call(root, "inspect_video_paths", { paths: ["/no/such/file.mov"] })
+        expect(result["result"]["rejected"].first["reason"]).to eq("not_found")
+      end
+    end
+  end
+
   describe "get_or_generate_thumbnail" do
     it "returns the cached path on second call without re-shelling out" do
       Dir.mktmpdir do |root|

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_controller_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+require "json"
+require "stringio"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/notifier"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
+require_relative "../../../lib/buttercut_ui_sidecar/analysis_controller"
+
+RSpec.describe ButtercutUiSidecar::AnalysisController do
+  def make_library(root, name: "demo", videos:)
+    lib_dir = File.join(root, name)
+    FileUtils.mkdir_p(File.join(lib_dir, "transcripts"))
+    FileUtils.mkdir_p(File.join(lib_dir, "summaries"))
+    File.write(File.join(lib_dir, "library.yaml"), YAML.dump(
+                 "library_name" => name, "language" => "English", "language_code" => "en",
+                 "transcript_refinement" => false, "videos" => videos.map { |v| { "path" => v, "duration" => "00:00:05" } }
+               ))
+    lib_dir
+  end
+
+  it "runs all three stages for one video and updates library.yaml" do
+    Dir.mktmpdir do |root|
+      v = File.join(root, "a.mp4")
+      File.write(v, "x")
+      lib_dir = make_library(root, videos: [v])
+
+      io = StringIO.new
+      notifier = ButtercutUiSidecar::Notifier.new(io: io)
+      registry = ButtercutUiSidecar::JobRegistry.new
+
+      transcribe = instance_double("TranscribeStage")
+      analyze = instance_double("AnalyzeStage")
+      summarize = instance_double("SummarizeStage")
+      allow(transcribe).to receive(:run) do |args|
+        path = File.join(args[:transcript_output_dir], "a.json")
+        File.write(path, JSON.generate(segments: []))
+        { transcript_path: path }
+      end
+      allow(analyze).to receive(:run) do |args|
+        File.write(args[:visual_transcript_path], JSON.generate(segments: []))
+        { visual_transcript_path: args[:visual_transcript_path] }
+      end
+      allow(summarize).to receive(:run) do |args|
+        File.write(args[:summary_output_path], "## Overview")
+        { summary_path: args[:summary_output_path] }
+      end
+
+      controller = described_class.new(
+        libraries_root: root, notifier: notifier, registry: registry,
+        transcribe: transcribe, analyze: analyze, summarize: summarize,
+        whisper_model: "small"
+      )
+      job_id = controller.start!(library: "demo")
+
+      controller.wait!(job_id)
+
+      data = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")))
+      v0 = data["videos"].first
+      expect(v0["transcript"]).to eq("a.json")
+      expect(v0["visual_transcript"]).to eq("visual_a.json")
+      expect(v0["summary"]).to eq("summary_a.md")
+
+      events = io.string.lines.map { |l| JSON.parse(l) }
+      methods = events.map { |e| e["method"] }
+      expect(methods).to include("job_started", "file_started", "artifact_ready", "file_done", "job_done")
+    end
+  end
+
+  it "skips stages already present and still completes the job" do
+    Dir.mktmpdir do |root|
+      v = File.join(root, "a.mp4")
+      File.write(v, "x")
+      lib_dir = make_library(root, videos: [v])
+      transcripts = File.join(lib_dir, "transcripts")
+      summaries = File.join(lib_dir, "summaries")
+      File.write(File.join(transcripts, "a.json"), JSON.generate(segments: []))
+      File.write(File.join(transcripts, "visual_a.json"), JSON.generate(segments: []))
+
+      yaml = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")))
+      yaml["videos"][0]["transcript"] = "a.json"
+      yaml["videos"][0]["visual_transcript"] = "visual_a.json"
+      File.write(File.join(lib_dir, "library.yaml"), YAML.dump(yaml))
+
+      io = StringIO.new
+      notifier = ButtercutUiSidecar::Notifier.new(io: io)
+      registry = ButtercutUiSidecar::JobRegistry.new
+
+      transcribe = instance_double("TranscribeStage")
+      analyze = instance_double("AnalyzeStage")
+      summarize = instance_double("SummarizeStage")
+      allow(transcribe).to receive(:run).and_raise("transcribe should not run")
+      allow(analyze).to receive(:run).and_raise("analyze should not run")
+      allow(summarize).to receive(:run) do |args|
+        File.write(args[:summary_output_path], "## Overview")
+        { summary_path: args[:summary_output_path] }
+      end
+
+      controller = described_class.new(
+        libraries_root: root, notifier: notifier, registry: registry,
+        transcribe: transcribe, analyze: analyze, summarize: summarize,
+        whisper_model: "small"
+      )
+      job_id = controller.start!(library: "demo")
+      controller.wait!(job_id)
+
+      data = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")))
+      expect(data["videos"].first["summary"]).to eq("summary_a.md")
+
+      methods = io.string.lines.map { |l| JSON.parse(l)["method"] }
+      expect(methods).not_to include("file_failed")
+      expect(methods.count { |m| m == "file_started" }).to eq(1)
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_job_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/analysis_job_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::AnalysisJob do
+  it "starts uncanceled" do
+    job = described_class.new(id: "j1", library: "demo")
+    expect(job.canceled?).to be false
+  end
+
+  it "cancel! flips the token and is idempotent" do
+    job = described_class.new(id: "j1", library: "demo")
+    job.cancel!
+    job.cancel!
+    expect(job.canceled?).to be true
+  end
+
+  it "registers and signals child PIDs on cancel" do
+    job = described_class.new(id: "j1", library: "demo")
+    pid = Process.spawn("sleep", "60")
+    job.register_pid(pid)
+    job.cancel!
+    # Reap the child to avoid zombies; Process.wait blocks until done.
+    Process.wait(pid)
+    expect($?.success?).to be_falsey
+  end
+
+  it "registers and aborts in-flight handles on cancel" do
+    job = described_class.new(id: "j1", library: "demo")
+    aborted = false
+    handle = Object.new
+    handle.define_singleton_method(:abort!) { aborted = true }
+    job.register_abortable(handle)
+    job.cancel!
+    expect(aborted).to be true
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/anthropic_client"
+
+RSpec.describe ButtercutUiSidecar::AnthropicClient do
+  # The wrapper takes a client factory so tests can inject a fake.
+  class FakeSdk
+    def initialize(response: nil, raise_with: nil)
+      @response = response
+      @raise_with = raise_with
+      @calls = []
+    end
+    attr_reader :calls
+
+    def messages
+      self
+    end
+
+    def create(**kwargs)
+      @calls << kwargs
+      raise @raise_with if @raise_with
+      @response
+    end
+  end
+
+  it "validates a key with a 1-token Haiku ping and returns true on success" do
+    fake = FakeSdk.new(response: { "content" => [{ "type" => "text", "text" => "ok" }] })
+    client = described_class.new(api_key: "sk-test", sdk: fake)
+    expect(client.validate_key!).to be true
+    expect(fake.calls.first[:model]).to match(/haiku/i)
+    expect(fake.calls.first[:max_tokens]).to eq(1)
+  end
+
+  it "raises InvalidApiKey when the SDK raises an auth error" do
+    fake = FakeSdk.new(raise_with: described_class::FakeAuthError.new("invalid x-api-key"))
+    client = described_class.new(api_key: "sk-bad", sdk: fake, auth_error_classes: [described_class::FakeAuthError])
+    expect { client.validate_key! }.to raise_error(ButtercutUiSidecar::AnthropicClient::InvalidApiKey, /invalid/)
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/anthropic_client_spec.rb
@@ -35,4 +35,11 @@ RSpec.describe ButtercutUiSidecar::AnthropicClient do
     client = described_class.new(api_key: "sk-bad", sdk: fake, auth_error_classes: [described_class::FakeAuthError])
     expect { client.validate_key! }.to raise_error(ButtercutUiSidecar::AnthropicClient::InvalidApiKey, /invalid/)
   end
+
+  describe ".message_body_text" do
+    it "joins text blocks from a Hash-shaped response" do
+      text = described_class.message_body_text({ "content" => [{ "text" => "a" }, { "text" => "b" }] })
+      expect(text).to eq("ab")
+    end
+  end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/job_registry_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/job_registry_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
+
+RSpec.describe ButtercutUiSidecar::JobRegistry do
+  it "stores, retrieves, and removes by job_id" do
+    registry = described_class.new
+    registry.put("j1", :payload)
+    expect(registry.get("j1")).to eq(:payload)
+    registry.delete("j1")
+    expect(registry.get("j1")).to be_nil
+  end
+
+  it "is concurrent-safe" do
+    registry = described_class.new
+    threads = 32.times.map do |i|
+      Thread.new { registry.put("j#{i}", i) }
+    end
+    threads.each(&:join)
+    32.times { |i| expect(registry.get("j#{i}")).to eq(i) }
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/library_creator_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/library_creator_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/library_creator"
+
+RSpec.describe ButtercutUiSidecar::LibraryCreator do
+  def video(dir, name, duration: "00:00:05")
+    path = File.join(dir, name)
+    File.write(path, "x")
+    { path: path, duration_seconds: 5 }
+  end
+
+  it "slugifies the name and creates the directory tree + library.yaml" do
+    Dir.mktmpdir do |root|
+      Dir.mktmpdir do |footage|
+        creator = described_class.new(libraries_root: root)
+        result = creator.create!(
+          name: "My Bike Series",
+          language: "English",
+          language_code: "en",
+          refinement: true,
+          videos: [video(footage, "a.mp4"), video(footage, "b.mp4")]
+        )
+        expect(result[:name]).to eq("my-bike-series")
+
+        lib_dir = File.join(root, "my-bike-series")
+        expect(File.directory?(File.join(lib_dir, "transcripts"))).to be true
+        expect(File.directory?(File.join(lib_dir, "summaries"))).to be true
+
+        data = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")), permitted_classes: [Date, Time])
+        expect(data["library_name"]).to eq("my-bike-series")
+        expect(data["language"]).to eq("English")
+        expect(data["language_code"]).to eq("en")
+        expect(data["transcript_refinement"]).to be true
+        expect(data["videos"].length).to eq(2)
+        expect(data["videos"].first["transcript"]).to eq("")
+        expect(data["videos"].first["visual_transcript"]).to eq("")
+        expect(data["videos"].first["summary"]).to eq("")
+      end
+    end
+  end
+
+  it "errors with library_exists when the slug already has a library.yaml" do
+    Dir.mktmpdir do |root|
+      FileUtils.mkdir_p(File.join(root, "demo"))
+      File.write(File.join(root, "demo", "library.yaml"), "library_name: demo")
+      creator = described_class.new(libraries_root: root)
+      expect {
+        creator.create!(name: "Demo", language: "English", language_code: "en", refinement: false, videos: [])
+      }.to raise_error(described_class::LibraryExists)
+    end
+  end
+
+  it "rolls back on partial failure (e.g. yaml write fails)" do
+    Dir.mktmpdir do |root|
+      creator = described_class.new(libraries_root: root)
+      allow(File).to receive(:write).and_call_original
+      allow(File).to receive(:write).with(/library\.yaml/, anything).and_raise(Errno::EACCES, "denied")
+
+      expect {
+        creator.create!(name: "rollback", language: "English", language_code: "en", refinement: false, videos: [])
+      }.to raise_error(Errno::EACCES)
+
+      expect(File.directory?(File.join(root, "rollback"))).to be false
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/limits_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/limits_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/limits"
+
+RSpec.describe ButtercutUiSidecar::Limits do
+  it "matches the values declared in the SKILL.md files" do
+    expect(described_class::TRANSCRIBE_PARALLELISM).to eq(2)
+    expect(described_class::ANALYZE_PARALLELISM).to eq(8)
+    expect(described_class::SUMMARIZE_PARALLELISM).to eq(10)
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/notifier_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/notifier_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "stringio"
+require "json"
+require_relative "../../../lib/buttercut_ui_sidecar/notifier"
+
+RSpec.describe ButtercutUiSidecar::Notifier do
+  it "writes a JSON-RPC 2.0 notification (no id) and flushes" do
+    io = StringIO.new
+    described_class.new(io: io).notify("file_started", job_id: "j1", video: "a.mp4", stage: "transcribe")
+
+    line = io.string.lines.last
+    payload = JSON.parse(line)
+    expect(payload["jsonrpc"]).to eq("2.0")
+    expect(payload).not_to have_key("id")
+    expect(payload["method"]).to eq("file_started")
+    expect(payload["params"]).to include("job_id" => "j1", "video" => "a.mp4", "stage" => "transcribe")
+    expect(payload["params"]).to have_key("ts")
+  end
+
+  it "is safe to call concurrently — lines are not interleaved" do
+    io = StringIO.new
+    notifier = described_class.new(io: io)
+    threads = 16.times.map do |i|
+      Thread.new { 50.times { notifier.notify("ping", n: i) } }
+    end
+    threads.each(&:join)
+
+    io.string.each_line do |line|
+      expect { JSON.parse(line) }.not_to raise_error
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/settings_store_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/settings_store_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/settings_store"
+
+RSpec.describe ButtercutUiSidecar::SettingsStore do
+  it "prefers ENV over the YAML file" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("anthropic_api_key" => "from-yaml"))
+      store = described_class.new(libraries_root: root, env: { "ANTHROPIC_API_KEY" => "from-env" })
+      expect(store.api_key).to eq("from-env")
+    end
+  end
+
+  it "falls back to settings.yaml when ENV is unset" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("anthropic_api_key" => "from-yaml"))
+      store = described_class.new(libraries_root: root, env: {})
+      expect(store.api_key).to eq("from-yaml")
+    end
+  end
+
+  it "returns nil when neither is set" do
+    Dir.mktmpdir do |root|
+      store = described_class.new(libraries_root: root, env: {})
+      expect(store.api_key).to be_nil
+    end
+  end
+
+  it "writes the key to settings.yaml without clobbering other fields" do
+    Dir.mktmpdir do |root|
+      File.write(File.join(root, "settings.yaml"), YAML.dump("editor" => "fcpx", "whisper_model" => "small"))
+      store = described_class.new(libraries_root: root, env: {})
+      store.write_api_key!("sk-abc")
+
+      data = YAML.safe_load(File.read(File.join(root, "settings.yaml")))
+      expect(data["editor"]).to eq("fcpx")
+      expect(data["whisper_model"]).to eq("small")
+      expect(data["anthropic_api_key"]).to eq("sk-abc")
+    end
+  end
+
+  it "creates settings.yaml when missing" do
+    Dir.mktmpdir do |root|
+      store = described_class.new(libraries_root: root, env: {})
+      store.write_api_key!("sk-xyz")
+      data = YAML.safe_load(File.read(File.join(root, "settings.yaml")))
+      expect(data["anthropic_api_key"]).to eq("sk-xyz")
+    end
+  end
+
+  it "configured? reflects whether a key is available" do
+    Dir.mktmpdir do |root|
+      empty = described_class.new(libraries_root: root, env: {})
+      expect(empty.configured?).to be false
+      configured = described_class.new(libraries_root: root, env: { "ANTHROPIC_API_KEY" => "x" })
+      expect(configured.configured?).to be true
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ButtercutUiSidecar::Stages::Analyze do
       audio = setup_audio(dir)
       visual = File.join(dir, "visual_a.json")
 
-      ffmpeg = ->(_video, _ts, out_path, on_pid:) { on_pid.call(rand(2**16)); File.write(out_path, "fakejpg"); true }
+      ffmpeg = ->(_video, _ts, out_path, job:) { job.register_pid(rand(2**16)); File.write(out_path, "fakejpg"); true }
       vision = ->(_frames, _prompt) { { "segments" => [{ "start" => 0.0, "end" => 5.0, "text" => "hello", "visual" => "scene" }] } }
 
       stage = described_class.new(ffmpeg: ffmpeg, vision: vision)
@@ -37,7 +37,7 @@ RSpec.describe ButtercutUiSidecar::Stages::Analyze do
       audio = setup_audio(dir)
       visual = File.join(dir, "visual_a.json")
 
-      ffmpeg = ->(_, _, out_path, on_pid:) { on_pid.call(1); File.write(out_path, "fakejpg"); true }
+      ffmpeg = ->(_, _, out_path, job:) { job.register_pid(1); File.write(out_path, "fakejpg"); true }
       vision = ->(_, _) { raise "should not call vision" }
 
       stage = described_class.new(ffmpeg: ffmpeg, vision: vision)

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/analyze_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/analyze"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Analyze do
+  let(:job) { ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo") }
+
+  def setup_audio(dir, name: "a.json")
+    path = File.join(dir, name)
+    File.write(path, JSON.generate(language: "en", video_path: "/x/a.mp4",
+      segments: [{ start: 0.0, end: 5.0, text: "hello", words: [] }]))
+    path
+  end
+
+  it "writes the visual transcript with model-supplied descriptions" do
+    Dir.mktmpdir do |dir|
+      audio = setup_audio(dir)
+      visual = File.join(dir, "visual_a.json")
+
+      ffmpeg = ->(_video, _ts, out_path, on_pid:) { on_pid.call(rand(2**16)); File.write(out_path, "fakejpg"); true }
+      vision = ->(_frames, _prompt) { { "segments" => [{ "start" => 0.0, "end" => 5.0, "text" => "hello", "visual" => "scene" }] } }
+
+      stage = described_class.new(ffmpeg: ffmpeg, vision: vision)
+      result = stage.run(job: job, video_path: "/x/a.mp4", audio_transcript_path: audio, visual_transcript_path: visual)
+
+      expect(result[:visual_transcript_path]).to eq(visual)
+      expect(File.file?(visual)).to be true
+      data = JSON.parse(File.read(visual))
+      expect(data["segments"].first["visual"]).to eq("scene")
+    end
+  end
+
+  it "respects cancellation between frame extraction and vision call" do
+    Dir.mktmpdir do |dir|
+      audio = setup_audio(dir)
+      visual = File.join(dir, "visual_a.json")
+
+      ffmpeg = ->(_, _, out_path, on_pid:) { on_pid.call(1); File.write(out_path, "fakejpg"); true }
+      vision = ->(_, _) { raise "should not call vision" }
+
+      stage = described_class.new(ffmpeg: ffmpeg, vision: vision)
+      job.cancel!
+      result = stage.run(job: job, video_path: "/x/a.mp4", audio_transcript_path: audio, visual_transcript_path: visual)
+      expect(result[:canceled]).to be true
+      expect(File.file?(visual)).to be false
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/summarize_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/summarize_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/summarize"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Summarize do
+  it "writes the markdown summary atomically using the supplied Haiku callable" do
+    Dir.mktmpdir do |dir|
+      visual = File.join(dir, "visual_a.json")
+      File.write(visual, JSON.generate(language: "en", video_path: "/x/a.mp4", segments: [
+        { start: 0.0, end: 5.0, text: "hello", visual: "scene" }
+      ]))
+      summary_path = File.join(dir, "summary_a.md")
+
+      haiku = ->(_prompt) { "## Overview\n\nMan says hello.\n\n## Key visuals\n- scene\n\n## Dialogue\n\nNone\n\n## B-roll\n\nNone\n" }
+      stage = described_class.new(haiku: haiku)
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+
+      result = stage.run(job: job, visual_transcript_path: visual, summary_output_path: summary_path)
+      expect(result[:summary_path]).to eq(summary_path)
+      expect(File.read(summary_path)).to include("## Overview")
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ButtercutUiSidecar::Stages::Transcribe do
       FileUtils.mkdir_p(transcript_dir)
       expected_output = File.join(transcript_dir, "tiny.json")
 
-      shell = lambda do |argv, on_pid:|
-        on_pid.call(12345)
+      shell = lambda do |_argv, job:|
+        job.register_pid(12_345)
         # simulate whisperx writing the file
         File.write(expected_output, JSON.generate({ language: "en", segments: [] }))
         [true, ""]
@@ -41,7 +41,7 @@ RSpec.describe ButtercutUiSidecar::Stages::Transcribe do
     Dir.mktmpdir do |dir|
       video = File.join(dir, "v.mp4"); File.write(video, "x")
       transcript_dir = File.join(dir, "transcripts"); FileUtils.mkdir_p(transcript_dir)
-      shell = ->(_argv, on_pid:) { on_pid.call(1); [false, "boom"] }
+      shell = ->(_argv, job:) { job.register_pid(1); [false, "boom"] }
       stage = described_class.new(shell: shell, prepare: ->(*) {})
       job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
       expect {

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/stages/transcribe_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../../lib/buttercut_ui_sidecar/stages/transcribe"
+require_relative "../../../../lib/buttercut_ui_sidecar/analysis_job"
+
+RSpec.describe ButtercutUiSidecar::Stages::Transcribe do
+  it "runs whisperx, prepares the JSON, registers the PID for cancellation" do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "tiny.mp4")
+      File.write(video, "x")
+      transcript_dir = File.join(dir, "transcripts")
+      FileUtils.mkdir_p(transcript_dir)
+      expected_output = File.join(transcript_dir, "tiny.json")
+
+      shell = lambda do |argv, on_pid:|
+        on_pid.call(12345)
+        # simulate whisperx writing the file
+        File.write(expected_output, JSON.generate({ language: "en", segments: [] }))
+        [true, ""]
+      end
+      prep = ->(_path, _video) { } # no-op; output already valid
+
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+      stage = described_class.new(shell: shell, prepare: prep)
+
+      result = stage.run(
+        job: job,
+        video_path: video,
+        transcript_output_dir: transcript_dir,
+        language_code: "en",
+        whisper_model: "small"
+      )
+
+      expect(result[:transcript_path]).to eq(expected_output)
+      expect(File.file?(expected_output)).to be true
+    end
+  end
+
+  it "raises if whisperx returns failure" do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "v.mp4"); File.write(video, "x")
+      transcript_dir = File.join(dir, "transcripts"); FileUtils.mkdir_p(transcript_dir)
+      shell = ->(_argv, on_pid:) { on_pid.call(1); [false, "boom"] }
+      stage = described_class.new(shell: shell, prepare: ->(*) {})
+      job = ButtercutUiSidecar::AnalysisJob.new(id: "j1", library: "demo")
+      expect {
+        stage.run(job: job, video_path: video, transcript_output_dir: transcript_dir,
+                  language_code: "en", whisper_model: "small")
+      }.to raise_error(/whisperx failed/)
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/video_inspector_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "tmpdir"
+require_relative "../../../lib/buttercut_ui_sidecar/video_inspector"
+
+RSpec.describe ButtercutUiSidecar::VideoInspector do
+  it "rejects paths that do not exist" do
+    result = described_class.new.inspect(["/no/such/file.mov"])
+    expect(result[:accepted]).to be_empty
+    expect(result[:rejected].first[:reason]).to eq("not_found")
+  end
+
+  it "rejects non-video files", skip: !system("which ffprobe > /dev/null 2>&1") do
+    Dir.mktmpdir do |dir|
+      txt = File.join(dir, "notes.txt")
+      File.write(txt, "hello")
+      result = described_class.new.inspect([txt])
+      expect(result[:rejected].first[:reason]).to eq("not_video")
+    end
+  end
+
+  it "accepts a real video and returns duration_seconds + size_bytes",
+     skip: !system("which ffmpeg > /dev/null 2>&1 && which ffprobe > /dev/null 2>&1") do
+    Dir.mktmpdir do |dir|
+      video = File.join(dir, "tiny.mp4")
+      system("ffmpeg -y -loglevel error -f lavfi -i color=c=red:s=64x64:d=2 -pix_fmt yuv420p #{video}")
+      result = described_class.new.inspect([video])
+      expect(result[:accepted].first[:path]).to eq(video)
+      expect(result[:accepted].first[:duration_seconds]).to be > 0
+      expect(result[:accepted].first[:size_bytes]).to be > 0
+    end
+  end
+end

--- a/ui/src-tauri/Cargo.lock
+++ b/ui/src-tauri/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tokio",
  "urlencoding",
@@ -2239,6 +2240,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2827,6 +2829,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3510,6 +3536,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4623,6 +4691,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4654,11 +4731,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4692,6 +4786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4702,6 +4802,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4716,10 +4822,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4734,6 +4852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4868,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4758,6 +4888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4768,6 +4904,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "process", "sync", "macros", "rt-multi-thread", "time"] }

--- a/ui/src-tauri/capabilities/default.json
+++ b/ui/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:event:default",
+    "dialog:allow-open",
     "opener:default",
     "core:webview:allow-create-webview-window",
     "core:window:allow-set-title"

--- a/ui/src-tauri/capabilities/default.json
+++ b/ui/src-tauri/capabilities/default.json
@@ -2,9 +2,10 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capabilities for all ButterCut windows",
-  "windows": ["main", "library-*"],
+  "windows": ["main", "library-*", "new-project"],
   "permissions": [
     "core:default",
+    "core:event:default",
     "opener:default",
     "core:webview:allow-create-webview-window",
     "core:window:allow-set-title"

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -154,6 +154,7 @@ fn sanitize_label(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             let (ruby_bin, sidecar_script, libraries_root) = resolve_sidecar_paths()?;
 

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -46,6 +46,77 @@ async fn allow_video_paths(app: tauri::AppHandle, root: String) -> Result<(), St
 }
 
 #[tauri::command]
+async fn inspect_video_paths(paths: Vec<String>) -> Result<Value, String> {
+    sidecar::call("inspect_video_paths", json!({ "paths": paths }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn create_library(
+    name: String,
+    language: String,
+    language_code: String,
+    refinement: bool,
+    videos: Value,
+) -> Result<Value, String> {
+    sidecar::call(
+        "create_library",
+        json!({
+            "name": name,
+            "language": language,
+            "language_code": language_code,
+            "refinement": refinement,
+            "videos": videos
+        }),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn has_api_key() -> Result<Value, String> {
+    sidecar::call("has_api_key", json!({})).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn set_api_key(key: String) -> Result<Value, String> {
+    sidecar::call("set_api_key", json!({ "key": key }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn start_analysis(library: String) -> Result<Value, String> {
+    sidecar::call("start_analysis", json!({ "library": library }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn cancel_job(job_id: String) -> Result<Value, String> {
+    sidecar::call("cancel_job", json!({ "job_id": job_id }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn open_new_project_window(app: tauri::AppHandle) -> Result<(), String> {
+    let label = "new-project";
+    if let Some(existing) = app.get_webview_window(label) {
+        existing.set_focus().map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(&app, label, WebviewUrl::App("index.html#/new-project".into()))
+        .title("New Project")
+        .inner_size(880.0, 720.0)
+        .min_inner_size(640.0, 540.0)
+        .build()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
 async fn open_library_window(app: tauri::AppHandle, name: String) -> Result<(), String> {
     let label = library_window_label(&name);
 
@@ -92,9 +163,15 @@ pub fn run() {
             app.asset_protocol_scope()
                 .allow_directory(&libraries_root, true)?;
 
+            let app_handle = app.handle().clone();
             // tokio::process::Command needs a running reactor; setup() runs before one exists.
             tauri::async_runtime::block_on(async move {
-                sidecar::init(ruby_bin, sidecar_script, libraries_root)
+                sidecar::init(
+                    app_handle,
+                    ruby_bin,
+                    sidecar_script,
+                    libraries_root,
+                )
             })?;
             Ok(())
         })
@@ -104,7 +181,14 @@ pub fn run() {
             get_clip_transcripts,
             get_or_generate_thumbnail,
             allow_video_paths,
-            open_library_window
+            open_library_window,
+            open_new_project_window,
+            inspect_video_paths,
+            create_library,
+            has_api_key,
+            set_api_key,
+            start_analysis,
+            cancel_job
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ui/src-tauri/src/sidecar.rs
+++ b/ui/src-tauri/src/sidecar.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::{oneshot, Mutex};
@@ -81,7 +82,15 @@ struct RpcError {
     message: String,
 }
 
+#[derive(Deserialize)]
+struct Notification {
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
 pub fn init(
+    app: tauri::AppHandle,
     ruby_bin: PathBuf,
     sidecar_script: PathBuf,
     libraries_root: PathBuf,
@@ -101,6 +110,7 @@ pub fn init(
     let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value, SidecarError>>>>> =
         Arc::new(Mutex::new(HashMap::new()));
     let pending_for_reader = pending.clone();
+    let app_for_reader = app.clone();
 
     tokio::spawn(async move {
         let mut reader = BufReader::new(stdout).lines();
@@ -111,8 +121,8 @@ pub fn init(
                         continue;
                     }
                     match serde_json::from_str::<Response>(&line) {
-                        Ok(resp) => {
-                            let Some(id) = resp.id else { continue };
+                        Ok(resp) if resp.id.is_some() => {
+                            let id = resp.id.unwrap();
                             let mut map = pending_for_reader.lock().await;
                             if let Some(tx) = map.remove(&id) {
                                 let payload = if let Some(err) = resp.error {
@@ -123,9 +133,23 @@ pub fn init(
                                 let _ = tx.send(payload);
                             }
                         }
-                        Err(e) => {
-                            eprintln!("[sidecar] parse error: {e}: {line}");
-                        }
+                        _ => match serde_json::from_str::<Notification>(&line) {
+                            Ok(n) => {
+                                let job_id = n.params.get("job_id").and_then(|v| v.as_str()).unwrap_or("");
+                                let event_name = if job_id.is_empty() {
+                                    "sidecar-event".to_string()
+                                } else {
+                                    format!("sidecar-event:{job_id}")
+                                };
+                                let payload = serde_json::json!({ "method": n.method, "params": n.params });
+                                if let Err(e) = app_for_reader.emit(&event_name, payload) {
+                                    eprintln!("[sidecar] emit error: {e}");
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("[sidecar] parse error: {e}: {line}");
+                            }
+                        },
                     }
                 }
                 Ok(None) => break,

--- a/ui/src/ipc/events.ts
+++ b/ui/src/ipc/events.ts
@@ -1,0 +1,32 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type StageName = "transcribe" | "analyze" | "summarize";
+
+export type JobEvent =
+  | { method: "job_started"; params: { job_id: string; library: string; video_count: number; ts: string } }
+  | { method: "file_started"; params: { job_id: string; video: string; stage: StageName; ts: string } }
+  | {
+      method: "file_progress";
+      params: { job_id: string; video: string; stage: StageName; message?: string; percent?: number; ts: string };
+    }
+  | {
+      method: "artifact_ready";
+      params: { job_id: string; video: string; stage: StageName; artifact_path: string; ts: string };
+    }
+  | {
+      method: "file_failed";
+      params: { job_id: string; video: string; stage: StageName; error_kind: string; message: string; ts: string };
+    }
+  | { method: "file_done"; params: { job_id: string; video: string; stage: StageName; ts: string } }
+  | {
+      method: "job_done";
+      params: { job_id: string; succeeded_count: number; failed_count: number; ts: string };
+    }
+  | {
+      method: "job_canceled";
+      params: { job_id: string; succeeded_count: number; failed_count: number; ts: string };
+    };
+
+export async function listenJobEvents(jobId: string, handler: (event: JobEvent) => void): Promise<UnlistenFn> {
+  return listen<JobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+}

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -30,3 +30,62 @@ export async function getOrGenerateThumbnail(library: string, video: string): Pr
 export async function allowVideoPaths(root: string): Promise<void> {
   await invoke("allow_video_paths", { root });
 }
+
+export interface AcceptedVideo {
+  path: string;
+  duration_seconds: number;
+  size_bytes: number;
+}
+
+export interface RejectedVideo {
+  path: string;
+  reason: "not_found" | "not_video" | "zero_duration";
+}
+
+export interface InspectResult {
+  accepted: AcceptedVideo[];
+  rejected: RejectedVideo[];
+}
+
+export async function inspectVideoPaths(paths: string[]): Promise<InspectResult> {
+  return invoke<InspectResult>("inspect_video_paths", { paths });
+}
+
+export async function hasApiKey(): Promise<{ configured: boolean }> {
+  return invoke<{ configured: boolean }>("has_api_key");
+}
+
+export async function setApiKey(key: string): Promise<{ ok: true }> {
+  return invoke<{ ok: true }>("set_api_key", { key });
+}
+
+export interface CreateLibraryArgs {
+  name: string;
+  language: string;
+  language_code: string;
+  refinement: boolean;
+  videos: AcceptedVideo[];
+}
+
+export async function createLibrary(args: CreateLibraryArgs): Promise<{ name: string }> {
+  const { name, language, language_code, refinement, videos } = args;
+  return invoke<{ name: string }>("create_library", {
+    name,
+    language,
+    language_code,
+    refinement,
+    videos,
+  });
+}
+
+export async function startAnalysis(library: string): Promise<{ job_id: string }> {
+  return invoke<{ job_id: string }>("start_analysis", { library });
+}
+
+export async function cancelJob(jobId: string): Promise<void> {
+  await invoke("cancel_job", { job_id: jobId });
+}
+
+export async function openNewProjectWindow(): Promise<void> {
+  await invoke("open_new_project_window");
+}

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -69,10 +69,11 @@ export interface CreateLibraryArgs {
 
 export async function createLibrary(args: CreateLibraryArgs): Promise<{ name: string }> {
   const { name, language, language_code, refinement, videos } = args;
+  // Tauri maps Rust snake_case params to camelCase invoke keys.
   return invoke<{ name: string }>("create_library", {
     name,
     language,
-    language_code,
+    languageCode: language_code,
     refinement,
     videos,
   });
@@ -83,7 +84,7 @@ export async function startAnalysis(library: string): Promise<{ job_id: string }
 }
 
 export async function cancelJob(jobId: string): Promise<void> {
-  await invoke("cancel_job", { job_id: jobId });
+  await invoke("cancel_job", { jobId });
 }
 
 export async function openNewProjectWindow(): Promise<void> {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,16 +3,20 @@ import ReactDOM from "react-dom/client";
 import "./styles/theme.css";
 import Projects from "./routes/projects";
 import Library from "./routes/library";
+import NewProject from "./routes/new-project";
 
 function pickRoute() {
   const hash = window.location.hash || "";
-  const match = hash.match(/^#\/library\/(.+)$/);
-  if (match) {
+  const lib = hash.match(/^#\/library\/(.+)$/);
+  if (lib) {
     try {
-      return <Library name={decodeURIComponent(match[1])} />;
+      return <Library name={decodeURIComponent(lib[1])} />;
     } catch {
       return <Projects />;
     }
+  }
+  if (hash === "#/new-project") {
+    return <NewProject />;
   }
   return <Projects />;
 }

--- a/ui/src/routes/new-project/api-key-modal.tsx
+++ b/ui/src/routes/new-project/api-key-modal.tsx
@@ -33,7 +33,9 @@ export function ApiKeyModal({ onClose, onSaved }: { onClose: () => void; onSaved
             Get a key →
           </a>
         </p>
+        <label htmlFor="anthropic-api-key">API key</label>
         <input
+          id="anthropic-api-key"
           type="password"
           value={key}
           onChange={(e) => setKey(e.target.value)}

--- a/ui/src/routes/new-project/api-key-modal.tsx
+++ b/ui/src/routes/new-project/api-key-modal.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { setApiKey } from "../../ipc/sidecar";
+
+function errMsg(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+export function ApiKeyModal({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+  const [key, setKey] = useState("");
+  const [status, setStatus] = useState<"idle" | "validating" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    setStatus("validating");
+    setError(null);
+    try {
+      await setApiKey(key);
+      onSaved();
+    } catch (e) {
+      setStatus("error");
+      setError(errMsg(e));
+    }
+  }
+
+  return (
+    <div className="np-modal-backdrop">
+      <div className="np-modal">
+        <h3>Connect your Anthropic API key</h3>
+        <p>
+          ButterCut uses Claude to analyze footage.{" "}
+          <a href="https://console.anthropic.com" target="_blank" rel="noreferrer">
+            Get a key →
+          </a>
+        </p>
+        <input
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="sk-ant-…"
+          autoFocus
+        />
+        {error ? <p className="np-error">{error}</p> : null}
+        <div className="np-modal-buttons">
+          <button type="button" onClick={onClose} disabled={status === "validating"}>
+            Cancel
+          </button>
+          <button type="button" onClick={() => void save()} disabled={!key || status === "validating"}>
+            {status === "validating" ? "Validating…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/routes/new-project/index.tsx
+++ b/ui/src/routes/new-project/index.tsx
@@ -1,12 +1,110 @@
+import { useEffect, useReducer, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { initialSetup, setupReducer, type StepId } from "./state";
+import { PickFootage } from "./steps/pick-footage";
+import { Name } from "./steps/name";
+import { Language } from "./steps/language";
+import { Refinement } from "./steps/refinement";
+import { Confirm } from "./steps/confirm";
+import { ApiKeyModal } from "./api-key-modal";
+import { ProgressView } from "./progress/progress-view";
+import { createLibrary, hasApiKey, startAnalysis } from "../../ipc/sidecar";
 import "./new-project.css";
 
+const STEPS: StepId[] = ["footage", "name", "language", "refinement", "confirm"];
+
+function errMsg(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
 export default function NewProject() {
+  const [state, dispatch] = useReducer(setupReducer, initialSetup);
+  const [phase, setPhase] = useState<"setup" | "progress">("setup");
+  const [job, setJob] = useState<{ id: string; library: string } | null>(null);
+  const [keyConfigured, setKeyConfigured] = useState(false);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    hasApiKey()
+      .then((r) => setKeyConfigured(r.configured))
+      .catch(() => setKeyConfigured(false));
+  }, []);
+
+  const idx = STEPS.indexOf(state.step);
+  const goNext = () => dispatch({ type: "go_step", step: STEPS[Math.min(STEPS.length - 1, idx + 1)] });
+  const goBack = () => dispatch({ type: "go_step", step: STEPS[Math.max(0, idx - 1)] });
+
+  async function start() {
+    setError(null);
+    try {
+      const { name } = await createLibrary({
+        name: state.name,
+        language: state.language.name,
+        language_code: state.language.code,
+        refinement: state.refinement,
+        videos: state.accepted,
+      });
+      const { job_id } = await startAnalysis(name);
+      setJob({ id: job_id, library: name });
+      setPhase("progress");
+    } catch (e) {
+      setError(errMsg(e));
+    }
+  }
+
+  if (phase === "progress" && job) {
+    return (
+      <ProgressView
+        key={job.id}
+        jobId={job.id}
+        library={job.library}
+        onComplete={() => void getCurrentWindow().close()}
+        onRestartJob={(newId) => setJob({ id: newId, library: job.library })}
+      />
+    );
+  }
+
   return (
-    <main className="new-project">
-      <header className="new-project__header">
-        <h1 className="new-project__title">New project</h1>
-        <p className="new-project__subtitle">Setup wizard and analysis progress will land here (M2).</p>
-      </header>
+    <main className="np">
+      <nav className="np-breadcrumb" aria-label="Setup steps">
+        {STEPS.map((s, i) => (
+          <span key={s} className={"np-breadcrumb__item" + (i === idx ? " np-breadcrumb__item--active" : "")}>
+            {i + 1}. {s}
+          </span>
+        ))}
+      </nav>
+
+      {state.step === "footage" ? <PickFootage state={state} dispatch={dispatch} onNext={goNext} /> : null}
+      {state.step === "name" ? <Name state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} /> : null}
+      {state.step === "language" ? (
+        <Language state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} />
+      ) : null}
+      {state.step === "refinement" ? (
+        <Refinement state={state} dispatch={dispatch} onBack={goBack} onNext={goNext} />
+      ) : null}
+      {state.step === "confirm" ? (
+        <Confirm
+          state={state}
+          apiKeyConfigured={keyConfigured}
+          onBack={goBack}
+          onStart={() => void start()}
+          onSetupKey={() => setShowKeyModal(true)}
+        />
+      ) : null}
+
+      {error ? <p className="np-error np-error--global">{error}</p> : null}
+
+      {showKeyModal ? (
+        <ApiKeyModal
+          onClose={() => setShowKeyModal(false)}
+          onSaved={() => {
+            setShowKeyModal(false);
+            setKeyConfigured(true);
+          }}
+        />
+      ) : null}
     </main>
   );
 }

--- a/ui/src/routes/new-project/index.tsx
+++ b/ui/src/routes/new-project/index.tsx
@@ -89,7 +89,7 @@ export default function NewProject() {
           state={state}
           apiKeyConfigured={keyConfigured}
           onBack={goBack}
-          onStart={() => void start()}
+          onStart={start}
           onSetupKey={() => setShowKeyModal(true)}
         />
       ) : null}

--- a/ui/src/routes/new-project/index.tsx
+++ b/ui/src/routes/new-project/index.tsx
@@ -1,0 +1,12 @@
+import "./new-project.css";
+
+export default function NewProject() {
+  return (
+    <main className="new-project">
+      <header className="new-project__header">
+        <h1 className="new-project__title">New project</h1>
+        <p className="new-project__subtitle">Setup wizard and analysis progress will land here (M2).</p>
+      </header>
+    </main>
+  );
+}

--- a/ui/src/routes/new-project/jobReducer.ts
+++ b/ui/src/routes/new-project/jobReducer.ts
@@ -29,9 +29,10 @@ export function jobReducer(state: JobState, evt: JobReducerAction): JobState {
   switch (evt.method) {
     case "job_started":
       return {
-        ...state,
         job_id: evt.params.job_id,
-        totals: { ...state.totals, total: evt.params.video_count },
+        videos: {},
+        totals: { done: 0, failed: 0, total: evt.params.video_count },
+        status: "running",
       };
     case "file_started":
       return updateClip(state, evt.params.video, (c) => ({

--- a/ui/src/routes/new-project/jobReducer.ts
+++ b/ui/src/routes/new-project/jobReducer.ts
@@ -1,0 +1,95 @@
+import type { JobEvent, StageName } from "../../ipc/events";
+
+export type StageState = "idle" | "queued" | "in_progress" | "done" | "failed";
+
+export interface ClipState {
+  video: string;
+  stages: Record<StageName, StageState>;
+  failure?: { stage: StageName; message: string; error_kind: string };
+  artifacts: Partial<Record<StageName, string>>;
+}
+
+export interface JobState {
+  job_id: string | null;
+  videos: Record<string, ClipState>;
+  totals: { done: number; failed: number; total: number };
+  status: "running" | "canceling" | "canceled" | "complete";
+}
+
+export const initialJobState: JobState = {
+  job_id: null,
+  videos: {},
+  totals: { done: 0, failed: 0, total: 0 },
+  status: "running",
+};
+
+export type JobReducerAction = JobEvent | { method: "_internal_canceling" };
+
+export function jobReducer(state: JobState, evt: JobReducerAction): JobState {
+  switch (evt.method) {
+    case "job_started":
+      return {
+        ...state,
+        job_id: evt.params.job_id,
+        totals: { ...state.totals, total: evt.params.video_count },
+      };
+    case "file_started":
+      return updateClip(state, evt.params.video, (c) => ({
+        ...c,
+        stages: { ...c.stages, [evt.params.stage]: "in_progress" },
+      }));
+    case "file_done":
+      return updateClip(state, evt.params.video, (c) => ({
+        ...c,
+        stages: { ...c.stages, [evt.params.stage]: "done" },
+      }));
+    case "artifact_ready":
+      return updateClip(state, evt.params.video, (c) => ({
+        ...c,
+        artifacts: { ...c.artifacts, [evt.params.stage]: evt.params.artifact_path },
+      }));
+    case "file_failed":
+      return updateClip(state, evt.params.video, (c) => ({
+        ...c,
+        stages: { ...c.stages, [evt.params.stage]: "failed" },
+        failure: {
+          stage: evt.params.stage,
+          message: evt.params.message,
+          error_kind: evt.params.error_kind,
+        },
+      }));
+    case "job_done":
+      return {
+        ...state,
+        status: "complete",
+        totals: {
+          ...state.totals,
+          done: evt.params.succeeded_count,
+          failed: evt.params.failed_count,
+        },
+      };
+    case "job_canceled":
+      return {
+        ...state,
+        status: "canceled",
+        totals: {
+          ...state.totals,
+          done: evt.params.succeeded_count,
+          failed: evt.params.failed_count,
+        },
+      };
+    case "_internal_canceling":
+      return { ...state, status: "canceling" };
+    case "file_progress":
+      return state;
+  }
+}
+
+function updateClip(state: JobState, video: string, fn: (c: ClipState) => ClipState): JobState {
+  const existing = state.videos[video] ?? {
+    video,
+    stages: { transcribe: "idle", analyze: "idle", summarize: "idle" },
+    artifacts: {},
+  };
+  return { ...state, videos: { ...state.videos, [video]: fn(existing) } };
+}

--- a/ui/src/routes/new-project/new-project.css
+++ b/ui/src/routes/new-project/new-project.css
@@ -1,0 +1,27 @@
+.new-project {
+  min-height: 100vh;
+  padding: 2rem 2.5rem;
+  background: var(--color-stage, #14141a);
+  color: var(--color-text, #e8e6e3);
+}
+
+.new-project__header {
+  max-width: 40rem;
+}
+
+.new-project__title {
+  font-family: "EB Garamond", Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+  font-size: 2rem;
+  margin: 0 0 0.5rem;
+  color: var(--color-accent, #e0a55a);
+}
+
+.new-project__subtitle {
+  margin: 0;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.85rem;
+  opacity: 0.85;
+  line-height: 1.5;
+}

--- a/ui/src/routes/new-project/new-project.css
+++ b/ui/src/routes/new-project/new-project.css
@@ -1,27 +1,431 @@
-.new-project {
+:root {
+  --np-bg: #14141a;
+  --np-fg: #e7e5e0;
+  --np-muted: #8b8a86;
+  --np-amber: #e0a55a;
+  --np-red: #c87272;
+  --np-line: #2a2a32;
+}
+
+.np {
+  padding: 32px;
+  color: var(--np-fg);
+  background: var(--np-bg);
   min-height: 100vh;
-  padding: 2rem 2.5rem;
-  background: var(--color-stage, #14141a);
-  color: var(--color-text, #e8e6e3);
+  font-family: var(--mono, "JetBrains Mono", ui-monospace, monospace);
 }
 
-.new-project__header {
-  max-width: 40rem;
+.np-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 32px;
+  color: var(--np-muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.new-project__title {
-  font-family: "EB Garamond", Georgia, serif;
+.np-breadcrumb__item--active {
+  color: var(--np-amber);
+}
+
+.np-step h2 {
+  font-family: var(--display, "EB Garamond", Georgia, serif);
   font-style: italic;
   font-weight: 400;
-  font-size: 2rem;
-  margin: 0 0 0.5rem;
-  color: var(--color-accent, #e0a55a);
+  font-size: 32px;
+  margin-top: 0;
 }
 
-.new-project__subtitle {
+.np-step input[type="text"],
+.np-step input:not([type]) {
+  width: 100%;
+  max-width: 28rem;
+  padding: 10px 12px;
+  margin-top: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  color: var(--np-fg);
+  font: inherit;
+}
+
+.np-dropzone {
+  border: 2px dashed var(--np-amber);
+  padding: 48px 32px;
+  text-align: center;
+  border-radius: 6px;
+}
+
+.np-dropzone__hint {
+  font-size: 11px;
+  color: var(--np-muted);
+  margin: 12px 0 0;
+  line-height: 1.4;
+}
+
+.np-dropzone__buttons {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.np-filelist {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0;
+}
+
+.np-filelist li {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--np-line);
+}
+
+.np-filelist__remove {
+  margin-left: auto;
+  background: transparent;
+  color: var(--np-muted);
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.np-rejected {
+  margin: 8px 0;
+  color: var(--np-amber);
+}
+
+.np-footer {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.np-footer button {
+  padding: 8px 20px;
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+}
+
+.np-footer button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.np-cards {
+  display: flex;
+  gap: 12px;
+  margin: 16px 0;
+  flex-wrap: wrap;
+}
+
+.np-cards--stack {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.np-card {
+  padding: 16px 20px;
+  border: 1px solid var(--np-line);
+  background: transparent;
+  color: var(--np-fg);
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+}
+
+.np-card--active {
+  border-color: var(--np-amber);
+}
+
+.np-card__sub {
+  display: block;
+  font-size: 12px;
+  color: var(--np-muted);
+  font-weight: 400;
+  margin-top: 6px;
+}
+
+.np-other {
+  display: block;
+  margin-top: 12px;
+}
+
+.np-summary {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0;
+}
+
+.np-summary li {
+  padding: 4px 0;
+}
+
+.np-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  background: rgba(224, 165, 90, 0.08);
+  padding: 12px 16px;
+  border-left: 2px solid var(--np-amber);
+  margin: 16px 0;
+}
+
+.np-banner button {
+  padding: 6px 14px;
+  border: 1px solid var(--np-amber);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--np-amber);
+  cursor: pointer;
+}
+
+.np-error {
+  color: var(--np-red);
+}
+
+.np-error--global {
+  margin-top: 16px;
+}
+
+.np-slug {
+  color: var(--np-muted);
+}
+
+.np-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.np-modal {
+  background: var(--np-bg);
+  border: 1px solid var(--np-line);
+  padding: 24px;
+  border-radius: 6px;
+  width: min(480px, 92vw);
+}
+
+.np-modal input[type="password"] {
+  width: 100%;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  color: var(--np-fg);
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.np-modal-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.np-modal-buttons button {
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--np-line);
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  color: var(--np-fg);
+}
+
+.np-progress {
+  padding: 32px;
+  color: var(--np-fg);
+  background: var(--np-bg);
+  min-height: 100vh;
+  box-sizing: border-box;
+}
+
+.np-progress__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.np-progress__header h2 {
+  font-family: var(--display, "EB Garamond", Georgia, serif);
+  font-style: italic;
+  font-weight: 400;
   margin: 0;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.85rem;
-  opacity: 0.85;
-  line-height: 1.5;
+}
+
+.np-progress__header button {
+  padding: 8px 16px;
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--np-fg);
+  cursor: pointer;
+}
+
+.np-progress__bar {
+  height: 4px;
+  background: var(--np-line);
+  margin: 16px 0 4px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.np-progress__bar > div {
+  height: 4px;
+  background: var(--np-amber);
+  transition: width 0.4s ease;
+  border-radius: 2px;
+}
+
+.np-progress__count {
+  color: var(--np-muted);
+  font-size: 12px;
+}
+
+.np-progress__failed {
+  color: var(--np-red);
+}
+
+.np-progress__list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+}
+
+.np-row {
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  margin: 8px 0;
+  overflow: hidden;
+}
+
+.np-row__head {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  color: var(--np-fg);
+  border: none;
+  cursor: pointer;
+  flex-wrap: wrap;
+}
+
+.np-row__name {
+  flex: 1;
+  text-align: left;
+  font-family: var(--mono, "JetBrains Mono", monospace);
+  font-size: 13px;
+}
+
+.np-chip {
+  font-size: 11px;
+  color: var(--np-muted);
+}
+
+.np-chip--in_progress {
+  color: var(--np-amber);
+  animation: np-pulse 1.6s ease-in-out infinite;
+}
+
+.np-chip--done {
+  color: var(--np-amber);
+}
+
+.np-chip--failed {
+  color: var(--np-red);
+}
+
+@keyframes np-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.np-row__body {
+  padding: 12px 16px;
+  border-top: 1px solid var(--np-line);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.np-failure pre {
+  color: var(--np-red);
+  white-space: pre-wrap;
+  font-size: 12px;
+}
+
+.np-failure-buttons {
+  margin-top: 8px;
+}
+
+.np-failure-buttons button {
+  padding: 6px 12px;
+  border: 1px solid var(--np-line);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--np-fg);
+  cursor: pointer;
+}
+
+.np-preview pre {
+  white-space: pre-wrap;
+  color: var(--np-muted);
+  font-size: 12px;
+}
+
+.np-md {
+  font-family: inherit;
+}
+
+.np-preview h4 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--np-muted);
+}
+
+.np-progress__footer {
+  margin-top: 32px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.np-progress__footer button {
+  padding: 10px 20px;
+  border-radius: 4px;
+  border: 1px solid var(--np-amber);
+  background: rgba(224, 165, 90, 0.12);
+  color: var(--np-amber);
+  cursor: pointer;
+}
+
+.np-progress__close {
+  border-color: var(--np-line) !important;
+  background: transparent !important;
+  color: var(--np-muted) !important;
 }

--- a/ui/src/routes/new-project/progress/artifact-preview.tsx
+++ b/ui/src/routes/new-project/progress/artifact-preview.tsx
@@ -11,8 +11,10 @@ export function ArtifactPreview({ clip, library }: { clip: ClipState; library: s
   });
 
   useEffect(() => {
+    let cancelled = false;
     getClipTranscripts(library, clip.video)
       .then((t: ClipTranscripts) => {
+        if (cancelled) return;
         setData({
           audio: previewAudio(t.audio),
           visual: previewVisual(t.visual),
@@ -20,6 +22,9 @@ export function ArtifactPreview({ clip, library }: { clip: ClipState; library: s
         });
       })
       .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [clip.artifacts.transcribe, clip.artifacts.analyze, clip.artifacts.summarize, library, clip.video]);
 
   return (

--- a/ui/src/routes/new-project/progress/artifact-preview.tsx
+++ b/ui/src/routes/new-project/progress/artifact-preview.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { getClipTranscripts } from "../../../ipc/sidecar";
+import type { ClipTranscripts } from "../../library/types";
+import type { ClipState } from "../jobReducer";
+
+export function ArtifactPreview({ clip, library }: { clip: ClipState; library: string }) {
+  const [data, setData] = useState<{ audio: string | null; visual: string | null; summary: string | null }>({
+    audio: null,
+    visual: null,
+    summary: null,
+  });
+
+  useEffect(() => {
+    getClipTranscripts(library, clip.video)
+      .then((t: ClipTranscripts) => {
+        setData({
+          audio: previewAudio(t.audio),
+          visual: previewVisual(t.visual),
+          summary: t.summary ?? null,
+        });
+      })
+      .catch(() => {});
+  }, [clip.artifacts.transcribe, clip.artifacts.analyze, clip.artifacts.summarize, library, clip.video]);
+
+  return (
+    <div className="np-preview">
+      {data.summary ? (
+        <section>
+          <h4>Summary</h4>
+          <pre className="np-md">{data.summary}</pre>
+        </section>
+      ) : null}
+      {data.visual ? (
+        <section>
+          <h4>Visual transcript</h4>
+          <pre>{data.visual}</pre>
+        </section>
+      ) : null}
+      {data.audio ? (
+        <section>
+          <h4>Transcript</h4>
+          <pre>{data.audio}</pre>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function previewAudio(t: ClipTranscripts["audio"]): string | null {
+  if (!t?.segments?.length) return null;
+  return t.segments
+    .slice(0, 6)
+    .map((s) => s.text)
+    .join(" ")
+    .trim() || null;
+}
+
+function previewVisual(t: ClipTranscripts["visual"]): string | null {
+  if (!t?.segments?.length) return null;
+  return t.segments
+    .slice(0, 6)
+    .map((s) => s.visual || s.text || "")
+    .filter(Boolean)
+    .join("\n");
+}

--- a/ui/src/routes/new-project/progress/clip-row.tsx
+++ b/ui/src/routes/new-project/progress/clip-row.tsx
@@ -1,0 +1,66 @@
+import type { ClipState } from "../jobReducer";
+import type { StageName } from "../../../ipc/events";
+import { ArtifactPreview } from "./artifact-preview";
+
+type StageGlyphState = ClipState["stages"][StageName];
+
+const GLYPH: Record<StageGlyphState, string> = {
+  idle: "○",
+  queued: "⏳",
+  in_progress: "◐",
+  done: "✓",
+  failed: "✗",
+};
+
+export function ClipRow({
+  clip,
+  library,
+  onRetry,
+  expanded,
+  onToggle,
+}: {
+  clip: ClipState;
+  library: string;
+  onRetry: (stage: StageName) => void;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const stages: StageName[] = ["transcribe", "analyze", "summarize"];
+
+  return (
+    <div
+      className={
+        "np-row" + (clip.failure ? " np-row--failed" : "") + (expanded ? " np-row--expanded" : "")
+      }
+    >
+      <button type="button" className="np-row__head" onClick={onToggle}>
+        <span className="np-row__name">{clip.video}</span>
+        {stages.map((s) => (
+          <span key={s} className={`np-chip np-chip--${clip.stages[s]}`}>
+            {GLYPH[clip.stages[s]]} {s}
+          </span>
+        ))}
+      </button>
+
+      {expanded ? (
+        <div className="np-row__body">
+          {clip.failure ? (
+            <div className="np-failure">
+              <strong>
+                ✗ {clip.failure.stage} stage failed
+              </strong>
+              <pre>{clip.failure.message}</pre>
+              <div className="np-failure-buttons">
+                <button type="button" onClick={() => onRetry(clip.failure!.stage)}>
+                  Retry {clip.failure.stage}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <ArtifactPreview clip={clip} library={library} />
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/routes/new-project/progress/progress-view.tsx
+++ b/ui/src/routes/new-project/progress/progress-view.tsx
@@ -19,11 +19,17 @@ export function ProgressView({
   const [expanded, setExpanded] = useState<string | null>(null);
 
   useEffect(() => {
+    let disposed = false;
     let unlisten: (() => void) | null = null;
     void listenJobEvents(jobId, (evt: JobEvent) => dispatch(evt as JobReducerAction)).then((fn) => {
+      if (disposed) {
+        fn();
+        return;
+      }
       unlisten = fn;
     });
     return () => {
+      disposed = true;
       unlisten?.();
     };
   }, [jobId]);

--- a/ui/src/routes/new-project/progress/progress-view.tsx
+++ b/ui/src/routes/new-project/progress/progress-view.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useReducer, useMemo, useState } from "react";
+import { jobReducer, initialJobState, type JobReducerAction } from "../jobReducer";
+import { ClipRow } from "./clip-row";
+import { listenJobEvents, type JobEvent, type StageName } from "../../../ipc/events";
+import { cancelJob, openLibraryWindow, startAnalysis } from "../../../ipc/sidecar";
+
+export function ProgressView({
+  jobId,
+  library,
+  onComplete,
+  onRestartJob,
+}: {
+  jobId: string;
+  library: string;
+  onComplete: () => void;
+  onRestartJob: (newJobId: string) => void;
+}) {
+  const [state, dispatch] = useReducer(jobReducer, initialJobState);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    void listenJobEvents(jobId, (evt: JobEvent) => dispatch(evt as JobReducerAction)).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [jobId]);
+
+  const clipList = useMemo(() => Object.values(state.videos).sort((a, b) => a.video.localeCompare(b.video)), [state.videos]);
+
+  const totalForBar = state.totals.total > 0 ? state.totals.total : clipList.length;
+  const readyCount = clipList.filter(
+    (c) =>
+      c.stages.transcribe === "done" &&
+      c.stages.analyze === "done" &&
+      c.stages.summarize === "done",
+  ).length;
+
+  const barPct = (readyCount / Math.max(1, totalForBar)) * 100;
+
+  const allClipsDone = clipList.length > 0 && clipList.every(
+    (c) =>
+      c.stages.transcribe === "done" &&
+      c.stages.analyze === "done" &&
+      c.stages.summarize === "done",
+  );
+
+  function onCancel() {
+    if (!confirm("Cancel analysis? Files already analyzed will be kept.")) return;
+    dispatch({ method: "_internal_canceling" });
+    void cancelJob(jobId);
+  }
+
+  async function onRetry(_stage: StageName) {
+    try {
+      const { job_id } = await startAnalysis(library);
+      onRestartJob(job_id);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  const showFooter =
+    state.status === "complete" || state.status === "canceled" || allClipsDone;
+
+  return (
+    <section className="np-progress">
+      <header className="np-progress__header">
+        <h2>Analyzing {library}</h2>
+        {state.status === "running" ? (
+          <button type="button" onClick={onCancel}>
+            Cancel
+          </button>
+        ) : null}
+        {state.status === "canceling" ? <span>Canceling…</span> : null}
+      </header>
+
+      <div className="np-progress__bar">
+        <div style={{ width: `${barPct}%` }} />
+      </div>
+      <p className="np-progress__count">
+        {readyCount} of {Math.max(totalForBar, clipList.length) || "?"} clips ready
+        {state.totals.failed > 0 ? (
+          <span className="np-progress__failed"> · {state.totals.failed} failed</span>
+        ) : null}
+      </p>
+
+      <ul className="np-progress__list">
+        {clipList.map((c) => (
+          <li key={c.video}>
+            <ClipRow
+              clip={c}
+              library={library}
+              expanded={expanded === c.video}
+              onToggle={() => setExpanded(expanded === c.video ? null : c.video)}
+              onRetry={onRetry}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {showFooter ? (
+        <footer className="np-progress__footer">
+          <button type="button" onClick={() => void openLibraryWindow(library).then(onComplete)}>
+            Open Library
+          </button>
+          <button type="button" className="np-progress__close" onClick={onComplete}>
+            Close window
+          </button>
+        </footer>
+      ) : null}
+    </section>
+  );
+}

--- a/ui/src/routes/new-project/state.ts
+++ b/ui/src/routes/new-project/state.ts
@@ -1,0 +1,64 @@
+import type { AcceptedVideo, RejectedVideo } from "../../ipc/sidecar";
+
+export type StepId = "footage" | "name" | "language" | "refinement" | "confirm";
+
+export interface SetupState {
+  step: StepId;
+  accepted: AcceptedVideo[];
+  rejected: RejectedVideo[];
+  name: string;
+  language: { name: string; code: string };
+  refinement: boolean;
+  collisionWith: string | null;
+}
+
+export const initialSetup: SetupState = {
+  step: "footage",
+  accepted: [],
+  rejected: [],
+  name: "",
+  language: { name: "English", code: "en" },
+  refinement: true,
+  collisionWith: null,
+};
+
+export type SetupAction =
+  | { type: "add_files"; accepted: AcceptedVideo[]; rejected: RejectedVideo[] }
+  | { type: "remove_file"; path: string }
+  | { type: "set_name"; value: string }
+  | { type: "set_collision"; value: string | null }
+  | { type: "set_language"; name: string; code: string }
+  | { type: "set_refinement"; value: boolean }
+  | { type: "go_step"; step: StepId };
+
+export function setupReducer(state: SetupState, action: SetupAction): SetupState {
+  switch (action.type) {
+    case "add_files": {
+      const existing = new Set(state.accepted.map((v) => v.path));
+      const merged = [...state.accepted, ...action.accepted.filter((v) => !existing.has(v.path))];
+      return { ...state, accepted: merged, rejected: [...state.rejected, ...action.rejected] };
+    }
+    case "remove_file":
+      return { ...state, accepted: state.accepted.filter((v) => v.path !== action.path) };
+    case "set_name":
+      return { ...state, name: action.value };
+    case "set_collision":
+      if (state.collisionWith === action.value) return state;
+      return { ...state, collisionWith: action.value };
+    case "set_language":
+      return { ...state, language: { name: action.name, code: action.code } };
+    case "set_refinement":
+      return { ...state, refinement: action.value };
+    case "go_step":
+      return { ...state, step: action.step };
+  }
+}
+
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/ui/src/routes/new-project/steps/confirm.tsx
+++ b/ui/src/routes/new-project/steps/confirm.tsx
@@ -1,0 +1,57 @@
+import type { SetupState } from "../state";
+import { slugify } from "../state";
+
+export function Confirm({
+  state,
+  apiKeyConfigured,
+  onBack,
+  onStart,
+  onSetupKey,
+}: {
+  state: SetupState;
+  apiKeyConfigured: boolean;
+  onBack: () => void;
+  onStart: () => void;
+  onSetupKey: () => void;
+}) {
+  const totalDuration = state.accepted.reduce((s, v) => s + v.duration_seconds, 0);
+  const minutes = Math.round(totalDuration / 60);
+
+  return (
+    <section className="np-step">
+      <h2>Confirm</h2>
+      <ul className="np-summary">
+        <li>
+          <strong>Project:</strong> <code>{slugify(state.name)}</code>
+        </li>
+        <li>
+          <strong>Videos:</strong> {state.accepted.length} ({minutes}m total)
+        </li>
+        <li>
+          <strong>Language:</strong> {state.language.name} ({state.language.code})
+        </li>
+        <li>
+          <strong>Refinement:</strong> {state.refinement ? "Yes" : "No"}
+        </li>
+      </ul>
+
+      {!apiKeyConfigured ? (
+        <div className="np-banner">
+          <p>ButterCut needs your Anthropic API key to analyze footage.</p>
+          <button type="button" onClick={onSetupKey}>
+            Set up
+          </button>
+        </div>
+      ) : null}
+
+      <footer className="np-footer">
+        <button type="button" onClick={onBack}>
+          Back
+        </button>
+        <button type="button" onClick={onStart} disabled={!apiKeyConfigured}>
+          Start analysis
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/ui/src/routes/new-project/steps/confirm.tsx
+++ b/ui/src/routes/new-project/steps/confirm.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { SetupState } from "../state";
 import { slugify } from "../state";
 
@@ -11,9 +12,20 @@ export function Confirm({
   state: SetupState;
   apiKeyConfigured: boolean;
   onBack: () => void;
-  onStart: () => void;
+  onStart: () => void | Promise<void>;
   onSetupKey: () => void;
 }) {
+  const [starting, setStarting] = useState(false);
+
+  async function handleStart() {
+    if (starting) return;
+    setStarting(true);
+    try {
+      await onStart();
+    } finally {
+      setStarting(false);
+    }
+  }
   const totalDuration = state.accepted.reduce((s, v) => s + v.duration_seconds, 0);
   const minutes = Math.round(totalDuration / 60);
 
@@ -48,8 +60,8 @@ export function Confirm({
         <button type="button" onClick={onBack}>
           Back
         </button>
-        <button type="button" onClick={onStart} disabled={!apiKeyConfigured}>
-          Start analysis
+        <button type="button" onClick={() => void handleStart()} disabled={!apiKeyConfigured || starting}>
+          {starting ? "Starting…" : "Start analysis"}
         </button>
       </footer>
     </section>

--- a/ui/src/routes/new-project/steps/language.tsx
+++ b/ui/src/routes/new-project/steps/language.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type { SetupState, SetupAction } from "../state";
+
+const PRESETS = [
+  { name: "English", code: "en" },
+  { name: "Spanish", code: "es" },
+];
+
+export function Language({
+  state,
+  dispatch,
+  onBack,
+  onNext,
+}: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const [other, setOther] = useState(state.language.code);
+  const isPreset = PRESETS.some((p) => p.code === state.language.code);
+
+  return (
+    <section className="np-step">
+      <h2>Language</h2>
+      <div className="np-cards">
+        {PRESETS.map((p) => (
+          <button
+            key={p.code}
+            type="button"
+            className={"np-card" + (state.language.code === p.code ? " np-card--active" : "")}
+            onClick={() => dispatch({ type: "set_language", name: p.name, code: p.code })}
+          >
+            {p.name}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={"np-card" + (!isPreset ? " np-card--active" : "")}
+          onClick={() => dispatch({ type: "set_language", name: "Other", code: other })}
+        >
+          Other…
+        </button>
+      </div>
+      {!isPreset ? (
+        <label className="np-other">
+          ISO 639-1 code
+          <input
+            value={other}
+            onChange={(e) => {
+              const v = e.target.value;
+              setOther(v);
+              dispatch({ type: "set_language", name: "Other", code: v });
+            }}
+          />
+        </label>
+      ) : null}
+      <footer className="np-footer">
+        <button type="button" onClick={onBack}>
+          Back
+        </button>
+        <button type="button" disabled={!state.language.code} onClick={onNext}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/ui/src/routes/new-project/steps/language.tsx
+++ b/ui/src/routes/new-project/steps/language.tsx
@@ -37,7 +37,10 @@ export function Language({
         <button
           type="button"
           className={"np-card" + (!isPreset ? " np-card--active" : "")}
-          onClick={() => dispatch({ type: "set_language", name: "Other", code: other })}
+          onClick={() => {
+            if (isPreset) setOther("");
+            dispatch({ type: "set_language", name: "Other", code: isPreset ? "" : other });
+          }}
         >
           Other…
         </button>

--- a/ui/src/routes/new-project/steps/name.tsx
+++ b/ui/src/routes/new-project/steps/name.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { listLibraries } from "../../../ipc/sidecar";
+import { slugify, type SetupState, type SetupAction } from "../state";
+
+export function Name({
+  state,
+  dispatch,
+  onBack,
+  onNext,
+}: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const slug = slugify(state.name);
+    if (!slug) {
+      dispatch({ type: "set_collision", value: null });
+      return;
+    }
+    let cancelled = false;
+    listLibraries()
+      .then((libs) => {
+        if (cancelled) return;
+        const hit = libs.find((l) => l.name === slug);
+        dispatch({ type: "set_collision", value: hit ? slug : null });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [state.name, dispatch]);
+
+  const slug = slugify(state.name);
+  const blocked = !slug || state.collisionWith === slug;
+
+  return (
+    <section className="np-step">
+      <h2>Name</h2>
+      <input
+        ref={ref}
+        value={state.name}
+        onChange={(e) => dispatch({ type: "set_name", value: e.target.value })}
+        placeholder="My Bike Series"
+      />
+      {slug ? (
+        <p className="np-slug">
+          → <code>{slug}</code>
+        </p>
+      ) : null}
+      {state.collisionWith && state.collisionWith === slug ? (
+        <p className="np-error">
+          A library named <code>{slug}</code> already exists. Choose a different name.
+        </p>
+      ) : null}
+      <footer className="np-footer">
+        <button type="button" onClick={onBack}>
+          Back
+        </button>
+        <button type="button" disabled={blocked} onClick={onNext}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/ui/src/routes/new-project/steps/pick-footage.tsx
+++ b/ui/src/routes/new-project/steps/pick-footage.tsx
@@ -1,0 +1,106 @@
+import { useEffect } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { inspectVideoPaths } from "../../../ipc/sidecar";
+import type { SetupState, SetupAction } from "../state";
+
+export function PickFootage({
+  state,
+  dispatch,
+  onNext,
+}: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onNext: () => void;
+}) {
+  useEffect(() => {
+    const unlistenP = getCurrentWebview().onDragDropEvent(async (event) => {
+      if (event.payload.type === "drop") {
+        const result = await inspectVideoPaths(event.payload.paths);
+        dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+      }
+    });
+    return () => {
+      void unlistenP.then((fn) => fn());
+    };
+  }, [dispatch]);
+
+  async function chooseFolder() {
+    const picked = await open({ directory: true });
+    if (picked == null) return;
+    const path = typeof picked === "string" ? picked : picked[0];
+    const result = await inspectVideoPaths([path]);
+    dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+  }
+
+  async function chooseFiles() {
+    const picked = await open({ multiple: true, filters: [{ name: "Video", extensions: ["mp4", "mov", "m4v", "mkv", "webm", "avi"] }] });
+    if (picked == null) return;
+    const paths = Array.isArray(picked) ? picked : [picked];
+    const result = await inspectVideoPaths(paths);
+    dispatch({ type: "add_files", accepted: result.accepted, rejected: result.rejected });
+  }
+
+  return (
+    <section className="np-step">
+      <h2>Pick footage</h2>
+      <div className="np-dropzone">
+        <p>Drop video files or a folder onto this window.</p>
+        <p className="np-dropzone__hint">
+          Folder button only adds files if the sidecar recognizes the path as a video; for full folders, use drag-and-drop (or choose files).
+        </p>
+        <div className="np-dropzone__buttons">
+          <button type="button" onClick={() => void chooseFolder()}>
+            Choose folder…
+          </button>
+          <button type="button" onClick={() => void chooseFiles()}>
+            Choose files…
+          </button>
+        </div>
+      </div>
+
+      {state.accepted.length > 0 && (
+        <ul className="np-filelist">
+          {state.accepted.map((v) => (
+            <li key={v.path}>
+              <span className="np-filelist__name">{v.path.split("/").pop()}</span>
+              <span className="np-filelist__dur">{formatDuration(v.duration_seconds)}</span>
+              <button
+                type="button"
+                className="np-filelist__remove"
+                onClick={() => dispatch({ type: "remove_file", path: v.path })}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {state.rejected.length > 0 && (
+        <details className="np-rejected">
+          <summary>{state.rejected.length} skipped</summary>
+          <ul>
+            {state.rejected.map((r) => (
+              <li key={r.path}>
+                {r.path.split("/").pop()} — {r.reason}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      <footer className="np-footer">
+        <button type="button" disabled={state.accepted.length === 0} onClick={onNext}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  );
+}
+
+function formatDuration(s: number) {
+  const m = Math.floor(s / 60);
+  const r = Math.floor(s % 60);
+  return `${m}:${String(r).padStart(2, "0")}`;
+}

--- a/ui/src/routes/new-project/steps/refinement.tsx
+++ b/ui/src/routes/new-project/steps/refinement.tsx
@@ -1,0 +1,45 @@
+import type { SetupState, SetupAction } from "../state";
+
+export function Refinement({
+  state,
+  dispatch,
+  onBack,
+  onNext,
+}: {
+  state: SetupState;
+  dispatch: React.Dispatch<SetupAction>;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <section className="np-step">
+      <h2>Can I proofread the transcripts after they&apos;re generated?</h2>
+      <p>I&apos;ll use the video&apos;s context to fix mistakes.</p>
+      <div className="np-cards np-cards--stack">
+        <button
+          type="button"
+          className={"np-card" + (state.refinement ? " np-card--active" : "")}
+          onClick={() => dispatch({ type: "set_refinement", value: true })}
+        >
+          <strong>Yes — Recommended</strong>
+          <span className="np-card__sub">Use Claude to refine video understanding.</span>
+        </button>
+        <button
+          type="button"
+          className={"np-card" + (!state.refinement ? " np-card--active" : "")}
+          onClick={() => dispatch({ type: "set_refinement", value: false })}
+        >
+          <strong>No</strong>
+        </button>
+      </div>
+      <footer className="np-footer">
+        <button type="button" onClick={onBack}>
+          Back
+        </button>
+        <button type="button" onClick={onNext}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/ui/src/routes/projects.css
+++ b/ui/src/routes/projects.css
@@ -10,39 +10,23 @@
 
 .projects__header {
   margin-bottom: 48px;
-  width: 100%;
-}
-
-.projects__header-row {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 20px 32px;
+  align-items: baseline;
+  gap: 24px;
 }
 
-.projects__new {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  padding: 12px 18px;
-  background: transparent;
-  color: var(--accent);
-  border: 1px solid var(--accent-dim);
-  border-radius: 4px;
-  cursor: pointer;
-  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+.card--new {
+  border-style: dashed;
+  border-color: var(--np-amber, #e0a55a);
+  min-height: 140px;
+  justify-content: center;
+  align-items: center;
 }
 
-.projects__new:hover {
-  border-color: var(--accent);
-  background: rgba(224, 165, 90, 0.08);
-}
-
-.projects__new:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
+.card__plus {
+  font-size: 32px;
+  line-height: 1;
+  color: var(--np-amber, #e0a55a);
 }
 
 .projects__title {

--- a/ui/src/routes/projects.css
+++ b/ui/src/routes/projects.css
@@ -10,9 +10,39 @@
 
 .projects__header {
   margin-bottom: 48px;
+  width: 100%;
+}
+
+.projects__header-row {
   display: flex;
-  align-items: baseline;
-  gap: 24px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px 32px;
+}
+
+.projects__new {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 12px 18px;
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent-dim);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.projects__new:hover {
+  border-color: var(--accent);
+  background: rgba(224, 165, 90, 0.08);
+}
+
+.projects__new:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .projects__title {

--- a/ui/src/routes/projects.tsx
+++ b/ui/src/routes/projects.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { listLibraries, openLibraryWindow, openNewProjectWindow, LibrarySummary } from "../ipc/sidecar";
+import { listLibraries, openLibraryWindow, openNewProjectWindow, type LibrarySummary } from "../ipc/sidecar";
 import "./projects.css";
 
 type LoadState =
@@ -19,19 +19,8 @@ export default function Projects() {
   return (
     <main className="projects">
       <header className="projects__header">
-        <div className="projects__header-row">
-          <div>
-            <h1 className="projects__title">ButterCut</h1>
-            <p className="projects__subtitle">Your libraries</p>
-          </div>
-          <button
-            type="button"
-            className="projects__new"
-            onClick={() => openNewProjectWindow().catch(console.error)}
-          >
-            New project
-          </button>
-        </div>
+        <h1 className="projects__title">ButterCut</h1>
+        <p className="projects__subtitle">Your libraries</p>
       </header>
 
       {state.kind === "loading" && <p className="projects__status">Reading libraries…</p>}
@@ -44,14 +33,27 @@ export default function Projects() {
       )}
 
       {state.kind === "ready" && state.libraries.length === 0 && (
-        <p className="projects__status">No libraries yet. Use New project to create one from the app, or use the CLI.</p>
+        <p className="projects__status">No libraries yet. Click <strong>+ New Project</strong> to start, or use the CLI.</p>
       )}
 
-      {state.kind === "ready" && state.libraries.length > 0 && (
+      {state.kind === "ready" && (
         <ul className="projects__grid">
+          <li>
+            <button
+              type="button"
+              className="card card--new"
+              onClick={() => openNewProjectWindow().catch(console.error)}
+            >
+              <span className="card__plus" aria-hidden>
+                +
+              </span>
+              <span className="card__name">New Project</span>
+            </button>
+          </li>
           {state.libraries.map((lib) => (
             <li key={lib.name}>
               <button
+                type="button"
                 className="card"
                 onClick={() => openLibraryWindow(lib.name).catch(console.error)}
               >

--- a/ui/src/routes/projects.tsx
+++ b/ui/src/routes/projects.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { listLibraries, openLibraryWindow, LibrarySummary } from "../ipc/sidecar";
+import { listLibraries, openLibraryWindow, openNewProjectWindow, LibrarySummary } from "../ipc/sidecar";
 import "./projects.css";
 
 type LoadState =
@@ -19,8 +19,19 @@ export default function Projects() {
   return (
     <main className="projects">
       <header className="projects__header">
-        <h1 className="projects__title">ButterCut</h1>
-        <p className="projects__subtitle">Your libraries</p>
+        <div className="projects__header-row">
+          <div>
+            <h1 className="projects__title">ButterCut</h1>
+            <p className="projects__subtitle">Your libraries</p>
+          </div>
+          <button
+            type="button"
+            className="projects__new"
+            onClick={() => openNewProjectWindow().catch(console.error)}
+          >
+            New project
+          </button>
+        </div>
       </header>
 
       {state.kind === "loading" && <p className="projects__status">Reading libraries…</p>}
@@ -33,7 +44,7 @@ export default function Projects() {
       )}
 
       {state.kind === "ready" && state.libraries.length === 0 && (
-        <p className="projects__status">No libraries yet. Create one with the CLI for now.</p>
+        <p className="projects__status">No libraries yet. Use New project to create one from the app, or use the CLI.</p>
       )}
 
       {state.kind === "ready" && state.libraries.length > 0 && (


### PR DESCRIPTION
## Summary
- **New Project flow** in the desktop app: pick footage → name → language → refinement → confirm → streaming analysis progress with per-clip stage chips, artifact preview, cancel/retry (retry re-runs `start_analysis`).
- **Sidecar** owns the analysis pipeline: WhisperX + ffmpeg subprocesses; Anthropic SDK for analyze + summarize; JSON-RPC **notifications** (no `id`) forwarded by Rust as scoped Tauri events `sidecar-event:{job_id}`.
- **Shared prompts** under `ui/sidecar/prompts/` for analyze/summarize (CLI agents + sidecar).
- **API key**: `ANTHROPIC_API_KEY` or `libraries/settings.yaml`; validated on save (Haiku ping).
- **Dev ergonomics**: root `Makefile` (`make check`, `make setup`, `make dev`) and `scripts/check_desktop_prereqs.sh`.

## Fixes during QA
- Tauri v2 `invoke` uses camelCase keys matching Rust params (`languageCode`, `jobId`).

## Deferred / follow-ups
- `retry_unit` RPC still raises in the sidecar; UI **Retry** starts a new analysis job for that library.
- Folder picker without enumerate RPC: drag-drop / multi-file pick preferred (documented in wizard copy).

## Test plan
- [ ] Manual happy path: `make check` → `make setup` → `pnpm tauri dev` → New Project → short clips → progress → Open Library.
- [ ] Cancel mid-job; resume via Start analysis / `start_analysis` again.
- [ ] Bad API key in modal shows upstream error.
- [ ] `cd ui/sidecar && bundle exec rspec`
- [ ] `cd ui/src-tauri && cargo check`
- [ ] `cd ui && pnpm build`
- [ ] M1 library browser still works from Projects.

Refs: `docs/superpowers/specs/2026-05-03-m2-library-creation-and-analysis-design.md`, `docs/superpowers/plans/2026-05-03-m2-library-creation-and-analysis.md` Task 7.1.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step "New Project" wizard (folder/file intake, naming, language, refinement) with a dedicated window and in-app API key modal.
  * Start-analysis flow with streaming, per-clip real-time progress, artifact previews, cancel and retry controls.
  * Video validation before import and safer folder-based project creation.

* **Improvements**
  * Persistent settings for API key, clearer onboarding and prerequisite checks, and improved progress feedback and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->