### PR TITLE
M4a: Brief composer + UI rough cut generation

### DIFF
--- a/docs/superpowers/specs/2026-05-04-m4a-brief-composer-roughcut-design.md
+++ b/docs/superpowers/specs/2026-05-04-m4a-brief-composer-roughcut-design.md
@@ -32,7 +32,7 @@ Terminal-free rough cut: user writes a plain-language brief and target duration,
 
 | Method | Params | Result |
 |--------|--------|--------|
-| `roughcut_prerequisites` | `library` | `{ "ok": bool, "missing": [ { "video", "missing" } ] }` — `missing` lists which of `transcript`, `visual_transcript`, `summary` are absent per basename. |
+| `roughcut_prerequisites` | `library` | `{ "ok": bool, "missing": [ { "video": string, "missing": string[] } ] }` — each element maps one **video basename** (same as `library.yaml` `path` basename) to `missing`, a subset of `transcript` / `visual_transcript` / `summary` still absent for that file. Example: `{ "ok": false, "missing": [ { "video": "clip.mov", "missing": ["summary"] } ] }`. |
 | `list_briefs` | `library` | `{ "briefs": [ { id, parent_id, prompt, target_duration_seconds, title, created_at, updated_at } ] }` |
 | `upsert_brief` | `library`, `prompt`, `target_duration_seconds`, optional `id`, optional `title` | `{ "id" }` |
 | `fork_brief` | `library`, `parent_id` | `{ "id" }` |
@@ -52,7 +52,7 @@ Terminal-free rough cut: user writes a plain-language brief and target duration,
 ## Generate → four artifacts
 
 1. Model returns rough cut **YAML** (extracted from a ` ```yaml ` fenced block).
-2. Sidecar writes `libraries/<lib>/roughcuts/<stem>_<timestamp>.yaml` with normalized `metadata.created_date` and `metadata.total_duration`.
+2. Sidecar writes `libraries/<lib>/roughcuts/<stem>.yaml` (and sibling XML / recipe / apply script with the same stem) where **`stem` = `roughcut_ui_<UTC_YYYYMMDD_HHMMSS>`** (a generated UI roughcut id, not the brief id or library slug), with normalized `metadata.created_date` and `metadata.total_duration`.
 3. Invokes the existing exporter (unchanged):
 
    `bundle exec ruby .claude/skills/roughcut/export_to_fcpxml.rb <yaml> <xml_out> <editor>`
@@ -65,7 +65,7 @@ Terminal-free rough cut: user writes a plain-language brief and target duration,
 
 ## Limits
 
-- Combined visual transcript NDJSON is capped (~900k bytes). Above that, the RPC fails with a clear message suggesting CLI / smaller libraries for now.
+- Combined visual transcript NDJSON is capped at **900000 bytes** (same constant as `RoughcutController::COMBINED_TRANSCRIPT_MAX_BYTES`). Above that, the RPC fails with a clear message suggesting CLI / smaller libraries for now.
 
 ## UI (minimal)
 

--- a/docs/superpowers/specs/2026-05-04-m4a-brief-composer-roughcut-design.md
+++ b/docs/superpowers/specs/2026-05-04-m4a-brief-composer-roughcut-design.md
@@ -1,0 +1,74 @@
+# M4a — Brief composer + rough cut generation (UI)
+
+**Status:** Implemented 2026-05-04  
+**Tracks:** epic [#14](https://github.com/William-Hill/buttercut/issues/14)  
+**Depends on:** M2 sidecar + Anthropic pattern  
+**Branch:** `sprint-02-m4a-brief-composer`
+
+## Goal
+
+Terminal-free rough cut: user writes a plain-language brief and target duration, optionally forks prior briefs, runs **Generate**, and receives the same on-disk artifacts as the CLI roughcut flow (YAML + editor XML + `.recipe.json` + `*_apply.py`). After generation, the UI shows a flat clip list with in/out and paths; the user opens the XML (etc.) in their NLE manually.
+
+## Architecture (mirrors M2)
+
+- **Sidecar** owns prerequisites check, combined transcript assembly, Anthropic **Sonnet** editorial call (same role as the Claude Code roughcut sub-agent), YAML normalization, and `bundle exec ruby .claude/skills/roughcut/export_to_fcpxml.rb` from the **repo root** (same script the skill documents).
+- **No** packaged headless Claude Code Task — one code path with the Anthropic Ruby SDK in-process, matching M2’s “sidecar owns long-running / Anthropic work.”
+- **IPC:** JSON-RPC methods on the existing stdio sidecar; progress via notifications with `job_id` scoped Tauri events (`sidecar-event:{job_id}`), same transport as analysis jobs.
+
+## Brief storage
+
+- **Path:** `libraries/<library-slug>/briefs/catalog.yaml` (gitignored with the rest of `libraries/`).
+- **Schema:** top-level `briefs:` array of records:
+  - `id` (string, `b-` + urlsafe base64)
+  - `parent_id` (nullable string; set when created via **Fork**)
+  - `prompt` (string)
+  - `target_duration_seconds` (integer)
+  - `title` (optional short label for the stack UI)
+  - `created_at`, `updated_at` (ISO8601 UTC)
+- **Fork:** append a new record with a new `id`, `parent_id` = source id, copied `prompt` / `target_duration_seconds`, fresh timestamps. The UI loads the fork into the editor as a new draft.
+- **History:** `list_briefs` returns rows sorted by `updated_at` descending (stack of past briefs).
+
+## RPC surface
+
+| Method | Params | Result |
+|--------|--------|--------|
+| `roughcut_prerequisites` | `library` | `{ "ok": bool, "missing": [ { "video", "missing" } ] }` — `missing` lists which of `transcript`, `visual_transcript`, `summary` are absent per basename. |
+| `list_briefs` | `library` | `{ "briefs": [ { id, parent_id, prompt, target_duration_seconds, title, created_at, updated_at } ] }` |
+| `upsert_brief` | `library`, `prompt`, `target_duration_seconds`, optional `id`, optional `title` | `{ "id" }` |
+| `fork_brief` | `library`, `parent_id` | `{ "id" }` |
+| `start_roughcut` | `library`, `brief_id` | `{ "job_id" }` — resolves prompt/duration from catalog; errors if prerequisites fail (sync error on dispatch before job starts) or unknown `brief_id`. |
+
+**Generate flow (UI):** optional `upsert_brief` to persist the draft, then `start_roughcut` with the returned `brief_id`. Prerequisites are checked in the sidecar before spawning the background thread; if not ok, RPC returns an error (no `job_id`).
+
+## Job notifications (`job_id` present)
+
+- `roughcut_job_started` — `{ job_id, library }`
+- `roughcut_phase` — `{ job_id, phase, message? }` (`combine_transcript`, `model`, `export`)
+- `roughcut_job_done` — `{ job_id, library, yaml_path, xml_path, recipe_path, apply_path, clips: [{ source_file, in_point, out_point }] }`
+- `roughcut_job_failed` — `{ job_id, message }`
+
+`cancel_job` reuses **JobRegistry** + **AnalysisJob**-style cancellation (SIGTERM/KILL has no effect on pure Ruby HTTP, but registry clears the job; future work can wire SDK abort).
+
+## Generate → four artifacts
+
+1. Model returns rough cut **YAML** (extracted from a ` ```yaml ` fenced block).
+2. Sidecar writes `libraries/<lib>/roughcuts/<stem>_<timestamp>.yaml` with normalized `metadata.created_date` and `metadata.total_duration`.
+3. Invokes the existing exporter (unchanged):
+
+   `bundle exec ruby .claude/skills/roughcut/export_to_fcpxml.rb <yaml> <xml_out> <editor>`
+
+   with `editor` in `{ fcpx, premiere, resolve }` from `library.yaml`’s `editor` field (and `libraries/settings.yaml` fallback if empty), matching the skill.
+
+4. Exporter already writes sibling **`.recipe.json`** and **`*_apply.py`** next to the XML/FCPXML path.
+
+**Note:** `export_to_fcpxml.rb` does **not** emit `*_edit_guide.html` today; the sprint doc mentioned it as optional. M4a matches the **implemented** exporter (YAML + XML/FCPXML + recipe + apply script).
+
+## Limits
+
+- Combined visual transcript NDJSON is capped (~900k bytes). Above that, the RPC fails with a clear message suggesting CLI / smaller libraries for now.
+
+## UI (minimal)
+
+- Library detail **tabs:** “Footage” (existing) / “Rough cut”.
+- Rough cut: prerequisite banner, prompt + target duration, brief history list (fork + load), Save brief, Generate, Cancel (when job running).
+- After `roughcut_job_done`: flat table of clips (source file, in, out) + absolute paths with “Reveal in Finder” via `@tauri-apps/plugin-opener`.

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -24,6 +24,7 @@ require_relative "lib/buttercut_ui_sidecar/stages/transcribe"
 require_relative "lib/buttercut_ui_sidecar/stages/analyze"
 require_relative "lib/buttercut_ui_sidecar/stages/summarize"
 require_relative "lib/buttercut_ui_sidecar/brief_store"
+require_relative "lib/buttercut_ui_sidecar/presence"
 require_relative "lib/buttercut_ui_sidecar/roughcut_controller"
 
 module ButtercutUiSidecar
@@ -179,14 +180,13 @@ module ButtercutUiSidecar
 
     def brief_catalog_list(name)
       library_dir(name)
-      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: name)
-      { briefs: store.list }
+      { briefs: brief_store_for(name).list }
     end
 
     def brief_catalog_upsert(params)
       lib = params.fetch("library")
       library_dir(lib)
-      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: lib)
+      store = brief_store_for(lib)
       id = store.upsert(
         id: params["id"],
         prompt: params.fetch("prompt"),
@@ -199,8 +199,7 @@ module ButtercutUiSidecar
     def brief_catalog_fork(params)
       lib = params.fetch("library")
       library_dir(lib)
-      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: lib)
-      { id: store.fork(parent_id: params.fetch("parent_id")) }
+      { id: brief_store_for(lib).fork(parent_id: params.fetch("parent_id")) }
     end
 
     def roughcut_start(params)
@@ -271,6 +270,10 @@ module ButtercutUiSidecar
       YAML.safe_load(yaml_path.read, permitted_classes: [Date, Time], aliases: true) || {}
     end
 
+    def brief_store_for(library_name)
+      ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: library_name)
+    end
+
     def find_video_entry(library_data, library_name, video)
       videos = library_data["videos"] || []
       entry = videos.find { |v| v["path"].to_s == video }
@@ -285,14 +288,10 @@ module ButtercutUiSidecar
         filename: File.basename(path),
         path: path,
         duration_seconds: parse_duration(v["duration"]),
-        has_audio_transcript: present?(v["transcript"]),
-        has_visual_transcript: present?(v["visual_transcript"]),
-        has_summary: present?(v["summary"])
+        has_audio_transcript: Presence.present?(v["transcript"]),
+        has_visual_transcript: Presence.present?(v["visual_transcript"]),
+        has_summary: Presence.present?(v["summary"])
       }
-    end
-
-    def present?(value)
-      !value.nil? && !value.to_s.empty?
     end
 
     def parse_duration(value)
@@ -334,7 +333,7 @@ module ButtercutUiSidecar
     end
 
     def read_json_if_set(dir, name)
-      return nil unless present?(name)
+      return nil unless Presence.present?(name)
       path = dir.join(name)
       return nil unless path.file?
       JSON.parse(path.read)
@@ -343,7 +342,7 @@ module ButtercutUiSidecar
     end
 
     def read_text_if_set(dir, name)
-      return nil unless present?(name)
+      return nil unless Presence.present?(name)
       path = dir.join(name)
       path.file? ? path.read : nil
     end

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -23,17 +23,22 @@ require_relative "lib/buttercut_ui_sidecar/library_replacer"
 require_relative "lib/buttercut_ui_sidecar/stages/transcribe"
 require_relative "lib/buttercut_ui_sidecar/stages/analyze"
 require_relative "lib/buttercut_ui_sidecar/stages/summarize"
+require_relative "lib/buttercut_ui_sidecar/brief_store"
+require_relative "lib/buttercut_ui_sidecar/roughcut_controller"
 
 module ButtercutUiSidecar
   def self.run(libraries_root:, io_in: $stdin, io_out: $stdout)
-    Dispatcher.new(libraries_root: libraries_root, io_in: io_in, io_out: io_out).run
+    repo_root = Pathname.new(__dir__).parent.parent
+    Dispatcher.new(libraries_root: libraries_root, io_in: io_in, io_out: io_out, repo_root: repo_root).run
   end
 
   class Dispatcher
