### PR TITLE
feat(desktop): M4b timeline preview + recipe glyphs (#14)

### DIFF
--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -168,7 +168,14 @@ async fn start_roughcut(library: String, brief_id: String) -> Result<Value, Stri
 #[tauri::command]
 fn read_library_text_file(path: String) -> Result<String, String> {
     let root = resolve_libraries_root().canonicalize().map_err(|e| e.to_string())?;
-    let candidate = PathBuf::from(&path);
+    let candidate = {
+        let p = PathBuf::from(&path);
+        if p.is_absolute() {
+            p
+        } else {
+            root.join(p)
+        }
+    };
     let abs = candidate.canonicalize().map_err(|e| e.to_string())?;
     if !abs.starts_with(&root) {
         return Err("path outside libraries root".into());

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -164,6 +164,32 @@ async fn start_roughcut(library: String, brief_id: String) -> Result<Value, Stri
     .map_err(|e| e.to_string())
 }
 
+/// Read a UTF-8 text file under the configured libraries root (for recipe.json, etc.).
+#[tauri::command]
+fn read_library_text_file(path: String) -> Result<String, String> {
+    let root = resolve_libraries_root().canonicalize().map_err(|e| e.to_string())?;
+    let candidate = PathBuf::from(&path);
+    let abs = candidate.canonicalize().map_err(|e| e.to_string())?;
+    if !abs.starts_with(&root) {
+        return Err("path outside libraries root".into());
+    }
+    if !abs.is_file() {
+        return Err("not a file".into());
+    }
+    std::fs::read_to_string(&abs).map_err(|e| e.to_string())
+}
+
+fn resolve_libraries_root() -> PathBuf {
+    std::env::var("BUTTERCUT_LIBRARIES_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let ui_dir = manifest_dir.parent().expect("ui dir");
+            let repo_root = ui_dir.parent().expect("repo root");
+            repo_root.join("libraries")
+        })
+}
+
 #[tauri::command]
 async fn apply_transcript_edit(library: String, clip: String, edit: Value) -> Result<Value, String> {
     sidecar::call(
@@ -306,7 +332,8 @@ pub fn run() {
             list_briefs,
             upsert_brief,
             fork_brief,
-            start_roughcut
+            start_roughcut,
+            read_library_text_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -119,6 +119,10 @@ export async function startRoughcut(library: string, briefId: string): Promise<{
   return invoke("start_roughcut", { library, briefId });
 }
 
+export async function readLibraryTextFile(path: string): Promise<string> {
+  return invoke<string>("read_library_text_file", { path });
+}
+
 export async function openNewProjectWindow(): Promise<void> {
   await invoke("open_new_project_window");
 }

--- a/ui/src/lib/recipeTypes.ts
+++ b/ui/src/lib/recipeTypes.ts
@@ -1,0 +1,71 @@
+/** Subset of `lib/buttercut/recipe.rb` JSON schema for desktop glyphs. */
+
+export type RecipeSpeedRamp = { at: number; speed: number; ease: string };
+
+export type RecipeMarker = { at: number; name: string; color: string };
+
+export type RecipeClip = {
+  index: number;
+  source_file: string;
+  speed_ramps?: RecipeSpeedRamp[];
+  color_tag?: string;
+  markers?: RecipeMarker[];
+};
+
+export type RecipeTransition = {
+  between: [number, number];
+  type: string;
+  color?: string;
+  duration_frames: number;
+};
+
+export type RecipeTitleCard = {
+  at_clip: number;
+  text: string;
+  fade_in_at: number;
+  fade_in_frames: number;
+};
+
+export type RecipePowergrade = {
+  name: string;
+  apply_to: "all" | number[];
+};
+
+export type RecipeJson = {
+  version: number;
+  library: string;
+  timeline: string;
+  clips: RecipeClip[];
+  transitions?: RecipeTransition[];
+  title_card?: RecipeTitleCard;
+  powergrade?: RecipePowergrade;
+};
+
+export function parseRoughcutRecipeJson(text: string): RecipeJson | null {
+  try {
+    const o = JSON.parse(text) as RecipeJson;
+    if (!o || o.version !== 1 || !Array.isArray(o.clips) || o.clips.length === 0) return null;
+    return o;
+  } catch {
+    return null;
+  }
+}
+
+/** Recipe clip index is 1..N in YAML order; UI `clips` array is the same order. */
+export function recipeClipForUiIndex(recipe: RecipeJson | null, uiIndex: number): RecipeClip | null {
+  if (!recipe) return null;
+  return recipe.clips.find((c) => c.index === uiIndex + 1) ?? null;
+}
+
+export function transitionAfterUiIndex(trs: RecipeTransition[] | undefined, uiIndex: number): RecipeTransition | null {
+  if (!trs?.length) return null;
+  const a = uiIndex + 1;
+  const b = uiIndex + 2;
+  return trs.find((t) => t.between?.[0] === a && t.between?.[1] === b) ?? null;
+}
+
+export function powergradeTouchesClip(pg: RecipePowergrade | undefined, recipeIndex1Based: number): boolean {
+  if (!pg) return false;
+  if (pg.apply_to === "all") return true;
+  return Array.isArray(pg.apply_to) && pg.apply_to.includes(recipeIndex1Based);
+}

--- a/ui/src/lib/roughcutTimeline.ts
+++ b/ui/src/lib/roughcutTimeline.ts
@@ -1,0 +1,51 @@
+import type { RoughcutClip } from "../ipc/events";
+
+export type TimelineSegment = {
+  uiIndex: number;
+  sourceFile: string;
+  durationSec: number;
+  startGlobal: number;
+  endGlobal: number;
+};
+
+export function timecodeToSeconds(tc: string): number {
+  const parts = tc.trim().split(":");
+  if (parts.length < 3) return 0;
+  const h = Number(parts[0]);
+  const m = Number(parts[1]);
+  const s = Number(parts[2]);
+  if (![h, m, s].every((x) => Number.isFinite(x))) return 0;
+  return h * 3600 + m * 60 + s;
+}
+
+export function buildTimelineSegments(clips: RoughcutClip[]): TimelineSegment[] {
+  let acc = 0;
+  return clips.map((c, uiIndex) => {
+    const dur = Math.max(0.001, timecodeToSeconds(c.out_point) - timecodeToSeconds(c.in_point));
+    const seg: TimelineSegment = {
+      uiIndex,
+      sourceFile: c.source_file,
+      durationSec: dur,
+      startGlobal: acc,
+      endGlobal: acc + dur,
+    };
+    acc += dur;
+    return seg;
+  });
+}
+
+export function segmentIndexForGlobalTime(segments: TimelineSegment[], t: number): number {
+  if (segments.length === 0) return 0;
+  const total = segments[segments.length - 1].endGlobal;
+  const x = Math.max(0, Math.min(t, total));
+  for (let i = 0; i < segments.length; i++) {
+    if (x < segments[i].endGlobal) return i;
+  }
+  return segments.length - 1;
+}
+
+export function localSourceSeconds(clips: RoughcutClip[], segments: TimelineSegment[], globalSec: number): number {
+  const i = segmentIndexForGlobalTime(segments, globalSec);
+  const inSec = timecodeToSeconds(clips[i].in_point);
+  return globalSec - segments[i].startGlobal + inSec;
+}

--- a/ui/src/lib/roughcutTimeline.ts
+++ b/ui/src/lib/roughcutTimeline.ts
@@ -18,6 +18,14 @@ export function timecodeToSeconds(tc: string): number {
   return h * 3600 + m * 60 + s;
 }
 
+/** m:ss for timeline / preview chrome (sub-minute projects only need seconds). */
+export function formatRoughcutClock(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
 export function buildTimelineSegments(clips: RoughcutClip[]): TimelineSegment[] {
   let acc = 0;
   return clips.map((c, uiIndex) => {
@@ -42,10 +50,4 @@ export function segmentIndexForGlobalTime(segments: TimelineSegment[], t: number
     if (x < segments[i].endGlobal) return i;
   }
   return segments.length - 1;
-}
-
-export function localSourceSeconds(clips: RoughcutClip[], segments: TimelineSegment[], globalSec: number): number {
-  const i = segmentIndexForGlobalTime(segments, globalSec);
-  const inSec = timecodeToSeconds(clips[i].in_point);
-  return globalSec - segments[i].startGlobal + inSec;
 }

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -6,10 +6,15 @@ import {
   forkBrief,
   hasApiKey,
   listBriefs,
+  readLibraryTextFile,
   roughcutPrerequisites,
   startRoughcut,
   upsertBrief,
 } from "../../ipc/sidecar";
+import { parseRoughcutRecipeJson, type RecipeJson } from "../../lib/recipeTypes";
+import type { VideoEntry } from "./types";
+import RoughcutStagePreview from "./RoughcutStagePreview";
+import RoughcutTimeline from "./RoughcutTimeline";
 import {
   listenRoughcutJobEvents,
   type RoughcutArtifactPaths,
@@ -52,7 +57,7 @@ function disposeRoughcutListener(
   if (ref.current === unlisten) ref.current = null;
 }
 
-export default function BriefComposer({ library }: { library: string }) {
+export default function BriefComposer({ library, videos }: { library: string; videos: VideoEntry[] }) {
   const [prereqOk, setPrereqOk] = useState<boolean | null>(null);
   const [prereqMissing, setPrereqMissing] = useState<PrereqRow[]>([]);
   const [briefs, setBriefs] = useState<BriefRow[]>([]);
@@ -64,6 +69,9 @@ export default function BriefComposer({ library }: { library: string }) {
   const [error, setError] = useState<string | null>(null);
   const [donePaths, setDonePaths] = useState<RoughcutArtifactPaths | null>(null);
   const [clips, setClips] = useState<RoughcutClip[]>([]);
+  const [recipe, setRecipe] = useState<RecipeJson | null>(null);
+  const [playheadSec, setPlayheadSec] = useState(0);
+  const [playing, setPlaying] = useState(false);
   const activeJobIdRef = useRef<string | null>(null);
   const unlistenRef = useRef<(() => void) | null>(null);
 
@@ -90,6 +98,11 @@ export default function BriefComposer({ library }: { library: string }) {
     },
     [],
   );
+
+  useEffect(() => {
+    setPlayheadSec(0);
+    setPlaying(false);
+  }, [donePaths?.yaml_path]);
 
   async function handleSaveBrief() {
     setError(null);
@@ -127,6 +140,9 @@ export default function BriefComposer({ library }: { library: string }) {
     setError(null);
     setDonePaths(null);
     setClips([]);
+    setRecipe(null);
+    setPlayheadSec(0);
+    setPlaying(false);
     setPhaseMessage(null);
     unlistenRef.current?.();
     unlistenRef.current = null;
@@ -175,6 +191,9 @@ export default function BriefComposer({ library }: { library: string }) {
               apply_path: ev.params.apply_path,
             });
             setClips(ev.params.clips);
+            void readLibraryTextFile(ev.params.recipe_path)
+              .then((raw) => setRecipe(parseRoughcutRecipeJson(raw)))
+              .catch(() => setRecipe(null));
             setJobRunning(false);
             setPhaseMessage(null);
             activeJobIdRef.current = null;
@@ -319,7 +338,54 @@ export default function BriefComposer({ library }: { library: string }) {
 
       {clips.length > 0 && (
         <div className="brief-composer__results">
-          <h3 className="brief-composer__results-title">Selected clips</h3>
+          <h3 className="brief-composer__results-title">Timeline preview</h3>
+          <p className="brief-composer__results-lead">
+            Clips in story order with editorial recipe glyphs. Scrub the bar to seek the preview.
+          </p>
+          <div className="brief-composer__chips" role="toolbar" aria-label="Rough cut iterations">
+            <button
+              type="button"
+              className="brief-composer__chip brief-composer__chip--active"
+              disabled={jobRunning || !prompt.trim() || prereqOk === false}
+              onClick={() => void handleGenerate()}
+              title="Runs the same generate pipeline again (full rough cut). Trim-level diff UI is planned."
+            >
+              Regenerate
+            </button>
+            <button
+              type="button"
+              className="brief-composer__chip"
+              disabled
+              title="TODO M4b+: append a tight pacing directive to the brief, re-run model, then show clip-level diff (trim/add/remove)."
+            >
+              Make tighter
+            </button>
+            <button
+              type="button"
+              className="brief-composer__chip"
+              disabled
+              title="TODO M4b+: steer speed ramps / slow motion in YAML and surface which clips changed."
+            >
+              Lean harder into slow-mo
+            </button>
+          </div>
+          <RoughcutTimeline
+            clips={clips}
+            recipe={recipe}
+            playheadSec={playheadSec}
+            onPlayheadSecChange={setPlayheadSec}
+            onScrubStart={() => setPlaying(false)}
+          />
+          <RoughcutStagePreview
+            clips={clips}
+            videos={videos}
+            playheadSec={playheadSec}
+            onPlayheadSecChange={setPlayheadSec}
+            playing={playing}
+            onPlayingChange={setPlaying}
+          />
+
+          <h3 className="brief-composer__results-title brief-composer__results-title--sub">Selected clips</h3>
           <table className="brief-composer__table">
             <thead>
               <tr>

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -74,6 +74,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
   const [playing, setPlaying] = useState(false);
   const activeJobIdRef = useRef<string | null>(null);
   const unlistenRef = useRef<(() => void) | null>(null);
+  const recipeReadTokenRef = useRef(0);
 
   const refreshBriefs = useCallback(async () => {
     const r = await listBriefs(library);
@@ -147,6 +148,8 @@ export default function BriefComposer({ library, videos }: { library: string; vi
     unlistenRef.current?.();
     unlistenRef.current = null;
 
+    const runToken = ++recipeReadTokenRef.current;
+
     try {
       const key = await hasApiKey();
       if (!key.configured) {
@@ -192,8 +195,14 @@ export default function BriefComposer({ library, videos }: { library: string; vi
             });
             setClips(ev.params.clips);
             void readLibraryTextFile(ev.params.recipe_path)
-              .then((raw) => setRecipe(parseRoughcutRecipeJson(raw)))
-              .catch(() => setRecipe(null));
+              .then((raw) => {
+                if (recipeReadTokenRef.current !== runToken) return;
+                setRecipe(parseRoughcutRecipeJson(raw));
+              })
+              .catch(() => {
+                if (recipeReadTokenRef.current !== runToken) return;
+                setRecipe(null);
+              });
             setJobRunning(false);
             setPhaseMessage(null);
             activeJobIdRef.current = null;

--- a/ui/src/routes/library/RecipeGlyphs.tsx
+++ b/ui/src/routes/library/RecipeGlyphs.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import type { RecipeClip, RecipeJson, RecipeTransition } from "../../lib/recipeTypes";
+import { powergradeTouchesClip, recipeClipForUiIndex } from "../../lib/recipeTypes";
+
+function IconWrap({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <span className="roughcut-glyph" title={title}>
+      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+        {children}
+      </svg>
+    </span>
+  );
+}
+
+function GlyphSpeedRamp() {
+  return (
+    <IconWrap title="Speed ramp">
+      <path
+        d="M2 10 L4 4 L6 9 L8 3 L10 8 L12 5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </IconWrap>
+  );
+}
+
+function GlyphColor() {
+  return (
+    <IconWrap title="Clip color tag">
+      <circle cx="7" cy="7" r="4" fill="currentColor" opacity="0.85" />
+    </IconWrap>
+  );
+}
+
+function GlyphMarker() {
+  return (
+    <IconWrap title="Marker">
+      <path d="M7 2 L11 7 L7 12 L3 7 Z" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    </IconWrap>
+  );
+}
+
+function GlyphTransition({ type }: { type: string }) {
+  const label = type === "dip_to_color" ? "Dip transition" : "Cross dissolve";
+  return (
+    <IconWrap title={label}>
+      <path d="M3 4 L7 7 L3 10" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <path d="M11 4 L7 7 L11 10" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </IconWrap>
+  );
+}
+
+function GlyphTitleCard() {
+  return (
+    <IconWrap title="Title card">
+      <rect x="3" y="4" width="8" height="7" rx="1" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M5.5 6.5 H8.5 M7 5.5 V9.5" stroke="currentColor" strokeWidth="1" />
+    </IconWrap>
+  );
+}
+
+function GlyphPowerGrade() {
+  return (
+    <IconWrap title="PowerGrade">
+      <circle cx="7" cy="7" r="4.5" fill="none" stroke="currentColor" strokeWidth="1.1" strokeDasharray="2 1.5" />
+      <circle cx="7" cy="7" r="1.6" fill="currentColor" />
+    </IconWrap>
+  );
+}
+
+export function GapTransitionGlyph({ tr }: { tr: RecipeTransition }) {
+  return (
+    <span className="roughcut-timeline__gap-glyph" title={`${tr.type}${tr.color ? ` (${tr.color})` : ""}`}>
+      <GlyphTransition type={tr.type} />
+    </span>
+  );
+}
+
+export function ClipRecipeGlyphs({ clipIndex, recipe }: { clipIndex: number; recipe: RecipeJson | null }) {
+  const c: RecipeClip | null = recipeClipForUiIndex(recipe, clipIndex);
+  const rc = clipIndex + 1;
+  const title = recipe?.title_card?.at_clip === rc;
+  const pg = powergradeTouchesClip(recipe?.powergrade, rc);
+
+  const nodes: ReactNode[] = [];
+  if (c?.speed_ramps?.length) nodes.push(<GlyphSpeedRamp key="ramp" />);
+  if (c?.color_tag) nodes.push(<GlyphColor key="color" />);
+  if (c?.markers?.length) nodes.push(<GlyphMarker key="marker" />);
+  if (title) nodes.push(<GlyphTitleCard key="title" />);
+  if (pg) nodes.push(<GlyphPowerGrade key="pg" />);
+
+  if (nodes.length === 0) return null;
+  return <div className="roughcut-timeline__glyph-row">{nodes}</div>;
+}

--- a/ui/src/routes/library/RecipeGlyphs.tsx
+++ b/ui/src/routes/library/RecipeGlyphs.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from "react";
-import type { RecipeClip, RecipeJson, RecipeTransition } from "../../lib/recipeTypes";
-import { powergradeTouchesClip, recipeClipForUiIndex } from "../../lib/recipeTypes";
+import {
+  powergradeTouchesClip,
+  recipeClipForUiIndex,
+  type RecipeClip,
+  type RecipeJson,
+  type RecipeTransition,
+} from "../../lib/recipeTypes";
 
 function IconWrap({ title, children }: { title: string; children: ReactNode }) {
   return (

--- a/ui/src/routes/library/RoughcutStagePreview.tsx
+++ b/ui/src/routes/library/RoughcutStagePreview.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import type { RoughcutClip } from "../../ipc/events";
 import {
   buildTimelineSegments,
+  formatRoughcutClock,
   segmentIndexForGlobalTime,
   timecodeToSeconds,
 } from "../../lib/roughcutTimeline";
@@ -11,13 +12,6 @@ import type { VideoEntry } from "./types";
 function basename(p: string): string {
   const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
   return i >= 0 ? p.slice(i + 1) : p;
-}
-
-function formatClock(sec: number): string {
-  if (!Number.isFinite(sec) || sec < 0) return "0:00";
-  const m = Math.floor(sec / 60);
-  const s = Math.floor(sec % 60);
-  return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
 export type RoughcutStagePreviewProps = {
@@ -93,7 +87,7 @@ export default function RoughcutStagePreview({
           {playing ? "Pause" : "Play"}
         </button>
         <span className="roughcut-preview__time">
-          {formatClock(playheadSec)} / {formatClock(total)}
+          {formatRoughcutClock(playheadSec)} / {formatRoughcutClock(total)}
         </span>
         <span className="roughcut-preview__clip-label">
           {basename(clip.source_file)}

--- a/ui/src/routes/library/RoughcutStagePreview.tsx
+++ b/ui/src/routes/library/RoughcutStagePreview.tsx
@@ -1,0 +1,130 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { useEffect, useRef } from "react";
+import type { RoughcutClip } from "../../ipc/events";
+import {
+  buildTimelineSegments,
+  segmentIndexForGlobalTime,
+  timecodeToSeconds,
+} from "../../lib/roughcutTimeline";
+import type { VideoEntry } from "./types";
+
+function basename(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+function formatClock(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export type RoughcutStagePreviewProps = {
+  clips: RoughcutClip[];
+  videos: VideoEntry[];
+  playheadSec: number;
+  onPlayheadSecChange: (t: number) => void;
+  playing: boolean;
+  onPlayingChange: (v: boolean) => void;
+};
+
+export default function RoughcutStagePreview({
+  clips,
+  videos,
+  playheadSec,
+  onPlayheadSecChange,
+  playing,
+  onPlayingChange,
+}: RoughcutStagePreviewProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const segments = buildTimelineSegments(clips);
+  const pathByFile = new Map(videos.map((v) => [v.filename, v.path]));
+
+  const i = segmentIndexForGlobalTime(segments, playheadSec);
+  const clip = clips[i];
+  const seg = segments[i];
+  const resolved = pathByFile.get(basename(clip.source_file)) ?? pathByFile.get(clip.source_file);
+  const src = resolved ? convertFileSrc(resolved) : "";
+  const inSec = timecodeToSeconds(clip.in_point);
+  const outSec = timecodeToSeconds(clip.out_point);
+  const localT = playheadSec - seg.startGlobal + inSec;
+
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v || !src) return;
+    if (playing) {
+      void v.play().catch(() => onPlayingChange(false));
+    } else {
+      v.pause();
+    }
+  }, [playing, src, onPlayingChange]);
+
+  useEffect(() => {
+    if (playing) return;
+    const v = videoRef.current;
+    if (!v || !src) return;
+    const clamped = Math.min(Math.max(localT, inSec + 0.02), outSec - 0.02);
+    if (Number.isFinite(clamped) && Math.abs(v.currentTime - clamped) > 0.08) {
+      v.currentTime = clamped;
+    }
+  }, [playheadSec, i, localT, inSec, outSec, src, playing]);
+
+  const total = segments.length ? segments[segments.length - 1].endGlobal : 0;
+
+  if (!resolved) {
+    return (
+      <div className="roughcut-preview roughcut-preview--missing">
+        <p>No library path for source file</p>
+        <code>{clip.source_file}</code>
+      </div>
+    );
+  }
+
+  return (
+    <div className="roughcut-preview">
+      <div className="roughcut-preview__chrome">
+        <button
+          type="button"
+          className="roughcut-preview__play"
+          onClick={() => onPlayingChange(!playing)}
+          aria-pressed={playing}
+        >
+          {playing ? "Pause" : "Play"}
+        </button>
+        <span className="roughcut-preview__time">
+          {formatClock(playheadSec)} / {formatClock(total)}
+        </span>
+        <span className="roughcut-preview__clip-label">
+          {basename(clip.source_file)}
+        </span>
+      </div>
+      <div className="roughcut-preview__frame">
+        <video
+          key={`${i}-${src}`}
+          ref={videoRef}
+          className="roughcut-preview__video"
+          src={src}
+          playsInline
+          onLoadedMetadata={(e) => {
+            const v = e.currentTarget;
+            const t = Math.min(Math.max(localT, inSec + 0.02), outSec - 0.02);
+            v.currentTime = Number.isFinite(t) ? t : inSec;
+          }}
+          onTimeUpdate={(e) => {
+            if (!playing) return;
+            const v = e.currentTarget;
+            if (v.currentTime >= outSec - 0.06) {
+              v.pause();
+              onPlayingChange(false);
+              const end = seg.endGlobal;
+              if (playheadSec < end - 0.01) onPlayheadSecChange(end);
+              return;
+            }
+            onPlayheadSecChange(seg.startGlobal + (v.currentTime - inSec));
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/routes/library/RoughcutStagePreview.tsx
+++ b/ui/src/routes/library/RoughcutStagePreview.tsx
@@ -14,6 +14,16 @@ function basename(p: string): string {
   return i >= 0 ? p.slice(i + 1) : p;
 }
 
+function clampToClipWindow(t: number, inSec: number, outSec: number): number {
+  const min = inSec + 0.02;
+  const max = outSec - 0.02;
+  if (!Number.isFinite(t)) return Math.max(0, inSec);
+  if (max <= min) {
+    return Math.max(0, Math.min(Math.max(t, inSec), outSec));
+  }
+  return Math.min(Math.max(t, min), max);
+}
+
 export type RoughcutStagePreviewProps = {
   clips: RoughcutClip[];
   videos: VideoEntry[];
@@ -33,12 +43,20 @@ export default function RoughcutStagePreview({
 }: RoughcutStagePreviewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const segments = buildTimelineSegments(clips);
-  const pathByFile = new Map(videos.map((v) => [v.filename, v.path]));
+  const pathByAbsolute = new Map(videos.map((v) => [v.path, v.path]));
+  const pathsByFilename = new Map<string, string[]>();
+  for (const v of videos) {
+    const arr = pathsByFilename.get(v.filename) ?? [];
+    arr.push(v.path);
+    pathsByFilename.set(v.filename, arr);
+  }
 
   const i = segmentIndexForGlobalTime(segments, playheadSec);
   const clip = clips[i];
   const seg = segments[i];
-  const resolved = pathByFile.get(basename(clip.source_file)) ?? pathByFile.get(clip.source_file);
+  const direct = pathByAbsolute.get(clip.source_file);
+  const nameMatches = pathsByFilename.get(basename(clip.source_file)) ?? [];
+  const resolved = direct ?? (nameMatches.length === 1 ? nameMatches[0] : "");
   const src = resolved ? convertFileSrc(resolved) : "";
   const inSec = timecodeToSeconds(clip.in_point);
   const outSec = timecodeToSeconds(clip.out_point);
@@ -58,7 +76,7 @@ export default function RoughcutStagePreview({
     if (playing) return;
     const v = videoRef.current;
     if (!v || !src) return;
-    const clamped = Math.min(Math.max(localT, inSec + 0.02), outSec - 0.02);
+    const clamped = clampToClipWindow(localT, inSec, outSec);
     if (Number.isFinite(clamped) && Math.abs(v.currentTime - clamped) > 0.08) {
       v.currentTime = clamped;
     }
@@ -102,7 +120,7 @@ export default function RoughcutStagePreview({
           playsInline
           onLoadedMetadata={(e) => {
             const v = e.currentTarget;
-            const t = Math.min(Math.max(localT, inSec + 0.02), outSec - 0.02);
+            const t = clampToClipWindow(localT, inSec, outSec);
             v.currentTime = Number.isFinite(t) ? t : inSec;
           }}
           onTimeUpdate={(e) => {

--- a/ui/src/routes/library/RoughcutTimeline.tsx
+++ b/ui/src/routes/library/RoughcutTimeline.tsx
@@ -62,6 +62,43 @@ export default function RoughcutTimeline({
     }
   };
 
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (total <= 0) return;
+      const step = e.shiftKey ? 5 : 1;
+      const bigStep = 10;
+      let next = playheadSec;
+      switch (e.key) {
+        case "ArrowLeft":
+        case "ArrowDown":
+          next = playheadSec - step;
+          break;
+        case "ArrowRight":
+        case "ArrowUp":
+          next = playheadSec + step;
+          break;
+        case "PageDown":
+          next = playheadSec - bigStep;
+          break;
+        case "PageUp":
+          next = playheadSec + bigStep;
+          break;
+        case "Home":
+          next = 0;
+          break;
+        case "End":
+          next = total;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      onScrubStart?.();
+      onPlayheadSecChange(Math.max(0, Math.min(total, next)));
+    },
+    [total, playheadSec, onPlayheadSecChange, onScrubStart],
+  );
+
   if (clips.length === 0) return null;
 
   return (
@@ -74,6 +111,7 @@ export default function RoughcutTimeline({
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
+        onKeyDown={onKeyDown}
         role="slider"
         tabIndex={0}
         aria-valuemin={0}

--- a/ui/src/routes/library/RoughcutTimeline.tsx
+++ b/ui/src/routes/library/RoughcutTimeline.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useRef, useState } from "react";
+import type { RoughcutClip } from "../../ipc/events";
+import type { RecipeJson } from "../../lib/recipeTypes";
+import { transitionAfterUiIndex } from "../../lib/recipeTypes";
+import { buildTimelineSegments, type TimelineSegment } from "../../lib/roughcutTimeline";
+import { ClipRecipeGlyphs, GapTransitionGlyph } from "./RecipeGlyphs";
+
+function formatClock(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return "0:00";
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export type RoughcutTimelineProps = {
+  clips: RoughcutClip[];
+  recipe: RecipeJson | null;
+  playheadSec: number;
+  onPlayheadSecChange: (t: number) => void;
+  onScrubStart?: () => void;
+};
+
+export default function RoughcutTimeline({
+  clips,
+  recipe,
+  playheadSec,
+  onPlayheadSecChange,
+  onScrubStart,
+}: RoughcutTimelineProps) {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const scrubbingRef = useRef(false);
+  const [scrubTick, setScrubTick] = useState(false);
+  const segments: TimelineSegment[] = buildTimelineSegments(clips);
+  const total = segments.length ? segments[segments.length - 1].endGlobal : 0;
+  const playPct = total > 0 ? (playheadSec / total) * 100 : 0;
+
+  const scrubToClientX = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el || total <= 0) return;
+      const r = el.getBoundingClientRect();
+      const ratio = Math.max(0, Math.min(1, (clientX - r.left) / Math.max(r.width, 1)));
+      onPlayheadSecChange(ratio * total);
+    },
+    [onPlayheadSecChange, total],
+  );
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    onScrubStart?.();
+    scrubbingRef.current = true;
+    setScrubTick(true);
+    trackRef.current?.setPointerCapture(e.pointerId);
+    scrubToClientX(e.clientX);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!scrubbingRef.current) return;
+    scrubToClientX(e.clientX);
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (!scrubbingRef.current) return;
+    scrubbingRef.current = false;
+    setScrubTick(false);
+    try {
+      trackRef.current?.releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (clips.length === 0) return null;
+
+  return (
+    <div className="roughcut-timeline">
+      <p className="roughcut-timeline__label">Story timeline</p>
+      <div
+        ref={trackRef}
+        className="roughcut-timeline__track"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        role="slider"
+        tabIndex={0}
+        aria-valuemin={0}
+        aria-valuemax={Math.floor(total)}
+        aria-valuenow={Math.floor(playheadSec)}
+        aria-label="Rough cut timeline scrub"
+      >
+        <div className="roughcut-timeline__segments">
+          {segments.map((s, idx) => {
+            const tr = idx < segments.length - 1 ? transitionAfterUiIndex(recipe?.transitions, idx) : null;
+            return (
+              <div
+                key={s.uiIndex}
+                className="roughcut-timeline__cell-wrap"
+                style={{ flex: `${s.durationSec} 1 0` }}
+              >
+                <div className="roughcut-timeline__cell">
+                  <span className="roughcut-timeline__cell-title" title={s.sourceFile}>
+                    {s.sourceFile.replace(/\.[^.]+$/, "")}
+                  </span>
+                  {tr ? (
+                    <span className="roughcut-timeline__junction">
+                      <GapTransitionGlyph tr={tr} />
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="roughcut-timeline__playhead" style={{ left: `${playPct}%` }} />
+      </div>
+
+      <div className="roughcut-timeline__glyph-strip">
+        {segments.map((s) => (
+          <div
+            key={`g-${s.uiIndex}`}
+            className="roughcut-timeline__glyph-cell"
+            style={{ flex: `${s.durationSec} 1 0` }}
+          >
+            <ClipRecipeGlyphs clipIndex={s.uiIndex} recipe={recipe} />
+          </div>
+        ))}
+      </div>
+
+      <p className="roughcut-timeline__hint">
+        {scrubTick ? "Scrubbing…" : `Drag the timeline to seek · ${formatClock(playheadSec)} / ${formatClock(total)}`}
+      </p>
+    </div>
+  );
+}

--- a/ui/src/routes/library/RoughcutTimeline.tsx
+++ b/ui/src/routes/library/RoughcutTimeline.tsx
@@ -1,16 +1,8 @@
 import { useCallback, useRef, useState } from "react";
 import type { RoughcutClip } from "../../ipc/events";
-import type { RecipeJson } from "../../lib/recipeTypes";
-import { transitionAfterUiIndex } from "../../lib/recipeTypes";
-import { buildTimelineSegments, type TimelineSegment } from "../../lib/roughcutTimeline";
+import { transitionAfterUiIndex, type RecipeJson } from "../../lib/recipeTypes";
+import { buildTimelineSegments, formatRoughcutClock, type TimelineSegment } from "../../lib/roughcutTimeline";
 import { ClipRecipeGlyphs, GapTransitionGlyph } from "./RecipeGlyphs";
-
-function formatClock(sec: number): string {
-  if (!Number.isFinite(sec) || sec < 0) return "0:00";
-  const m = Math.floor(sec / 60);
-  const s = Math.floor(sec % 60);
-  return `${m}:${s.toString().padStart(2, "0")}`;
-}
 
 export type RoughcutTimelineProps = {
   clips: RoughcutClip[];
@@ -29,7 +21,7 @@ export default function RoughcutTimeline({
 }: RoughcutTimelineProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const scrubbingRef = useRef(false);
-  const [scrubTick, setScrubTick] = useState(false);
+  const [showScrubHint, setShowScrubHint] = useState(false);
   const segments: TimelineSegment[] = buildTimelineSegments(clips);
   const total = segments.length ? segments[segments.length - 1].endGlobal : 0;
   const playPct = total > 0 ? (playheadSec / total) * 100 : 0;
@@ -49,7 +41,7 @@ export default function RoughcutTimeline({
     e.preventDefault();
     onScrubStart?.();
     scrubbingRef.current = true;
-    setScrubTick(true);
+    setShowScrubHint(true);
     trackRef.current?.setPointerCapture(e.pointerId);
     scrubToClientX(e.clientX);
   };
@@ -62,7 +54,7 @@ export default function RoughcutTimeline({
   const onPointerUp = (e: React.PointerEvent) => {
     if (!scrubbingRef.current) return;
     scrubbingRef.current = false;
-    setScrubTick(false);
+    setShowScrubHint(false);
     try {
       trackRef.current?.releasePointerCapture(e.pointerId);
     } catch {
@@ -128,7 +120,9 @@ export default function RoughcutTimeline({
       </div>
 
       <p className="roughcut-timeline__hint">
-        {scrubTick ? "Scrubbing…" : `Drag the timeline to seek · ${formatClock(playheadSec)} / ${formatClock(total)}`}
+        {showScrubHint
+          ? "Scrubbing…"
+          : `Drag the timeline to seek · ${formatRoughcutClock(playheadSec)} / ${formatRoughcutClock(total)}`}
       </p>
     </div>
   );

--- a/ui/src/routes/library/RoughcutTimeline.tsx
+++ b/ui/src/routes/library/RoughcutTimeline.tsx
@@ -37,8 +37,9 @@ export default function RoughcutTimeline({
     [onPlayheadSecChange, total],
   );
 
-  const onPointerDown = (e: React.PointerEvent) => {
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
+    e.currentTarget.focus();
     onScrubStart?.();
     scrubbingRef.current = true;
     setShowScrubHint(true);

--- a/ui/src/routes/library/index.tsx
+++ b/ui/src/routes/library/index.tsx
@@ -93,7 +93,7 @@ export default function Library({ name }: { name: string }) {
             />
           </div>
         ) : (
-          <BriefComposer library={state.library.name} />
+          <BriefComposer library={state.library.name} videos={state.library.videos} />
         )}
       </div>
     </main>

--- a/ui/src/routes/library/library.css
+++ b/ui/src/routes/library/library.css
@@ -816,3 +816,271 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+.brief-composer__results-lead {
+  margin: 0 0 14px;
+  font-family: var(--display);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.brief-composer__results-title--sub {
+  margin-top: 28px;
+}
+
+.brief-composer__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.brief-composer__chip {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.brief-composer__chip:hover:not(:disabled) {
+  border-color: var(--accent-dim);
+  color: var(--text);
+}
+
+.brief-composer__chip:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.brief-composer__chip--active:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* M4b — rough cut timeline + preview */
+
+.roughcut-timeline {
+  margin-bottom: 16px;
+}
+
+.roughcut-timeline__label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 8px;
+}
+
+.roughcut-timeline__track {
+  position: relative;
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  background: var(--surface);
+  touch-action: none;
+  cursor: grab;
+  min-height: 44px;
+}
+
+.roughcut-timeline__track:active {
+  cursor: grabbing;
+}
+
+.roughcut-timeline__segments {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: stretch;
+}
+
+.roughcut-timeline__cell-wrap {
+  min-width: 0;
+}
+
+.roughcut-timeline__cell {
+  position: relative;
+  height: 100%;
+  min-height: 44px;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 6px;
+  box-sizing: border-box;
+}
+
+.roughcut-timeline__cell-wrap:last-child .roughcut-timeline__cell {
+  border-right: none;
+}
+
+.roughcut-timeline__cell-title {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.roughcut-timeline__junction {
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.roughcut-timeline__gap-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  border-radius: 50%;
+  border: 1px solid var(--hairline);
+  padding: 1px;
+}
+
+.roughcut-timeline__playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.roughcut-timeline__glyph-strip {
+  display: flex;
+  width: 100%;
+  margin-top: 6px;
+  min-height: 22px;
+  align-items: flex-start;
+}
+
+.roughcut-timeline__glyph-cell {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.roughcut-timeline__glyph-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+}
+
+.roughcut-glyph {
+  display: inline-flex;
+  color: var(--accent-dim);
+  opacity: 0.95;
+}
+
+.roughcut-timeline__hint {
+  margin: 8px 0 0;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-faint);
+}
+
+.roughcut-preview {
+  margin-bottom: 20px;
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.roughcut-preview--missing {
+  padding: 20px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent-warm);
+}
+
+.roughcut-preview--missing code {
+  display: block;
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.roughcut-preview__chrome {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--hairline);
+  background: var(--bg);
+}
+
+.roughcut-preview__play {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--accent);
+  background: rgba(224, 165, 90, 0.12);
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.roughcut-preview__play:hover {
+  background: rgba(224, 165, 90, 0.2);
+}
+
+.roughcut-preview__time {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.roughcut-preview__clip-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-faint);
+  margin-left: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 45%;
+}
+
+.roughcut-preview__frame {
+  background: #000;
+  aspect-ratio: 16 / 9;
+  max-height: 280px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.roughcut-preview__video {
+  width: 100%;
+  height: 100%;
+  max-height: 280px;
+  object-fit: contain;
+}


### PR DESCRIPTION
## Summary
Ships the **M4b** slice from Epic **#14**: scrubbable story timeline, glanceable recipe glyphs, synced preview player, and iteration chips (Regenerate wired; others stubbed).

## In scope
- `read_library_text_file` Tauri command — UTF-8 text under configured libraries root only (canonical path check).
- After `roughcut_job_done`, load and parse sibling `.recipe.json`; **SVG** glyphs: speed ramps, color tag, markers, transitions at clip junctions, title card, PowerGrade.
- **Horizontal timeline** — segments proportional to clip duration, playhead, pointer scrub.
- **Preview** — 16:9 strip with Play/Pause; seek synced to timeline; playback stops at clip `out_point` (no cross-clip auto-play in this slice).
- **Regenerate** chip — same pipeline as Generate (full regen; trim-level diff deferred).
- **Stub chips:** Make tighter, Lean harder into slow-mo (disabled + TODO tooltips).

## Out of scope / follow-ups
- Clip-level diff vs prior generation; chip-driven brief mutations.
- Continuous playback across multiple source files.
- Resolve-embedded preview.

## Testing
- `npm run build` (ui), `cargo check` (ui/src-tauri) verified.
- Recommend: `bundle exec rspec ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb` before merge.

Advances milestone **M4b** on #14.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive roughcut timeline with playback, scrubbing, keyboard seek, segmented clips, and transition/gap glyphs.
  * Timeline glyphs and icons for speed ramps, markers, color tags, title cards, and powergrades.
  * Synchronized preview player that follows the global playhead and handles missing media.
  * Import and parse recipe files from the library to drive timeline/glyph displays; timecode and timeline-building utilities.

* **Style**
  * New styles for brief composer results, timeline, glyphs, and preview chrome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->