-    def initialize(libraries_root:, io_in:, io_out:)
+    def initialize(libraries_root:, io_in:, io_out:, repo_root:)
       raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      raise ArgumentError, "repo_root required" if repo_root.nil? || repo_root.to_s.empty?
 
       @libraries_root = Pathname.new(libraries_root)
+      @repo_root = Pathname.new(repo_root)
       @io_in = io_in
       @io_out = io_out
       @io_out.sync = true
@@ -152,8 +157,67 @@ module ButtercutUiSidecar
           notifier: @notifier,
           mutex: @transcript_mutex
         )
+      when "roughcut_prerequisites"
+        roughcut_prerequisites(params.fetch("library"))
+      when "list_briefs"
+        brief_catalog_list(params.fetch("library"))
+      when "upsert_brief"
+        brief_catalog_upsert(params)
+      when "fork_brief"
+        brief_catalog_fork(params)
+      when "start_roughcut"
+        roughcut_start(params)
       else raise UnknownMethod, "unknown method: #{method}"
       end
+    end
+
+    def roughcut_prerequisites(name)
+      data = load_library_yaml(name)
+      pre = ButtercutUiSidecar::RoughcutController.prerequisites_report(data)
+      { ok: pre[:ok], missing: pre[:missing] }
+    end
+
+    def brief_catalog_list(name)
+      library_dir(name)
+      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: name)
+      { briefs: store.list }
+    end
+
+    def brief_catalog_upsert(params)
+      lib = params.fetch("library")
+      library_dir(lib)
+      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: lib)
+      id = store.upsert(
+        id: params["id"],
+        prompt: params.fetch("prompt"),
+        target_duration_seconds: params.fetch("target_duration_seconds"),
+        title: params["title"]
+      )
+      { id: id }
+    end
+
+    def brief_catalog_fork(params)
+      lib = params.fetch("library")
+      library_dir(lib)
+      store = ButtercutUiSidecar::BriefStore.new(libraries_root: @libraries_root.to_s, library: lib)
+      { id: store.fork(parent_id: params.fetch("parent_id")) }
+    end
+
+    def roughcut_start(params)
+      lib = params.fetch("library")
+      library_dir(lib)
+      api_key = @settings.api_key
+      raise StandardError, "missing_api_key" if api_key.nil? || api_key.empty?
+
+      client = ButtercutUiSidecar::AnthropicClient.new(api_key: api_key)
+      rc = ButtercutUiSidecar::RoughcutController.new(
+        libraries_root: @libraries_root.to_s,
+        repo_root: @repo_root.to_s,
+        notifier: @notifier,
+        registry: @registry,
+        client: client
+      )
+      rc.validate_and_start!(library: lib, brief_id: params.fetch("brief_id"))
     end
 
     def list_libraries

--- a/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/analysis_controller.rb
@@ -9,6 +9,7 @@ require "securerandom"
 require "yaml"
 require_relative "limits"
 require_relative "analysis_job"
+require_relative "presence"
 
 module ButtercutUiSidecar
   class AnalysisController
@@ -35,7 +36,7 @@ module ButtercutUiSidecar
       lib_dir = @libraries_root.join(library)
       data = read_yaml(lib_dir)
       videos = (data["videos"] || []).reject do |v|
-        present?(v["transcript"]) && present?(v["visual_transcript"]) && present?(v["summary"])
+        Presence.present?(v["transcript"]) && Presence.present?(v["visual_transcript"]) && Presence.present?(v["summary"])
       end
 
       @completion_latch = Concurrent::CountDownLatch.new(1)
@@ -80,15 +81,11 @@ module ButtercutUiSidecar
 
     private
 
-    def present?(value)
-      !value.nil? && !value.to_s.empty?
-    end
-
     def pending_stage_count(video)
       n = 0
-      n += 1 unless present?(video["transcript"])
-      n += 1 unless present?(video["visual_transcript"])
-      n += 1 unless present?(video["summary"])
+      n += 1 unless Presence.present?(video["transcript"])
+      n += 1 unless Presence.present?(video["visual_transcript"])
+      n += 1 unless Presence.present?(video["summary"])
       n
     end
 
@@ -113,9 +110,9 @@ module ButtercutUiSidecar
       visual_path  = File.join(transcripts_dir, "visual_#{stem}.json")
       summary_path = File.join(summaries_dir,   "summary_#{stem}.md")
 
-      need_t = !present?(video["transcript"])
-      need_a = !present?(video["visual_transcript"])
-      need_s = !present?(video["summary"])
+      need_t = !Presence.present?(video["transcript"])
+      need_a = !Presence.present?(video["visual_transcript"])
+      need_s = !Presence.present?(video["summary"])
 
       transcribe_body = lambda do
         res = @stages[:transcribe].run(

--- a/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "pathname"
 require "securerandom"
 require "time"
 require "yaml"
@@ -94,6 +95,8 @@ module ButtercutUiSidecar
     private
 
     def with_catalog_lock
+      raise "library directory missing: #{@lib_dir}" unless @lib_dir.directory?
+
       @briefs_dir.mkpath
       lock_path = @briefs_dir.join(".catalog.lock")
       File.open(lock_path, File::CREAT | File::RDWR) do |lock_io|

--- a/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "securerandom"
+require "time"
+require "yaml"
+
+module ButtercutUiSidecar
+  # Per-library stack of edit briefs (plain-language prompts + target duration).
+  class BriefStore
+    CATALOG = "catalog.yaml"
+
+    def initialize(libraries_root:, library:)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      raise ArgumentError, "library required" if library.nil? || library.to_s.empty?
+
+      @lib_dir = Pathname.new(libraries_root).join(library)
+      @briefs_dir = @lib_dir.join("briefs")
+      @catalog_path = @briefs_dir.join(CATALOG)
+    end
+
+    def list
+      data = read_catalog
+      briefs = (data["briefs"] || []).map(&:dup)
+      briefs.sort_by { |b| Time.parse(b["updated_at"].to_s).to_i }.reverse
+    end
+
+    def upsert(id:, prompt:, target_duration_seconds:, title: nil)
+      raise ArgumentError, "prompt required" if prompt.nil? || prompt.to_s.strip.empty?
+      n = Integer(target_duration_seconds)
+      raise ArgumentError, "target_duration_seconds must be positive" if n <= 0
+
+      now = Time.now.utc.iso8601(3)
+      data = read_catalog
+      rows = data["briefs"] || []
+
+      if id && !id.to_s.empty?
+        row = rows.find { |r| r["id"] == id }
+        raise ArgumentError, "unknown brief id: #{id}" if row.nil?
+
+        row["prompt"] = prompt.to_s
+        row["target_duration_seconds"] = n
+        row["title"] = title.to_s unless title.nil?
+        row["updated_at"] = now
+      else
+        row = {
+          "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
+          "parent_id" => nil,
+          "prompt" => prompt.to_s,
+          "target_duration_seconds" => n,
+          "title" => title.to_s,
+          "created_at" => now,
+          "updated_at" => now
+        }
+        rows << row
+      end
+
+      write_catalog!("briefs" => rows)
+      row["id"]
+    end
+
+    def fork(parent_id:)
+      pid = parent_id.to_s
+      data = read_catalog
+      rows = data["briefs"] || []
+      parent = rows.find { |r| r["id"] == pid }
+      raise ArgumentError, "unknown parent brief: #{parent_id}" if parent.nil?
+
+      now = Time.now.utc.iso8601(3)
+      row = {
+        "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
+        "parent_id" => pid,
+        "prompt" => parent["prompt"].to_s,
+        "target_duration_seconds" => Integer(parent["target_duration_seconds"]),
+        "title" => parent["title"].to_s,
+        "created_at" => now,
+        "updated_at" => now
+      }
+      rows << row
+      write_catalog!("briefs" => rows)
+      row["id"]
+    end
+
+    def get(id)
+      rows = read_catalog["briefs"] || []
+      rows.find { |r| r["id"] == id }
+    end
+
+    private
+
+    def read_catalog
+      return { "briefs" => [] } unless @catalog_path.file?
+
+      YAML.safe_load(@catalog_path.read, permitted_classes: [Time, Date], aliases: true) || { "briefs" => [] }
+    end
+
+    def write_catalog!(data)
+      raise "library directory missing: #{@lib_dir}" unless @lib_dir.directory?
+
+      @briefs_dir.mkpath
+      tmp = @catalog_path.to_s + ".tmp"
+      File.write(tmp, YAML.dump(data))
+      File.rename(tmp, @catalog_path.to_s)
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
@@ -22,7 +22,8 @@ module ButtercutUiSidecar
     def list
       data = read_catalog
       briefs = (data["briefs"] || []).map(&:dup)
-      briefs.sort_by { |b| Time.parse(b["updated_at"].to_s).to_i }.reverse
+      # Newest first by updated_at; on timestamp ties, later catalog rows win (stable fork-after-parent).
+      briefs.each_with_index.sort_by { |(b, i)| [brief_sort_epoch(b["updated_at"]), i] }.map(&:first).reverse
     end
 
     def upsert(id:, prompt:, target_duration_seconds:, title: nil)
@@ -87,6 +88,12 @@ module ButtercutUiSidecar
     end
 
     private
+
+    def brief_sort_epoch(value)
+      Time.parse(value.to_s).to_i
+    rescue ArgumentError, TypeError
+      0
+    end
 
     def read_catalog
       return { "briefs" => [] } unless @catalog_path.file?

--- a/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/brief_store.rb
@@ -32,54 +32,58 @@ module ButtercutUiSidecar
       raise ArgumentError, "target_duration_seconds must be positive" if n <= 0
 
       now = Time.now.utc.iso8601(3)
-      data = read_catalog
-      rows = data["briefs"] || []
+      with_catalog_lock do
+        data = read_catalog
+        rows = data["briefs"] || []
 
-      if id && !id.to_s.empty?
-        row = rows.find { |r| r["id"] == id }
-        raise ArgumentError, "unknown brief id: #{id}" if row.nil?
+        if id && !id.to_s.empty?
+          row = rows.find { |r| r["id"] == id }
+          raise ArgumentError, "unknown brief id: #{id}" if row.nil?
 
-        row["prompt"] = prompt.to_s
-        row["target_duration_seconds"] = n
-        row["title"] = title.to_s unless title.nil?
-        row["updated_at"] = now
-      else
-        row = {
-          "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
-          "parent_id" => nil,
-          "prompt" => prompt.to_s,
-          "target_duration_seconds" => n,
-          "title" => title.to_s,
-          "created_at" => now,
-          "updated_at" => now
-        }
-        rows << row
+          row["prompt"] = prompt.to_s
+          row["target_duration_seconds"] = n
+          row["title"] = title.to_s unless title.nil?
+          row["updated_at"] = now
+        else
+          row = {
+            "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
+            "parent_id" => nil,
+            "prompt" => prompt.to_s,
+            "target_duration_seconds" => n,
+            "title" => title.to_s,
+            "created_at" => now,
+            "updated_at" => now
+          }
+          rows << row
+        end
+
+        write_catalog!("briefs" => rows)
+        row["id"]
       end
-
-      write_catalog!("briefs" => rows)
-      row["id"]
     end
 
     def fork(parent_id:)
       pid = parent_id.to_s
-      data = read_catalog
-      rows = data["briefs"] || []
-      parent = rows.find { |r| r["id"] == pid }
-      raise ArgumentError, "unknown parent brief: #{parent_id}" if parent.nil?
+      with_catalog_lock do
+        data = read_catalog
+        rows = data["briefs"] || []
+        parent = rows.find { |r| r["id"] == pid }
+        raise ArgumentError, "unknown parent brief: #{parent_id}" if parent.nil?
 
-      now = Time.now.utc.iso8601(3)
-      row = {
-        "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
-        "parent_id" => pid,
-        "prompt" => parent["prompt"].to_s,
-        "target_duration_seconds" => Integer(parent["target_duration_seconds"]),
-        "title" => parent["title"].to_s,
-        "created_at" => now,
-        "updated_at" => now
-      }
-      rows << row
-      write_catalog!("briefs" => rows)
-      row["id"]
+        now = Time.now.utc.iso8601(3)
+        row = {
+          "id" => "b-#{SecureRandom.urlsafe_base64(9)}",
+          "parent_id" => pid,
+          "prompt" => parent["prompt"].to_s,
+          "target_duration_seconds" => Integer(parent["target_duration_seconds"]),
+          "title" => parent["title"].to_s,
+          "created_at" => now,
+          "updated_at" => now
+        }
+        rows << row
+        write_catalog!("briefs" => rows)
+        row["id"]
+      end
     end
 
     def get(id)
@@ -88,6 +92,15 @@ module ButtercutUiSidecar
     end
 
     private
+
+    def with_catalog_lock
+      @briefs_dir.mkpath
+      lock_path = @briefs_dir.join(".catalog.lock")
+      File.open(lock_path, File::CREAT | File::RDWR) do |lock_io|
+        lock_io.flock(File::LOCK_EX)
+        yield
+      end
+    end
 
     def brief_sort_epoch(value)
       Time.parse(value.to_s).to_i
@@ -102,12 +115,15 @@ module ButtercutUiSidecar
     end
 
     def write_catalog!(data)
+      tmp = nil
       raise "library directory missing: #{@lib_dir}" unless @lib_dir.directory?
 
       @briefs_dir.mkpath
-      tmp = @catalog_path.to_s + ".tmp"
+      tmp = @briefs_dir.join("catalog.#{Process.pid}.#{SecureRandom.hex(6)}.tmp")
       File.write(tmp, YAML.dump(data))
-      File.rename(tmp, @catalog_path.to_s)
+      File.rename(tmp.to_s, @catalog_path.to_s)
+    ensure
+      FileUtils.rm_f(tmp.to_s) if tmp&.to_s && File.exist?(tmp.to_s)
     end
   end
 end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/presence.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/presence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ButtercutUiSidecar
+  # Shared blank-check for transcript paths, YAML fields, etc.
+  module Presence
+    module_function
+
+    def present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -16,16 +16,14 @@ module ButtercutUiSidecar
   class RoughcutController
     COMBINED_TRANSCRIPT_MAX_BYTES = 900_000
     MODEL = AnthropicClient::VISION_MODEL
+    PREREQ_KEYS = %w[transcript visual_transcript summary].freeze
 
     def self.prerequisites_report(library_data)
       missing = []
       (library_data["videos"] || []).each do |v|
         base = File.basename(v["path"].to_s)
-        m = []
-        m << "transcript" unless RoughcutController.present?(v["transcript"])
-        m << "visual_transcript" unless RoughcutController.present?(v["visual_transcript"])
-        m << "summary" unless RoughcutController.present?(v["summary"])
-        missing << { "video" => base, "missing" => m } unless m.empty?
+        absent = PREREQ_KEYS.reject { |k| RoughcutController.present?(v[k]) }
+        missing << { "video" => base, "missing" => absent } unless absent.empty?
       end
       { ok: missing.empty?, missing: missing }
     end
@@ -203,12 +201,12 @@ module ButtercutUiSidecar
 
       gemfile = @repo_root.join("Gemfile").to_s
       cmd = ["bundle", "exec", "ruby", script.to_s, yaml_path.expand_path.to_s, xml_path.expand_path.to_s, editor]
-      out = +""
+      out = nil
       status = nil
       Dir.chdir(@repo_root.to_s) do
         out, status = Open3.capture2e({ "BUNDLE_GEMFILE" => gemfile }, *cmd)
       end
-      raise "export_failed: #{out.strip}" unless status.success?
+      raise "export_failed: #{out.to_s.strip}" unless status.success?
     end
 
     def resolve_editor_flag(library_data)

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -4,6 +4,7 @@ require "json"
 require "open3"
 require "pathname"
 require "securerandom"
+require "set"
 require "time"
 require "yaml"
 
@@ -35,7 +36,7 @@ module ButtercutUiSidecar
         fn = v["visual_transcript"]
         next unless Presence.present?(fn)
 
-        path = lib_dir.join("transcripts", fn.to_s)
+        path = safe_visual_transcript_path(lib_dir, fn)
         next unless path.file?
 
         obj = JSON.parse(path.read)
@@ -43,6 +44,32 @@ module ButtercutUiSidecar
         lines << JSON.generate(obj)
       end
       lines.join("\n") + "\n"
+    end
+
+    # Reject absolute paths and directory traversal in library.yaml visual_transcript refs.
+    def self.safe_visual_transcript_path(lib_dir, fn)
+      s = fn.to_s
+      raise "invalid_visual_transcript_ref:#{fn}" if Pathname.new(s).absolute?
+      raise "invalid_visual_transcript_ref:#{fn}" if s != File.basename(s)
+
+      transcripts_dir = lib_dir.join("transcripts").expand_path
+      path = transcripts_dir.join(s).expand_path
+      unless path.to_s.start_with?(transcripts_dir.to_s + File::SEPARATOR)
+        raise "invalid_visual_transcript_ref:#{fn}"
+      end
+
+      path
+    end
+
+    def self.video_basenames(library_data)
+      (library_data["videos"] || []).map { |v| File.basename(v["path"].to_s) }.to_set
+    end
+
+    def self.valid_clip_timecode?(tc)
+      parts = tc.to_s.split(":")
+      return false unless parts.length == 3
+
+      parts.all? { |p| p.match?(/\A\d+(\.\d+)?\z/) }
     end
 
     def self.timecode_to_seconds(tc)
@@ -153,7 +180,7 @@ module ButtercutUiSidecar
       yaml_text = extract_yaml_fence(body)
       rough = YAML.safe_load(yaml_text, permitted_classes: [Date, Time, Symbol]) || {}
       (rough["clips"] || []).each { |c| c["dialogue"] = "" unless c.key?("dialogue") }
-      validate_roughcut_shape!(rough)
+      validate_roughcut_shape!(rough, library_data)
 
       enrich_metadata!(rough)
       ts = Time.now.utc.strftime("%Y%m%d_%H%M%S")
@@ -272,9 +299,11 @@ module ButtercutUiSidecar
       body.strip
     end
 
-    def validate_roughcut_shape!(rough)
+    def validate_roughcut_shape!(rough, library_data)
       clips = rough["clips"]
       raise "roughcut_missing_clips" unless clips.is_a?(Array) && !clips.empty?
+
+      allowed = self.class.video_basenames(library_data)
 
       clips.each_with_index do |c, i|
         raise "clip #{i} missing source_file" unless Presence.present?(c["source_file"])
@@ -282,6 +311,17 @@ module ButtercutUiSidecar
         raise "clip #{i} missing out_point" unless Presence.present?(c["out_point"])
         raise "clip #{i} missing dialogue" unless c.key?("dialogue")
         raise "clip #{i} missing visual_description" unless Presence.present?(c["visual_description"])
+
+        base = File.basename(c["source_file"].to_s)
+        raise "clip #{i} invalid_source_file" unless allowed.include?(base)
+
+        unless self.class.valid_clip_timecode?(c["in_point"]) && self.class.valid_clip_timecode?(c["out_point"])
+          raise "clip #{i} invalid_timecode"
+        end
+
+        t_in = self.class.timecode_to_seconds(c["in_point"])
+        t_out = self.class.timecode_to_seconds(c["out_point"])
+        raise "clip #{i} invalid_time_range" unless t_out > t_in
       end
     end
 

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -10,6 +10,7 @@ require "yaml"
 require_relative "analysis_job"
 require_relative "anthropic_client"
 require_relative "brief_store"
+require_relative "presence"
 
 module ButtercutUiSidecar
   # UI-driven rough cut: combine visual transcripts → Sonnet YAML → existing export script.
@@ -22,7 +23,7 @@ module ButtercutUiSidecar
       missing = []
       (library_data["videos"] || []).each do |v|
         base = File.basename(v["path"].to_s)
-        absent = PREREQ_KEYS.reject { |k| RoughcutController.present?(v[k]) }
+        absent = PREREQ_KEYS.reject { |k| Presence.present?(v[k]) }
         missing << { "video" => base, "missing" => absent } unless absent.empty?
       end
       { ok: missing.empty?, missing: missing }
@@ -32,7 +33,7 @@ module ButtercutUiSidecar
       lines = []
       (library_data["videos"] || []).each do |v|
         fn = v["visual_transcript"]
-        next unless RoughcutController.present?(fn)
+        next unless Presence.present?(fn)
 
         path = lib_dir.join("transcripts", fn.to_s)
         next unless path.file?
@@ -42,10 +43,6 @@ module ButtercutUiSidecar
         lines << JSON.generate(obj)
       end
       lines.join("\n") + "\n"
-    end
-
-    def self.present?(value)
-      !value.nil? && !value.to_s.empty?
     end
 
     def self.timecode_to_seconds(tc)
@@ -255,13 +252,24 @@ module ButtercutUiSidecar
     end
 
     def extract_yaml_fence(text)
-      if text =~ /```yaml\s*\n(.*?)\n```/m
-        Regexp.last_match(1)
-      elsif text =~ /```\s*\n(.*?)\n```/m
-        Regexp.last_match(1)
-      else
-        text.strip
+      body = text.to_s
+      if (m = body.match(/```(?:yaml|yml)\s*\n([\s\S]*?)```/mi))
+        return m[1].strip
       end
+
+      body.scan(/```[^\n\r]*\r?\n([\s\S]*?)```/m).each do |(inner)|
+        begin
+          candidate = inner&.strip
+          next if candidate.nil? || candidate.empty?
+
+          parsed = YAML.safe_load(candidate, permitted_classes: [Date, Time, Symbol], aliases: true)
+          return candidate if parsed.is_a?(Hash) && parsed["clips"].is_a?(Array) && !parsed["clips"].empty?
+        rescue Psych::SyntaxError, ArgumentError
+          next
+        end
+      end
+
+      body.strip
     end
 
     def validate_roughcut_shape!(rough)
@@ -269,11 +277,11 @@ module ButtercutUiSidecar
       raise "roughcut_missing_clips" unless clips.is_a?(Array) && !clips.empty?
 
       clips.each_with_index do |c, i|
-        raise "clip #{i} missing source_file" unless self.class.present?(c["source_file"])
-        raise "clip #{i} missing in_point" unless self.class.present?(c["in_point"])
-        raise "clip #{i} missing out_point" unless self.class.present?(c["out_point"])
+        raise "clip #{i} missing source_file" unless Presence.present?(c["source_file"])
+        raise "clip #{i} missing in_point" unless Presence.present?(c["in_point"])
+        raise "clip #{i} missing out_point" unless Presence.present?(c["out_point"])
         raise "clip #{i} missing dialogue" unless c.key?("dialogue")
-        raise "clip #{i} missing visual_description" unless self.class.present?(c["visual_description"])
+        raise "clip #{i} missing visual_description" unless Presence.present?(c["visual_description"])
       end
     end
 

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "securerandom"
+require "time"
+require "yaml"
+
+require_relative "analysis_job"
+require_relative "anthropic_client"
+require_relative "brief_store"
+
+module ButtercutUiSidecar
+  # UI-driven rough cut: combine visual transcripts → Sonnet YAML → existing export script.
+  class RoughcutController
+    COMBINED_TRANSCRIPT_MAX_BYTES = 900_000
+    MODEL = AnthropicClient::VISION_MODEL
+
+    def self.prerequisites_report(library_data)
+      missing = []
+      (library_data["videos"] || []).each do |v|
+        base = File.basename(v["path"].to_s)
+        m = []
+        m << "transcript" unless RoughcutController.present?(v["transcript"])
+        m << "visual_transcript" unless RoughcutController.present?(v["visual_transcript"])
+        m << "summary" unless RoughcutController.present?(v["summary"])
+        missing << { "video" => base, "missing" => m } unless m.empty?
+      end
+      { ok: missing.empty?, missing: missing }
+    end
+
+    def self.build_combined_visual_ndjson(library_data:, lib_dir:)
+      lines = []
+      (library_data["videos"] || []).each do |v|
+        fn = v["visual_transcript"]
+        next unless RoughcutController.present?(fn)
+
+        path = lib_dir.join("transcripts", fn.to_s)
+        next unless path.file?
+
+        obj = JSON.parse(path.read)
+        obj["video_path"] = v["path"].to_s if obj["video_path"].to_s.empty?
+        lines << JSON.generate(obj)
+      end
+      lines.join("\n") + "\n"
+    end
+
+    def self.present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
+
+    def self.timecode_to_seconds(tc)
+      parts = tc.to_s.split(":")
+      return 0.0 if parts.length < 3
+
+      parts[0].to_i * 3600 + parts[1].to_i * 60 + parts[2].to_f
+    end
+
+    def self.format_timecode(total_seconds)
+      t = total_seconds.to_f
+      h = (t / 3600).floor
+      m = ((t - h * 3600) / 60).floor
+      s = t - (h * 3600) - (m * 60)
+      format("%02d:%02d:%05.2f", h, m, s)
+    end
+
+    def initialize(libraries_root:, repo_root:, notifier:, registry:, client:)
+      raise ArgumentError, "libraries_root required" if libraries_root.nil? || libraries_root.to_s.empty?
+      raise ArgumentError, "repo_root required" if repo_root.nil? || repo_root.to_s.empty?
+      raise ArgumentError, "notifier required" if notifier.nil?
+      raise ArgumentError, "registry required" if registry.nil?
+      raise ArgumentError, "client required" if client.nil?
+
+      @libraries_root = Pathname.new(libraries_root)
+      @repo_root = Pathname.new(repo_root)
+      @notifier = notifier
+      @registry = registry
+      @client = client
+    end
+
+    # Raises StandardError if prerequisites, brief, or size checks fail.
+    def validate_and_start!(library:, brief_id:)
+      lib_dir = @libraries_root.join(library)
+      raise "library.yaml not found" unless lib_dir.join("library.yaml").file?
+
+      library_data = YAML.safe_load(
+        lib_dir.join("library.yaml").read,
+        permitted_classes: [Date, Time],
+        aliases: true
+      ) || {}
+
+      pre = self.class.prerequisites_report(library_data)
+      raise "roughcut_prerequisites: #{JSON.generate(pre[:missing])}" unless pre[:ok]
+
+      store = BriefStore.new(libraries_root: @libraries_root.to_s, library: library)
+      brief = store.get(brief_id)
+      raise "unknown_brief: #{brief_id}" if brief.nil?
+
+      combined = self.class.build_combined_visual_ndjson(library_data: library_data, lib_dir: lib_dir)
+      raise "no_visual_transcripts" if combined.strip.empty?
+
+      bytes = combined.bytesize
+      if bytes > COMBINED_TRANSCRIPT_MAX_BYTES
+        raise "combined_transcript_too_large: #{bytes} bytes (max #{COMBINED_TRANSCRIPT_MAX_BYTES})"
+      end
+
+      job_id = "job-#{SecureRandom.hex(6)}"
+      job = AnalysisJob.new(id: job_id, library: library)
+      @registry.put(job_id, job)
+
+      prompt_text = brief["prompt"].to_s
+      target = Integer(brief["target_duration_seconds"])
+
+      Thread.new do
+        run_job(job: job, library: library, lib_dir: lib_dir, library_data: library_data,
+                combined_ndjson: combined, prompt_text: prompt_text, target_duration: target)
+      rescue StandardError => e
+        notify_failed(job_id, e.message)
+      ensure
+        @registry.delete(job_id)
+      end
+
+      { job_id: job_id }
+    end
+
+    private
+
+    def notify_failed(job_id, message)
+      @notifier.notify("roughcut_job_failed", job_id: job_id, message: message)
+    end
+
+    def run_job(job:, library:, lib_dir:, library_data:, combined_ndjson:, prompt_text:, target_duration:)
+      if job.canceled?
+        @notifier.notify("roughcut_job_failed", job_id: job.id, message: "canceled")
+        return
+      end
+
+      @notifier.notify("roughcut_job_started", job_id: job.id, library: library)
+      @notifier.notify("roughcut_phase", job_id: job.id, phase: "model", message: "Generating rough cut YAML…")
+
+      system_instructions = roughcut_prompt_template
+      user_blob = build_user_message(
+        library_data: library_data,
+        combined_ndjson: combined_ndjson,
+        prompt_text: prompt_text,
+        target_duration: target_duration
+      )
+
+      response = @client.messages_create(
+        model: MODEL,
+        max_tokens: 24_576,
+        temperature: 0.2,
+        system: system_instructions,
+        messages: [{ role: "user", content: user_blob }]
+      )
+      body = AnthropicClient.message_body_text(response)
+      yaml_text = extract_yaml_fence(body)
+      rough = YAML.safe_load(yaml_text, permitted_classes: [Date, Time, Symbol]) || {}
+      (rough["clips"] || []).each { |c| c["dialogue"] = "" unless c.key?("dialogue") }
+      validate_roughcut_shape!(rough)
+
+      enrich_metadata!(rough)
+      ts = Time.now.utc.strftime("%Y%m%d_%H%M%S")
+      stem = "roughcut_ui_#{ts}"
+      roughcuts_dir = lib_dir.join("roughcuts")
+      roughcuts_dir.mkpath
+      yaml_path = roughcuts_dir.join("#{stem}.yaml")
+      yaml_path.write(YAML.dump(stringify_keys_deep(rough)))
+
+      editor = resolve_editor_flag(library_data)
+      xml_path = roughcuts_dir.join(editor == "fcpx" ? "#{stem}.fcpxml" : "#{stem}.xml")
+
+      @notifier.notify("roughcut_phase", job_id: job.id, phase: "export", message: "Exporting XML and recipe…")
+      export!(yaml_path: yaml_path, xml_path: xml_path, editor: editor)
+
+      xml_base = xml_path.to_s.sub(/\.[^.]+\z/, "")
+      recipe_path = "#{xml_base}.recipe.json"
+      apply_path = "#{xml_base}_apply.py"
+      clips = (rough["clips"] || []).map do |c|
+        {
+          "source_file" => c["source_file"].to_s,
+          "in_point" => c["in_point"].to_s,
+          "out_point" => c["out_point"].to_s
+        }
+      end
+
+      @notifier.notify(
+        "roughcut_job_done",
+        job_id: job.id,
+        library: library,
+        yaml_path: yaml_path.expand_path.to_s,
+        xml_path: xml_path.expand_path.to_s,
+        recipe_path: Pathname.new(recipe_path).expand_path.to_s,
+        apply_path: Pathname.new(apply_path).expand_path.to_s,
+        clips: clips
+      )
+    end
+
+    def export!(yaml_path:, xml_path:, editor:)
+      script = @repo_root.join(".claude/skills/roughcut", "export_to_fcpxml.rb")
+      raise "export script missing: #{script}" unless script.file?
+
+      gemfile = @repo_root.join("Gemfile").to_s
+      cmd = ["bundle", "exec", "ruby", script.to_s, yaml_path.expand_path.to_s, xml_path.expand_path.to_s, editor]
+      out = +""
+      status = nil
+      Dir.chdir(@repo_root.to_s) do
+        out, status = Open3.capture2e({ "BUNDLE_GEMFILE" => gemfile }, *cmd)
+      end
+      raise "export_failed: #{out.strip}" unless status.success?
+    end
+
+    def resolve_editor_flag(library_data)
+      raw = library_data["editor"].to_s.strip.downcase
+      return normalize_editor_token(raw) unless raw.empty?
+
+      settings = @libraries_root.join("settings.yaml")
+      if settings.file?
+        s = YAML.safe_load(settings.read, permitted_classes: [Date, Time], aliases: true) || {}
+        raw2 = s["editor"].to_s.strip.downcase
+        return normalize_editor_token(raw2) unless raw2.empty?
+      end
+      "fcpx"
+    end
+
+    def normalize_editor_token(raw)
+      return "fcpx" if raw.match?(/fcpx|final\s*cut|finalcut/)
+      return "premiere" if raw.match?(/premiere|adobe/)
+      return "resolve" if raw.match?(/resolve|davinci/)
+
+      "fcpx"
+    end
+
+    def roughcut_prompt_template
+      path = Pathname.new(__dir__).join("../../prompts/roughcut_from_transcript.md")
+      raise "roughcut prompt missing: #{path}" unless path.file?
+
+      path.read
+    end
+
+    def build_user_message(library_data:, combined_ndjson:, prompt_text:, target_duration:)
+      ctx = []
+      ctx << "footage_summary: #{library_data['footage_summary']}" if library_data["footage_summary"]
+      ctx << "user_context: #{library_data['user_context']}" if library_data["user_context"]
+      <<~MSG
+        USER_BRIEF:
+        #{prompt_text}
+
+        TARGET_DURATION_SECONDS: #{target_duration}
+
+        #{ctx.join("\n")}
+
+        COMBINED_VISUAL_TRANSCRIPTS_NDJSON:
+        #{combined_ndjson}
+      MSG
+    end
+
+    def extract_yaml_fence(text)
+      if text =~ /```yaml\s*\n(.*?)\n```/m
+        Regexp.last_match(1)
+      elsif text =~ /```\s*\n(.*?)\n```/m
+        Regexp.last_match(1)
+      else
+        text.strip
+      end
+    end
+
+    def validate_roughcut_shape!(rough)
+      clips = rough["clips"]
+      raise "roughcut_missing_clips" unless clips.is_a?(Array) && !clips.empty?
+
+      clips.each_with_index do |c, i|
+        raise "clip #{i} missing source_file" unless self.class.present?(c["source_file"])
+        raise "clip #{i} missing in_point" unless self.class.present?(c["in_point"])
+        raise "clip #{i} missing out_point" unless self.class.present?(c["out_point"])
+        raise "clip #{i} missing dialogue" unless c.key?("dialogue")
+        raise "clip #{i} missing visual_description" unless self.class.present?(c["visual_description"])
+      end
+    end
+
+    def enrich_metadata!(rough)
+      clips = rough["clips"] || []
+      total = clips.sum do |c|
+        self.class.timecode_to_seconds(c["out_point"]) - self.class.timecode_to_seconds(c["in_point"])
+      end
+      rough["metadata"] ||= {}
+      rough["metadata"]["created_date"] = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S")
+      rough["metadata"]["total_duration"] = self.class.format_timecode(total)
+    end
+
+    def stringify_keys_deep(obj)
+      case obj
+      when Hash
+        obj.each_with_object({}) { |(k, v), h| h[k.to_s] = stringify_keys_deep(v) }
+      when Array
+        obj.map { |e| stringify_keys_deep(e) }
+      else
+        obj
+      end
+    end
+  end
+end

--- a/ui/sidecar/prompts/roughcut_from_transcript.md
+++ b/ui/sidecar/prompts/roughcut_from_transcript.md
@@ -1,0 +1,36 @@
+You are a professional video editor. You receive NDJSON lines: each line is one JSON object describing one video's visual transcript (`video_path`, `segments` with `start`, `end`, `text`, optional `visual`, optional `b_roll`).
+
+## User brief
+
+The human described what they want in this cut, and a **target duration in seconds** (wall-clock length of the finished sequence). Aim for that duration (±15% is acceptable).
+
+## Output contract
+
+Return **only** one fenced Markdown block of YAML (language tag `yaml`). No prose before or after the fence.
+
+The YAML must follow this shape (populate all clip rows; you may omit optional editorial keys unless justified):
+
+```yaml
+description: "One sentence describing the cut"
+notes: |
+  Short working notes.
+footage_coverage: |
+  How you used the footage.
+clips:
+  - source_file: "filename.ext"
+    in_point: "HH:MM:SS.ss"
+    out_point: "HH:MM:SS.ss"
+    dialogue: "spoken text for this span or empty string"
+    visual_description: "shot description"
+metadata:
+  created_date: "YYYY-MM-DD HH:MM:SS"
+  total_duration: "HH:MM:SS.ss"
+```
+
+Rules:
+
+- `source_file` must be **only the basename** exactly as it appears in the input JSON (not a full path).
+- `in_point` / `out_point` use hundredths where needed; they must align to segment boundaries from the transcript.
+- Every clip needs `dialogue` and `visual_description` (use `""` for silent B-roll dialogue).
+- Order clips in timeline order.
+- `metadata.total_duration` must equal the sum of clip durations (out − in) formatted as `HH:MM:SS.ss`.

--- a/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+++ b/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
@@ -102,6 +102,50 @@ RSpec.describe ButtercutUiSidecar do
     end
   end
 
+  describe "roughcut_prerequisites" do
+    it "returns ok false when a summary is missing" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo",
+          videos: [{ path: "/x/a.mp4", transcript: "a.json", visual_transcript: "visual_a.json", summary: "" }])
+        r = call(root, "roughcut_prerequisites", { library: "demo" })
+        expect(r["error"]).to be_nil
+        expect(r["result"]["ok"]).to be false
+        expect(r["result"]["missing"].first["video"]).to eq("a.mp4")
+      end
+    end
+
+    it "returns ok true when all three artifacts are listed per video" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo",
+          videos: [{ path: "/x/a.mp4", transcript: "a.json", visual_transcript: "visual_a.json", summary: "s.md" }])
+        r = call(root, "roughcut_prerequisites", { library: "demo" })
+        expect(r["result"]["ok"]).to be true
+        expect(r["result"]["missing"]).to eq([])
+      end
+    end
+  end
+
+  describe "list_briefs and upsert_brief" do
+    it "round-trips a brief in the library catalog" do
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p(File.join(root, "demo"))
+        File.write(File.join(root, "demo", "library.yaml"), YAML.dump("library_name" => "demo"))
+
+        r1 = call(root, "upsert_brief", {
+          library: "demo",
+          prompt: "Open on action",
+          target_duration_seconds: 45
+        })
+        expect(r1["error"]).to be_nil
+        id = r1["result"]["id"]
+
+        r2 = call(root, "list_briefs", { library: "demo" })
+        expect(r2["result"]["briefs"].first["id"]).to eq(id)
+        expect(r2["result"]["briefs"].first["prompt"]).to eq("Open on action")
+      end
+    end
+  end
+
   describe "has_api_key" do
     it "returns false when no key is configured" do
       prev = ENV.delete("ANTHROPIC_API_KEY")
@@ -172,7 +216,7 @@ RSpec.describe ButtercutUiSidecar do
         File.write(cached, "fake-jpg-bytes")
 
         r = call(root, "get_or_generate_thumbnail", { library: "demo", video: "a.mp4" })["result"]
-        expect(r["path"]).to eq(cached)
+        expect(File.realpath(r["path"])).to eq(File.realpath(cached))
       end
     end
 

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
@@ -6,6 +6,13 @@ require "yaml"
 require_relative "../../../lib/buttercut_ui_sidecar/brief_store"
 
 RSpec.describe ButtercutUiSidecar::BriefStore do
+  it "refuses upsert when the library directory does not exist" do
+    Dir.mktmpdir do |root|
+      store = described_class.new(libraries_root: root, library: "missing-lib")
+      expect { store.upsert(id: nil, prompt: "x", target_duration_seconds: 10) }.to raise_error(/library directory missing/)
+    end
+  end
+
   it "upserts, lists newest first, and forks" do
     Dir.mktmpdir do |root|
       FileUtils.mkdir_p(File.join(root, "demo"))

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
@@ -31,4 +31,41 @@ RSpec.describe ButtercutUiSidecar::BriefStore do
       expect(parent["target_duration_seconds"]).to eq(90)
     end
   end
+
+  it "sorts rows with invalid updated_at last without raising" do
+    Dir.mktmpdir do |root|
+      FileUtils.mkdir_p(File.join(root, "demo", "briefs"))
+      catalog = File.join(root, "demo", "briefs", "catalog.yaml")
+      File.write(
+        catalog,
+        YAML.dump(
+          "briefs" => [
+            {
+              "id" => "b-bad",
+              "parent_id" => nil,
+              "prompt" => "old",
+              "target_duration_seconds" => 1,
+              "title" => "",
+              "created_at" => "2020-01-01T00:00:00.000Z",
+              "updated_at" => "not-a-valid-time"
+            },
+            {
+              "id" => "b-good",
+              "parent_id" => nil,
+              "prompt" => "new",
+              "target_duration_seconds" => 1,
+              "title" => "",
+              "created_at" => "2020-01-01T00:00:00.000Z",
+              "updated_at" => "2026-06-01T12:00:00.000Z"
+            }
+          ]
+        )
+      )
+
+      store = described_class.new(libraries_root: root, library: "demo")
+      rows = store.list
+      expect(rows.first["id"]).to eq("b-good")
+      expect(rows.last["id"]).to eq("b-bad")
+    end
+  end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/brief_store_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/brief_store"
+
+RSpec.describe ButtercutUiSidecar::BriefStore do
+  it "upserts, lists newest first, and forks" do
+    Dir.mktmpdir do |root|
+      FileUtils.mkdir_p(File.join(root, "demo"))
+      File.write(File.join(root, "demo", "library.yaml"), YAML.dump("library_name" => "demo"))
+
+      store = described_class.new(libraries_root: root, library: "demo")
+
+      id1 = store.upsert(id: nil, prompt: "First cut", target_duration_seconds: 60, title: "v1")
+      expect(id1).to start_with("b-")
+
+      id2 = store.upsert(id: id1, prompt: "First cut revised", target_duration_seconds: 90, title: "v1b")
+      expect(id2).to eq(id1)
+
+      forked = store.fork(parent_id: id1)
+      expect(forked).not_to eq(id1)
+
+      rows = store.list
+      expect(rows.first["id"]).to eq(forked)
+      expect(rows.first["parent_id"]).to eq(id1)
+      expect(rows.first["prompt"]).to eq("First cut revised")
+
+      parent = rows.find { |r| r["id"] == id1 }
+      expect(parent["target_duration_seconds"]).to eq(90)
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/presence_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/presence_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/buttercut_ui_sidecar/presence"
+
+RSpec.describe ButtercutUiSidecar::Presence do
+  it "is false for nil and empty string" do
+    expect(described_class.present?(nil)).to be false
+    expect(described_class.present?("")).to be false
+  end
+
+  it "treats whitespace-only strings as present (matches path / YAML field checks)" do
+    expect(described_class.present?("  ")).to be true
+  end
+
+  it "is true for non-empty strings and other values" do
+    expect(described_class.present?("x")).to be true
+    expect(described_class.present?(0)).to be true
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
@@ -110,4 +110,51 @@ RSpec.describe ButtercutUiSidecar::RoughcutController do
       expect(Open3).to have_received(:capture2e)
     end
   end
+
+  describe "#extract_yaml_fence" do
+    let(:controller) { described_class.allocate }
+
+    it "extracts multiline ```yaml bodies" do
+      inner = <<~YAML.strip
+        clips:
+          - source_file: a.mp4
+            in_point: "00:00:00.00"
+            out_point: "00:00:01.00"
+            dialogue: ""
+            visual_description: "x"
+      YAML
+      text = "Intro\n```yaml\n#{inner}\n```\n"
+      expect(controller.send(:extract_yaml_fence, text)).to eq(inner)
+    end
+
+    it "prefers ```yaml over an earlier non-roughcut fence" do
+      yaml_inner = <<~YAML.strip
+        clips:
+          - source_file: a.mp4
+            in_point: "00:00:00.00"
+            out_point: "00:00:01.00"
+            dialogue: ""
+            visual_description: "x"
+      YAML
+      text = <<~MD
+        ```json
+        {"note": "not roughcut yaml"}
+        ```
+        ```yaml
+        #{yaml_inner}
+        ```
+      MD
+      expect(controller.send(:extract_yaml_fence, text)).to eq(yaml_inner)
+    end
+
+    it "accepts an untagged fence that parses as roughcut YAML" do
+      inner = fake_yaml.strip
+      text = "```\n#{inner}\n```"
+      expect(controller.send(:extract_yaml_fence, text)).to eq(inner)
+    end
+
+    it "returns stripped raw text when no fence matches" do
+      expect(controller.send(:extract_yaml_fence, "  clips: []\n")).to eq("clips: []")
+    end
+  end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
@@ -157,4 +157,53 @@ RSpec.describe ButtercutUiSidecar::RoughcutController do
       expect(controller.send(:extract_yaml_fence, "  clips: []\n")).to eq("clips: []")
     end
   end
+
+  describe ".safe_visual_transcript_path" do
+    it "rejects absolute paths and path traversal" do
+      lib = Pathname.new("/tmp/demo_lib")
+      expect { described_class.safe_visual_transcript_path(lib, "/etc/passwd") }.to raise_error(/invalid_visual_transcript_ref/)
+      expect { described_class.safe_visual_transcript_path(lib, "..#{File::SEPARATOR}x.json") }.to raise_error(/invalid_visual_transcript_ref/)
+    end
+
+    it "returns a path under transcripts for a basename" do
+      lib = Pathname.new("/tmp/demo_lib")
+      p = described_class.safe_visual_transcript_path(lib, "foo.json")
+      expect(p.to_s).to end_with(File.join("transcripts", "foo.json"))
+    end
+  end
+
+  describe "#validate_roughcut_shape!" do
+    let(:controller) { described_class.allocate }
+    let(:library_data) { { "videos" => [{ "path" => "/vol/a.mp4" }] } }
+
+    it "rejects source_file not in the library" do
+      rough = {
+        "clips" => [
+          {
+            "source_file" => "other.mp4",
+            "in_point" => "00:00:00.00",
+            "out_point" => "00:00:01.00",
+            "dialogue" => "",
+            "visual_description" => "x"
+          }
+        ]
+      }
+      expect { controller.send(:validate_roughcut_shape!, rough, library_data) }.to raise_error(/invalid_source_file/)
+    end
+
+    it "rejects out_point <= in_point" do
+      rough = {
+        "clips" => [
+          {
+            "source_file" => "a.mp4",
+            "in_point" => "00:00:05.00",
+            "out_point" => "00:00:01.00",
+            "dialogue" => "",
+            "visual_description" => "x"
+          }
+        ]
+      }
+      expect { controller.send(:validate_roughcut_shape!, rough, library_data) }.to raise_error(/invalid_time_range/)
+    end
+  end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require "stringio"
+require_relative "../../../lib/buttercut_ui_sidecar/notifier"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
+require_relative "../../../lib/buttercut_ui_sidecar/roughcut_controller"
+require_relative "../../fixtures/library_fixture"
+
+RSpec.describe ButtercutUiSidecar::RoughcutController do
+  def repo_root
+    File.expand_path("../../../../../", __dir__)
+  end
+
+  let(:fake_yaml) do
+    <<~YAML
+      description: "Test"
+      notes: ""
+      footage_coverage: ""
+      clips:
+        - source_file: "a.mp4"
+          in_point: "00:00:00.00"
+          out_point: "00:00:01.00"
+          dialogue: "hello"
+          visual_description: "wide shot"
+      metadata:
+        created_date: ""
+        total_duration: ""
+    YAML
+  end
+
+  it "prerequisites_report flags missing fields" do
+    data = {
+      "videos" => [
+        { "path" => "/x/a.mp4", "transcript" => "a.json", "visual_transcript" => "", "summary" => "s.md" }
+      ]
+    }
+    r = described_class.prerequisites_report(data)
+    expect(r[:ok]).to be false
+    expect(r[:missing].first["missing"]).to include("visual_transcript")
+  end
+
+  it "runs model + export and notifies done" do
+    Dir.mktmpdir do |root|
+      video = File.join(root, "a.mp4")
+      File.write(video, "x")
+      lib_dir = LibraryFixture.build(
+        root,
+        name: "demo",
+        videos: [{
+          path: video,
+          transcript: "a.json",
+          visual_transcript: "visual_a.json",
+          summary: "summary_a.md"
+        }]
+      )
+      LibraryFixture.write_visual_transcript(lib_dir, "visual_a.json", segments: [
+        { start: 0.0, end: 2.0, text: "hello", visual: "wide" }
+      ])
+      yaml_lib = YAML.safe_load(File.read(File.join(lib_dir, "library.yaml")))
+      yaml_lib["editor"] = "fcpx"
+      File.write(File.join(lib_dir, "library.yaml"), YAML.dump(yaml_lib))
+
+      store = ButtercutUiSidecar::BriefStore.new(libraries_root: root, library: "demo")
+      bid = store.upsert(id: nil, prompt: "Make a one second cut", target_duration_seconds: 5, title: "t")
+
+      io = StringIO.new
+      notifier = ButtercutUiSidecar::Notifier.new(io: io)
+
+      client = instance_double(ButtercutUiSidecar::AnthropicClient)
+      wrapped = "```yaml\n#{fake_yaml}\n```"
+      allow(client).to receive(:messages_create).and_return(
+        { "content" => [{ "text" => wrapped }] }
+      )
+
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e).and_return(["export ok", status])
+
+      controller = described_class.new(
+        libraries_root: root,
+        repo_root: repo_root,
+        notifier: notifier,
+        registry: ButtercutUiSidecar::JobRegistry.new,
+        client: client
+      )
+
+      controller.validate_and_start!(library: "demo", brief_id: bid)
+
+      deadline = Time.now + 5
+      loop do
+        break if io.string.include?("roughcut_job_done") || io.string.include?("roughcut_job_failed")
+        raise "roughcut job did not finish" if Time.now > deadline
+
+        sleep 0.02
+      end
+
+      lines = io.string.lines.map { |l| JSON.parse(l) }
+      methods = lines.map { |x| x["method"] }
+      expect(methods).to include("roughcut_job_done")
+
+      done = lines.reverse.find { |x| x["method"] == "roughcut_job_done" }
+      expect(done["params"]["clips"].size).to eq(1)
+      expect(done["params"]["yaml_path"]).to end_with(".yaml")
+      expect(done["params"]["xml_path"]).to end_with(".fcpxml")
+      expect(done["params"]["recipe_path"]).to end_with(".recipe.json")
+      expect(done["params"]["apply_path"]).to end_with("_apply.py")
+
+      expect(Open3).to have_received(:capture2e)
+    end
+  end
+end

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -109,6 +109,62 @@ async fn cancel_job(job_id: String) -> Result<Value, String> {
 }
 
 #[tauri::command]
+async fn roughcut_prerequisites(library: String) -> Result<Value, String> {
+    sidecar::call("roughcut_prerequisites", json!({ "library": library }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn list_briefs(library: String) -> Result<Value, String> {
+    sidecar::call("list_briefs", json!({ "library": library }))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn upsert_brief(
+    library: String,
+    prompt: String,
+    target_duration_seconds: u32,
+    id: Option<String>,
+    title: Option<String>,
+) -> Result<Value, String> {
+    sidecar::call(
+        "upsert_brief",
+        json!({
+            "library": library,
+            "prompt": prompt,
+            "target_duration_seconds": target_duration_seconds,
+            "id": id,
+            "title": title
+        }),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn fork_brief(library: String, parent_id: String) -> Result<Value, String> {
+    sidecar::call(
+        "fork_brief",
+        json!({ "library": library, "parent_id": parent_id }),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn start_roughcut(library: String, brief_id: String) -> Result<Value, String> {
+    sidecar::call(
+        "start_roughcut",
+        json!({ "library": library, "brief_id": brief_id }),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 async fn apply_transcript_edit(library: String, clip: String, edit: Value) -> Result<Value, String> {
     sidecar::call(
         "apply_transcript_edit",
@@ -245,7 +301,12 @@ pub fn run() {
             cancel_job,
             apply_transcript_edit,
             find_transcript_matches,
-            apply_library_replace
+            apply_library_replace,
+            roughcut_prerequisites,
+            list_briefs,
+            upsert_brief,
+            fork_brief,
+            start_roughcut
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ui/src/ipc/events.ts
+++ b/ui/src/ipc/events.ts
@@ -27,8 +27,15 @@ export type JobEvent =
       params: { job_id: string; succeeded_count: number; failed_count: number; ts: string };
     };
 
+async function listenSidecarJobChannel<T>(
+  jobId: string,
+  handler: (event: T) => void,
+): Promise<UnlistenFn> {
+  return listen<T>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+}
+
 export async function listenJobEvents(jobId: string, handler: (event: JobEvent) => void): Promise<UnlistenFn> {
-  return listen<JobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+  return listenSidecarJobChannel<JobEvent>(jobId, handler);
 }
 
 /** Paths returned with `roughcut_job_done` (all absolute). */
@@ -63,5 +70,5 @@ export async function listenRoughcutJobEvents(
   jobId: string,
   handler: (event: RoughcutJobEvent) => void,
 ): Promise<UnlistenFn> {
-  return listen<RoughcutJobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+  return listenSidecarJobChannel<RoughcutJobEvent>(jobId, handler);
 }

--- a/ui/src/ipc/events.ts
+++ b/ui/src/ipc/events.ts
@@ -31,6 +31,16 @@ export async function listenJobEvents(jobId: string, handler: (event: JobEvent) 
   return listen<JobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
 }
 
+/** Paths returned with `roughcut_job_done` (all absolute). */
+export type RoughcutArtifactPaths = {
+  yaml_path: string;
+  xml_path: string;
+  recipe_path: string;
+  apply_path: string;
+};
+
+export type RoughcutClip = { source_file: string; in_point: string; out_point: string };
+
 export type RoughcutJobEvent =
   | { method: "roughcut_job_started"; params: { job_id: string; library: string; ts?: string } }
   | { method: "roughcut_phase"; params: { job_id: string; phase: string; message?: string; ts?: string } }
@@ -43,7 +53,7 @@ export type RoughcutJobEvent =
         xml_path: string;
         recipe_path: string;
         apply_path: string;
-        clips: { source_file: string; in_point: string; out_point: string }[];
+        clips: RoughcutClip[];
         ts?: string;
       };
     }

--- a/ui/src/ipc/events.ts
+++ b/ui/src/ipc/events.ts
@@ -30,3 +30,28 @@ export type JobEvent =
 export async function listenJobEvents(jobId: string, handler: (event: JobEvent) => void): Promise<UnlistenFn> {
   return listen<JobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
 }
+
+export type RoughcutJobEvent =
+  | { method: "roughcut_job_started"; params: { job_id: string; library: string; ts?: string } }
+  | { method: "roughcut_phase"; params: { job_id: string; phase: string; message?: string; ts?: string } }
+  | {
+      method: "roughcut_job_done";
+      params: {
+        job_id: string;
+        library: string;
+        yaml_path: string;
+        xml_path: string;
+        recipe_path: string;
+        apply_path: string;
+        clips: { source_file: string; in_point: string; out_point: string }[];
+        ts?: string;
+      };
+    }
+  | { method: "roughcut_job_failed"; params: { job_id: string; message: string; ts?: string } };
+
+export async function listenRoughcutJobEvents(
+  jobId: string,
+  handler: (event: RoughcutJobEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<RoughcutJobEvent>(`sidecar-event:${jobId}`, (e) => handler(e.payload));
+}

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -87,6 +87,38 @@ export async function cancelJob(jobId: string): Promise<void> {
   await invoke("cancel_job", { jobId });
 }
 
+export async function roughcutPrerequisites(library: string): Promise<{ ok: boolean; missing: { video: string; missing: string[] }[] }> {
+  return invoke("roughcut_prerequisites", { library });
+}
+
+export async function listBriefs(library: string): Promise<{ briefs: Record<string, unknown>[] }> {
+  return invoke("list_briefs", { library });
+}
+
+export async function upsertBrief(args: {
+  library: string;
+  prompt: string;
+  targetDurationSeconds: number;
+  id?: string;
+  title?: string;
+}): Promise<{ id: string }> {
+  return invoke("upsert_brief", {
+    library: args.library,
+    prompt: args.prompt,
+    targetDurationSeconds: args.targetDurationSeconds,
+    id: args.id ?? null,
+    title: args.title ?? null,
+  });
+}
+
+export async function forkBrief(library: string, parentId: string): Promise<{ id: string }> {
+  return invoke("fork_brief", { library, parentId });
+}
+
+export async function startRoughcut(library: string, briefId: string): Promise<{ job_id: string }> {
+  return invoke("start_roughcut", { library, briefId });
+}
+
 export async function openNewProjectWindow(): Promise<void> {
   await invoke("open_new_project_window");
 }

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import {
+  cancelJob,
+  forkBrief,
+  hasApiKey,
+  listBriefs,
+  roughcutPrerequisites,
+  startRoughcut,
+  upsertBrief,
+} from "../../ipc/sidecar";
+import { listenRoughcutJobEvents, type RoughcutJobEvent } from "../../ipc/events";
+
+export interface BriefRow {
+  id: string;
+  parent_id: string | null;
+  prompt: string;
+  target_duration_seconds: number;
+  title: string;
+  created_at: string;
+  updated_at: string;
+}
+
+type PrereqRow = { video: string; missing: string[] };
+
+export default function BriefComposer({ library }: { library: string }) {
+  const [prereqOk, setPrereqOk] = useState<boolean | null>(null);
+  const [prereqMissing, setPrereqMissing] = useState<PrereqRow[]>([]);
+  const [briefs, setBriefs] = useState<BriefRow[]>([]);
+  const [prompt, setPrompt] = useState("");
+  const [targetSeconds, setTargetSeconds] = useState(120);
+  const [currentBriefId, setCurrentBriefId] = useState<string | null>(null);
+  const [phaseMessage, setPhaseMessage] = useState<string | null>(null);
+  const [jobRunning, setJobRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [donePaths, setDonePaths] = useState<{
+    yaml_path: string;
+    xml_path: string;
+    recipe_path: string;
+    apply_path: string;
+  } | null>(null);
+  const [clips, setClips] = useState<{ source_file: string; in_point: string; out_point: string }[]>([]);
+  const activeJobIdRef = useRef<string | null>(null);
+  const unlistenRef = useRef<null | (() => void)>(null);
+
+  const refreshBriefs = useCallback(async () => {
+    const r = await listBriefs(library);
+    setBriefs((r.briefs as unknown as BriefRow[]) ?? []);
+  }, [library]);
+
+  const refreshPrereq = useCallback(async () => {
+    const r = await roughcutPrerequisites(library);
+    setPrereqOk(!!r.ok);
+    setPrereqMissing(r.missing ?? []);
+  }, [library]);
+
+  useEffect(() => {
+    void refreshPrereq();
+    void refreshBriefs();
+  }, [refreshBriefs, refreshPrereq]);
+
+  useEffect(
+    () => () => {
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+    },
+    [],
+  );
+
+  async function handleSaveBrief() {
+    setError(null);
+    const { id } = await upsertBrief({
+      library,
+      prompt,
+      targetDurationSeconds: targetSeconds,
+      id: currentBriefId ?? undefined,
+    });
+    setCurrentBriefId(id);
+    await refreshBriefs();
+  }
+
+  async function handleFork(parentId: string) {
+    setError(null);
+    const { id } = await forkBrief(library, parentId);
+    const row = briefs.find((b) => b.id === parentId);
+    setCurrentBriefId(id);
+    if (row) {
+      setPrompt(row.prompt);
+      setTargetSeconds(row.target_duration_seconds);
+    }
+    await refreshBriefs();
+  }
+
+  async function handleGenerate() {
+    setError(null);
+    setDonePaths(null);
+    setClips([]);
+    setPhaseMessage(null);
+    unlistenRef.current?.();
+    unlistenRef.current = null;
+
+    const key = await hasApiKey();
+    if (!key.configured) {
+      setError("Add your Anthropic API key in New Project before generating a rough cut.");
+      return;
+    }
+
+    if (!prereqOk) {
+      setError(
+        "Footage analysis is incomplete for one or more clips. Finish transcripts, visuals, and summaries first.",
+      );
+      return;
+    }
+
+    const { id: briefId } = await upsertBrief({
+      library,
+      prompt,
+      targetDurationSeconds: targetSeconds,
+      id: currentBriefId ?? undefined,
+    });
+    setCurrentBriefId(briefId);
+
+    let jobId: string;
+    try {
+      const started = await startRoughcut(library, briefId);
+      jobId = started.job_id;
+    } catch (e) {
+      setError(String(e));
+      return;
+    }
+
+    activeJobIdRef.current = jobId;
+    setJobRunning(true);
+
+    const unlisten = await listenRoughcutJobEvents(jobId, (ev: RoughcutJobEvent) => {
+      if (ev.method === "roughcut_phase") {
+        setPhaseMessage(ev.params.message ?? ev.params.phase);
+      }
+      if (ev.method === "roughcut_job_done") {
+        setDonePaths({
+          yaml_path: ev.params.yaml_path,
+          xml_path: ev.params.xml_path,
+          recipe_path: ev.params.recipe_path,
+          apply_path: ev.params.apply_path,
+        });
+        setClips(ev.params.clips);
+        setJobRunning(false);
+        setPhaseMessage(null);
+        activeJobIdRef.current = null;
+        unlisten();
+        if (unlistenRef.current === unlisten) unlistenRef.current = null;
+      }
+      if (ev.method === "roughcut_job_failed") {
+        setError(ev.params.message);
+        setJobRunning(false);
+        setPhaseMessage(null);
+        activeJobIdRef.current = null;
+        unlisten();
+        if (unlistenRef.current === unlisten) unlistenRef.current = null;
+      }
+    });
+    unlistenRef.current = unlisten;
+  }
+
+  function handleCancelJob() {
+    const id = activeJobIdRef.current;
+    if (id) void cancelJob(id);
+    unlistenRef.current?.();
+    unlistenRef.current = null;
+    activeJobIdRef.current = null;
+    setJobRunning(false);
+    setPhaseMessage(null);
+  }
+
+  return (
+    <section className="brief-composer">
+      <header className="brief-composer__header">
+        <h2 className="brief-composer__title">Rough cut</h2>
+        {prereqOk === false && (
+          <p className="brief-composer__warn">
+            Analysis incomplete. Each clip needs audio transcript, visual transcript, and summary.
+            {prereqMissing.length > 0 && (
+              <span className="brief-composer__warn-detail">
+                {" "}
+                Missing:{" "}
+                {prereqMissing.map((m) => `${m.video} (${m.missing.join(", ")})`).join("; ")}
+              </span>
+            )}
+          </p>
+        )}
+        {prereqOk && <p className="brief-composer__ok">All clips ready for rough cut generation.</p>}
+      </header>
+
+      <div className="brief-composer__grid">
+        <div className="brief-composer__editor">
+          <label className="brief-composer__label" htmlFor="brief-prompt">
+            Brief
+          </label>
+          <textarea
+            id="brief-prompt"
+            className="brief-composer__textarea"
+            rows={8}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Describe the story, pacing, and what to include or avoid…"
+          />
+
+          <label className="brief-composer__label" htmlFor="brief-duration">
+            Target duration (seconds)
+          </label>
+          <input
+            id="brief-duration"
+            className="brief-composer__input"
+            type="number"
+            min={5}
+            max={86_400}
+            value={targetSeconds}
+            onChange={(e) => setTargetSeconds(Number(e.target.value) || 0)}
+          />
+
+          <div className="brief-composer__actions">
+            <button type="button" className="brief-composer__btn" onClick={() => void handleSaveBrief()}>
+              Save brief
+            </button>
+            <button
+              type="button"
+              className="brief-composer__btn brief-composer__btn--primary"
+              disabled={jobRunning || !prompt.trim()}
+              onClick={() => void handleGenerate()}
+            >
+              {jobRunning ? "Generating…" : "Generate"}
+            </button>
+            {jobRunning && (
+              <button type="button" className="brief-composer__btn" onClick={handleCancelJob}>
+                Cancel
+              </button>
+            )}
+          </div>
+          {phaseMessage && <p className="brief-composer__phase">{phaseMessage}</p>}
+          {error && <pre className="brief-composer__error">{error}</pre>}
+        </div>
+
+        <aside className="brief-composer__history">
+          <h3 className="brief-composer__history-title">Brief history</h3>
+          <ul className="brief-composer__list">
+            {briefs.map((b) => (
+              <li key={b.id} className="brief-composer__history-item">
+                <button
+                  type="button"
+                  className="brief-composer__history-load"
+                  onClick={() => {
+                    setCurrentBriefId(b.id);
+                    setPrompt(b.prompt);
+                    setTargetSeconds(b.target_duration_seconds);
+                  }}
+                >
+                  Load
+                </button>
+                <button type="button" className="brief-composer__history-fork" onClick={() => void handleFork(b.id)}>
+                  Fork
+                </button>
+                <div className="brief-composer__history-meta">
+                  <span className="brief-composer__history-id">{b.id}</span>
+                  <span className="brief-composer__history-time">{b.updated_at}</span>
+                </div>
+                <p className="brief-composer__history-snippet">
+                  {b.prompt.slice(0, 120)}
+                  {b.prompt.length > 120 ? "…" : ""}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+
+      {clips.length > 0 && (
+        <div className="brief-composer__results">
+          <h3 className="brief-composer__results-title">Selected clips</h3>
+          <table className="brief-composer__table">
+            <thead>
+              <tr>
+                <th>Source</th>
+                <th>In</th>
+                <th>Out</th>
+              </tr>
+            </thead>
+            <tbody>
+              {clips.map((c, i) => (
+                <tr key={`${c.source_file}-${i}`}>
+                  <td>{c.source_file}</td>
+                  <td className="brief-composer__mono">{c.in_point}</td>
+                  <td className="brief-composer__mono">{c.out_point}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {donePaths && (
+            <div className="brief-composer__paths">
+              <p className="brief-composer__paths-label">Artifacts (reveal in Finder)</p>
+              <ul>
+                <li>
+                  <button
+                    type="button"
+                    className="brief-composer__linkish"
+                    onClick={() => void revealItemInDir(donePaths.xml_path)}
+                  >
+                    {donePaths.xml_path}
+                  </button>
+                </li>
+                <li>
+                  <button
+                    type="button"
+                    className="brief-composer__linkish"
+                    onClick={() => void revealItemInDir(donePaths.yaml_path)}
+                  >
+                    {donePaths.yaml_path}
+                  </button>
+                </li>
+                <li>
+                  <button
+                    type="button"
+                    className="brief-composer__linkish"
+                    onClick={() => void revealItemInDir(donePaths.recipe_path)}
+                  >
+                    {donePaths.recipe_path}
+                  </button>
+                </li>
+                <li>
+                  <button
+                    type="button"
+                    className="brief-composer__linkish"
+                    onClick={() => void revealItemInDir(donePaths.apply_path)}
+                  >
+                    {donePaths.apply_path}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -29,6 +29,14 @@ export interface BriefRow {
 
 type PrereqRow = { video: string; missing: string[] };
 
+const MIN_TARGET_DURATION = 5;
+const MAX_TARGET_DURATION = 86_400;
+
+function clampTargetSeconds(raw: number): number {
+  if (!Number.isFinite(raw)) return MIN_TARGET_DURATION;
+  return Math.max(MIN_TARGET_DURATION, Math.min(MAX_TARGET_DURATION, Math.floor(raw)));
+}
+
 const ARTIFACT_PATH_KEYS: (keyof RoughcutArtifactPaths)[] = [
   "xml_path",
   "yaml_path",
@@ -85,26 +93,34 @@ export default function BriefComposer({ library }: { library: string }) {
 
   async function handleSaveBrief() {
     setError(null);
-    const { id } = await upsertBrief({
-      library,
-      prompt,
-      targetDurationSeconds: targetSeconds,
-      id: currentBriefId ?? undefined,
-    });
-    setCurrentBriefId(id);
-    await refreshBriefs();
+    try {
+      const { id } = await upsertBrief({
+        library,
+        prompt,
+        targetDurationSeconds: clampTargetSeconds(targetSeconds),
+        id: currentBriefId ?? undefined,
+      });
+      setCurrentBriefId(id);
+      await refreshBriefs();
+    } catch (e) {
+      setError(String(e));
+    }
   }
 
   async function handleFork(parentId: string) {
     setError(null);
-    const { id } = await forkBrief(library, parentId);
-    const row = briefs.find((b) => b.id === parentId);
-    setCurrentBriefId(id);
-    if (row) {
-      setPrompt(row.prompt);
-      setTargetSeconds(row.target_duration_seconds);
+    try {
+      const { id } = await forkBrief(library, parentId);
+      const row = briefs.find((b) => b.id === parentId);
+      setCurrentBriefId(id);
+      if (row) {
+        setPrompt(row.prompt);
+        setTargetSeconds(clampTargetSeconds(row.target_duration_seconds));
+      }
+      await refreshBriefs();
+    } catch (e) {
+      setError(String(e));
     }
-    await refreshBriefs();
   }
 
   async function handleGenerate() {
@@ -115,69 +131,75 @@ export default function BriefComposer({ library }: { library: string }) {
     unlistenRef.current?.();
     unlistenRef.current = null;
 
-    const key = await hasApiKey();
-    if (!key.configured) {
-      setError("Add your Anthropic API key in New Project before generating a rough cut.");
-      return;
-    }
-
-    if (!prereqOk) {
-      setError(
-        "Footage analysis is incomplete for one or more clips. Finish transcripts, visuals, and summaries first.",
-      );
-      return;
-    }
-
-    const { id: briefId } = await upsertBrief({
-      library,
-      prompt,
-      targetDurationSeconds: targetSeconds,
-      id: currentBriefId ?? undefined,
-    });
-    setCurrentBriefId(briefId);
-
-    let jobId: string;
     try {
+      const key = await hasApiKey();
+      if (!key.configured) {
+        setError("Add your Anthropic API key in New Project before generating a rough cut.");
+        return;
+      }
+
+      if (!prereqOk) {
+        setError(
+          "Footage analysis is incomplete for one or more clips. Finish transcripts, visuals, and summaries first.",
+        );
+        return;
+      }
+
+      const duration = clampTargetSeconds(targetSeconds);
+      setTargetSeconds(duration);
+
+      const { id: briefId } = await upsertBrief({
+        library,
+        prompt,
+        targetDurationSeconds: duration,
+        id: currentBriefId ?? undefined,
+      });
+      setCurrentBriefId(briefId);
+
       const started = await startRoughcut(library, briefId);
-      jobId = started.job_id;
+      const jobId = started.job_id;
+
+      activeJobIdRef.current = jobId;
+      setJobRunning(true);
+
+      const unlisten = await listenRoughcutJobEvents(jobId, (ev: RoughcutJobEvent) => {
+        switch (ev.method) {
+          case "roughcut_phase":
+            setPhaseMessage(ev.params.message ?? ev.params.phase);
+            break;
+          case "roughcut_job_done":
+            setDonePaths({
+              yaml_path: ev.params.yaml_path,
+              xml_path: ev.params.xml_path,
+              recipe_path: ev.params.recipe_path,
+              apply_path: ev.params.apply_path,
+            });
+            setClips(ev.params.clips);
+            setJobRunning(false);
+            setPhaseMessage(null);
+            activeJobIdRef.current = null;
+            disposeRoughcutListener(unlisten, unlistenRef);
+            break;
+          case "roughcut_job_failed":
+            setError(ev.params.message);
+            setJobRunning(false);
+            setPhaseMessage(null);
+            activeJobIdRef.current = null;
+            disposeRoughcutListener(unlisten, unlistenRef);
+            break;
+          default:
+            break;
+        }
+      });
+      unlistenRef.current = unlisten;
     } catch (e) {
       setError(String(e));
-      return;
+      setJobRunning(false);
+      setPhaseMessage(null);
+      activeJobIdRef.current = null;
+      unlistenRef.current?.();
+      unlistenRef.current = null;
     }
-
-    activeJobIdRef.current = jobId;
-    setJobRunning(true);
-
-    const unlisten = await listenRoughcutJobEvents(jobId, (ev: RoughcutJobEvent) => {
-      switch (ev.method) {
-        case "roughcut_phase":
-          setPhaseMessage(ev.params.message ?? ev.params.phase);
-          break;
-        case "roughcut_job_done":
-          setDonePaths({
-            yaml_path: ev.params.yaml_path,
-            xml_path: ev.params.xml_path,
-            recipe_path: ev.params.recipe_path,
-            apply_path: ev.params.apply_path,
-          });
-          setClips(ev.params.clips);
-          setJobRunning(false);
-          setPhaseMessage(null);
-          activeJobIdRef.current = null;
-          disposeRoughcutListener(unlisten, unlistenRef);
-          break;
-        case "roughcut_job_failed":
-          setError(ev.params.message);
-          setJobRunning(false);
-          setPhaseMessage(null);
-          activeJobIdRef.current = null;
-          disposeRoughcutListener(unlisten, unlistenRef);
-          break;
-        default:
-          break;
-      }
-    });
-    unlistenRef.current = unlisten;
   }
 
   function handleCancelJob() {
@@ -233,7 +255,11 @@ export default function BriefComposer({ library }: { library: string }) {
             min={5}
             max={86_400}
             value={targetSeconds}
-            onChange={(e) => setTargetSeconds(Number(e.target.value) || 0)}
+            onChange={(e) => {
+              const raw = Number(e.target.value);
+              if (!Number.isFinite(raw)) return;
+              setTargetSeconds(clampTargetSeconds(raw));
+            }}
           />
 
           <div className="brief-composer__actions">
@@ -243,7 +269,7 @@ export default function BriefComposer({ library }: { library: string }) {
             <button
               type="button"
               className="brief-composer__btn brief-composer__btn--primary"
-              disabled={jobRunning || !prompt.trim()}
+              disabled={jobRunning || !prompt.trim() || targetSeconds < MIN_TARGET_DURATION}
               onClick={() => void handleGenerate()}
             >
               {jobRunning ? "Generating…" : "Generate"}
@@ -269,7 +295,7 @@ export default function BriefComposer({ library }: { library: string }) {
                   onClick={() => {
                     setCurrentBriefId(b.id);
                     setPrompt(b.prompt);
-                    setTargetSeconds(b.target_duration_seconds);
+                    setTargetSeconds(clampTargetSeconds(b.target_duration_seconds));
                   }}
                 >
                   Load

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -1,3 +1,4 @@
+import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
@@ -9,7 +10,12 @@ import {
   startRoughcut,
   upsertBrief,
 } from "../../ipc/sidecar";
-import { listenRoughcutJobEvents, type RoughcutJobEvent } from "../../ipc/events";
+import {
+  listenRoughcutJobEvents,
+  type RoughcutArtifactPaths,
+  type RoughcutClip,
+  type RoughcutJobEvent,
+} from "../../ipc/events";
 
 export interface BriefRow {
   id: string;
@@ -23,6 +29,21 @@ export interface BriefRow {
 
 type PrereqRow = { video: string; missing: string[] };
 
+const ARTIFACT_PATH_KEYS: (keyof RoughcutArtifactPaths)[] = [
+  "xml_path",
+  "yaml_path",
+  "recipe_path",
+  "apply_path",
+];
+
+function disposeRoughcutListener(
+  unlisten: () => void,
+  ref: MutableRefObject<(() => void) | null>,
+): void {
+  unlisten();
+  if (ref.current === unlisten) ref.current = null;
+}
+
 export default function BriefComposer({ library }: { library: string }) {
   const [prereqOk, setPrereqOk] = useState<boolean | null>(null);
   const [prereqMissing, setPrereqMissing] = useState<PrereqRow[]>([]);
@@ -33,15 +54,10 @@ export default function BriefComposer({ library }: { library: string }) {
   const [phaseMessage, setPhaseMessage] = useState<string | null>(null);
   const [jobRunning, setJobRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [donePaths, setDonePaths] = useState<{
-    yaml_path: string;
-    xml_path: string;
-    recipe_path: string;
-    apply_path: string;
-  } | null>(null);
-  const [clips, setClips] = useState<{ source_file: string; in_point: string; out_point: string }[]>([]);
+  const [donePaths, setDonePaths] = useState<RoughcutArtifactPaths | null>(null);
+  const [clips, setClips] = useState<RoughcutClip[]>([]);
   const activeJobIdRef = useRef<string | null>(null);
-  const unlistenRef = useRef<null | (() => void)>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
 
   const refreshBriefs = useCallback(async () => {
     const r = await listBriefs(library);
@@ -133,30 +149,32 @@ export default function BriefComposer({ library }: { library: string }) {
     setJobRunning(true);
 
     const unlisten = await listenRoughcutJobEvents(jobId, (ev: RoughcutJobEvent) => {
-      if (ev.method === "roughcut_phase") {
-        setPhaseMessage(ev.params.message ?? ev.params.phase);
-      }
-      if (ev.method === "roughcut_job_done") {
-        setDonePaths({
-          yaml_path: ev.params.yaml_path,
-          xml_path: ev.params.xml_path,
-          recipe_path: ev.params.recipe_path,
-          apply_path: ev.params.apply_path,
-        });
-        setClips(ev.params.clips);
-        setJobRunning(false);
-        setPhaseMessage(null);
-        activeJobIdRef.current = null;
-        unlisten();
-        if (unlistenRef.current === unlisten) unlistenRef.current = null;
-      }
-      if (ev.method === "roughcut_job_failed") {
-        setError(ev.params.message);
-        setJobRunning(false);
-        setPhaseMessage(null);
-        activeJobIdRef.current = null;
-        unlisten();
-        if (unlistenRef.current === unlisten) unlistenRef.current = null;
+      switch (ev.method) {
+        case "roughcut_phase":
+          setPhaseMessage(ev.params.message ?? ev.params.phase);
+          break;
+        case "roughcut_job_done":
+          setDonePaths({
+            yaml_path: ev.params.yaml_path,
+            xml_path: ev.params.xml_path,
+            recipe_path: ev.params.recipe_path,
+            apply_path: ev.params.apply_path,
+          });
+          setClips(ev.params.clips);
+          setJobRunning(false);
+          setPhaseMessage(null);
+          activeJobIdRef.current = null;
+          disposeRoughcutListener(unlisten, unlistenRef);
+          break;
+        case "roughcut_job_failed":
+          setError(ev.params.message);
+          setJobRunning(false);
+          setPhaseMessage(null);
+          activeJobIdRef.current = null;
+          disposeRoughcutListener(unlisten, unlistenRef);
+          break;
+        default:
+          break;
       }
     });
     unlistenRef.current = unlisten;
@@ -299,42 +317,17 @@ export default function BriefComposer({ library }: { library: string }) {
             <div className="brief-composer__paths">
               <p className="brief-composer__paths-label">Artifacts (reveal in Finder)</p>
               <ul>
-                <li>
-                  <button
-                    type="button"
-                    className="brief-composer__linkish"
-                    onClick={() => void revealItemInDir(donePaths.xml_path)}
-                  >
-                    {donePaths.xml_path}
-                  </button>
-                </li>
-                <li>
-                  <button
-                    type="button"
-                    className="brief-composer__linkish"
-                    onClick={() => void revealItemInDir(donePaths.yaml_path)}
-                  >
-                    {donePaths.yaml_path}
-                  </button>
-                </li>
-                <li>
-                  <button
-                    type="button"
-                    className="brief-composer__linkish"
-                    onClick={() => void revealItemInDir(donePaths.recipe_path)}
-                  >
-                    {donePaths.recipe_path}
-                  </button>
-                </li>
-                <li>
-                  <button
-                    type="button"
-                    className="brief-composer__linkish"
-                    onClick={() => void revealItemInDir(donePaths.apply_path)}
-                  >
-                    {donePaths.apply_path}
-                  </button>
-                </li>
+                {ARTIFACT_PATH_KEYS.map((key) => (
+                  <li key={key}>
+                    <button
+                      type="button"
+                      className="brief-composer__linkish"
+                      onClick={() => void revealItemInDir(donePaths[key])}
+                    >
+                      {donePaths[key]}
+                    </button>
+                  </li>
+                ))}
               </ul>
             </div>
           )}

--- a/ui/src/routes/library/index.tsx
+++ b/ui/src/routes/library/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { allowVideoPaths, getLibrary } from "../../ipc/sidecar";
 import type { LibraryDetail } from "./types";
+import BriefComposer from "./BriefComposer";
 import ClipGrid from "./ClipGrid";
 import StageZone from "./StageZone";
 import TranscriptZone from "./TranscriptZone";
@@ -11,8 +12,11 @@ type LoadState =
   | { kind: "ready"; library: LibraryDetail; selected: string }
   | { kind: "error"; message: string };
 
+type DetailTab = "footage" | "roughcut";
+
 export default function Library({ name }: { name: string }) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [detailTab, setDetailTab] = useState<DetailTab>("footage");
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
@@ -58,17 +62,39 @@ export default function Library({ name }: { name: string }) {
         selected={state.selected}
         onSelect={(filename) => setState({ kind: "ready", library: state.library, selected: filename })}
       />
-      <div className="library__detail">
-        <StageZone ref={videoRef} video={selectedVideo} footageSummary={state.library.footage_summary} />
-        <TranscriptZone
-          library={state.library.name}
-          video={state.selected || null}
-          onSeek={(seconds) => {
-            const v = videoRef.current;
-            if (v) v.currentTime = seconds;
-          }}
-          onClipChange={(filename) => setState({ kind: "ready", library: state.library, selected: filename })}
-        />
+      <div className="library__right">
+        <nav className="library__tabs" aria-label="Library views">
+          <button
+            type="button"
+            className={`library__tab${detailTab === "footage" ? " library__tab--active" : ""}`}
+            onClick={() => setDetailTab("footage")}
+          >
+            Footage
+          </button>
+          <button
+            type="button"
+            className={`library__tab${detailTab === "roughcut" ? " library__tab--active" : ""}`}
+            onClick={() => setDetailTab("roughcut")}
+          >
+            Rough cut
+          </button>
+        </nav>
+        {detailTab === "footage" ? (
+          <div className="library__detail">
+            <StageZone ref={videoRef} video={selectedVideo} footageSummary={state.library.footage_summary} />
+            <TranscriptZone
+              library={state.library.name}
+              video={state.selected || null}
+              onSeek={(seconds) => {
+                const v = videoRef.current;
+                if (v) v.currentTime = seconds;
+              }}
+              onClipChange={(filename) => setState({ kind: "ready", library: state.library, selected: filename })}
+            />
+          </div>
+        ) : (
+          <BriefComposer library={state.library.name} />
+        )}
       </div>
     </main>
   );

--- a/ui/src/routes/library/library.css
+++ b/ui/src/routes/library/library.css
@@ -130,7 +130,45 @@
 .clip-card__dot--full { background: var(--accent-dim); }
 .clip-card__dot--partial { background: var(--accent); }
 .clip-card__dot--none { background: var(--hairline); }
+
+.library__right {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-left: 1px solid var(--hairline);
+}
+
+.library__tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--hairline);
+  background: var(--surface);
+}
+
+.library__tab {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 12px 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.library__tab:hover {
+  color: var(--text);
+}
+
+.library__tab--active {
+  color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
 .library__detail {
+  flex: 1;
   display: grid;
   grid-template-rows: minmax(220px, 40%) 1fr;
   min-height: 0;
@@ -494,4 +532,287 @@
   padding: 8px 12px;
   border-radius: 4px;
   font-size: 12px;
+}
+
+.brief-composer {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.brief-composer__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.brief-composer__title {
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 20px;
+  margin: 0;
+  color: var(--text);
+}
+
+.brief-composer__warn {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent-warm);
+  line-height: 1.45;
+}
+
+.brief-composer__warn-detail {
+  color: var(--text-muted);
+}
+
+.brief-composer__ok {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent-dim);
+}
+
+.brief-composer__grid {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .brief-composer__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.brief-composer__label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.brief-composer__textarea,
+.brief-composer__input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 14px;
+}
+
+.brief-composer__textarea {
+  resize: vertical;
+  min-height: 140px;
+  line-height: 1.45;
+}
+
+.brief-composer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.brief-composer__btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 8px 14px;
+  border-radius: 4px;
+  border: 1px solid var(--hairline);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.brief-composer__btn:hover:not(:disabled) {
+  border-color: var(--accent-dim);
+  color: var(--text);
+}
+
+.brief-composer__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.brief-composer__btn--primary {
+  background: rgba(224, 165, 90, 0.15);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.brief-composer__phase {
+  margin: 10px 0 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.brief-composer__error {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  background: rgba(180, 60, 60, 0.12);
+  border: 1px solid rgba(239, 120, 100, 0.45);
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent-warm);
+  white-space: pre-wrap;
+}
+
+.brief-composer__history-title {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+
+.brief-composer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.brief-composer__history-item {
+  padding: 10px 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+}
+
+.brief-composer__history-load,
+.brief-composer__history-fork {
+  font-family: var(--mono);
+  font-size: 10px;
+  margin-right: 8px;
+  padding: 4px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--hairline);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.brief-composer__history-fork {
+  border-color: rgba(224, 165, 90, 0.35);
+  color: var(--accent);
+}
+
+.brief-composer__history-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 8px;
+}
+
+.brief-composer__history-id {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.brief-composer__history-time {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+
+.brief-composer__history-snippet {
+  margin: 6px 0 0;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text);
+  line-height: 1.35;
+  opacity: 0.9;
+}
+
+.brief-composer__results-title {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+
+.brief-composer__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.brief-composer__table th,
+.brief-composer__table td {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.brief-composer__table th {
+  color: var(--text-muted);
+  font-weight: normal;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+}
+
+.brief-composer__mono {
+  white-space: nowrap;
+}
+
+.brief-composer__paths {
+  margin-top: 20px;
+}
+
+.brief-composer__paths-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  margin: 0 0 8px;
+}
+
+.brief-composer__paths ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.brief-composer__linkish {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--accent);
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  word-break: break-all;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }


### PR DESCRIPTION
## Summary

Adds a **Rough cut** tab on the library screen: users write a brief and target duration, save/fork briefs, run **Generate**, and get the same on-disk artifacts as the CLI roughcut flow (YAML + editor XML + `.recipe.json` + `*_apply.py`). The sidecar combines visual transcripts, calls Anthropic, normalizes YAML, and runs the existing `export_to_fcpxml.rb` from the repo root.

## Key pieces

- **Sidecar RPC:** `roughcut_prerequisites`, `list_briefs`, `upsert_brief`, `fork_brief`, `start_roughcut` + job notifications (`roughcut_job_*`).
- **Brief catalog:** `libraries/<lib>/briefs/catalog.yaml` (with the rest of `libraries/`, gitignored).
- **Desktop UI:** `BriefComposer`, tabs in library detail, Tauri commands + IPC.
- **Hardening:** shared `Presence` helper, safer YAML fence extraction, resilient brief list sorting; specs for fences and catalog edge cases.
- **Design note:** `docs/superpowers/specs/2026-05-04-m4a-brief-composer-roughcut-design.md`.

## Verification (this branch)

- `cd ui/sidecar && bundle exec rspec` — **88 examples, 0 failures**
- `cd ui && npm run build` — **passes** (`tsc` + Vite)

## Tracking

Related to epic [#14](https://github.com/William-Hill/buttercut/issues/14).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brief Composer UI to create/save/fork plain-language briefs and run AI rough-cut generation.
  * New "Roughcut" tab in Library with brief history, Load/Fork, Save/Generate/Cancel, live progress, and reveal-in-Finder for artifacts.
  * Real-time job events and cancellation for roughcut jobs.

* **Validation / Errors**
  * Prerequisite checks and a combined visual-transcript size cap with clear RPC error guidance.

* **Documentation**
  * Added spec and prompt format for brief composer + rough-cut UI flow.

* **Tests**
  * New unit and integration tests covering briefs, presence, and roughcut flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->