### PR TITLE
M5: Export sheet + Send to Resolve (#14)

### DIFF
--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -87,6 +87,8 @@ module ButtercutUiSidecar
         respond_error(id: id, code: -32010, message: "missing_api_key")
       when /\Ainvalid_api_key/
         respond_error(id: id, code: -32012, message: e.message)
+      when /\A(resolve_[a-z_]+|missing_[a-z_]+):/
+        respond_error(id: id, code: -32000, message: e.message)
       else
         respond_error(id: id, code: -32000, message: "#{e.class}: #{e.message}")
       end

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -181,9 +181,10 @@ module ButtercutUiSidecar
     def export_roughcut_artifacts(params)
       library = params.fetch("library")
       library_dir(library)
+      yaml_safe = assert_artifact_path_in_library!(library, params.fetch("yaml_path"), "yaml_path")
       exporter = ButtercutUiSidecar::RoughcutExporter.new(repo_root: @repo_root.to_s)
       exporter.export(
-        yaml_path: params.fetch("yaml_path"),
+        yaml_path: yaml_safe,
         format: params.fetch("format"),
         filename: params["filename"]
       )
@@ -192,11 +193,31 @@ module ButtercutUiSidecar
     def send_to_resolve(params)
       library = params.fetch("library")
       library_dir(library)
+      apply_safe = assert_artifact_path_in_library!(library, params.fetch("apply_path"), "apply_path")
+      recipe_safe = assert_artifact_path_in_library!(library, params.fetch("recipe_path"), "recipe_path")
       handoff = ButtercutUiSidecar::ResolveHandoff.new
       handoff.run(
-        apply_path: params.fetch("apply_path"),
-        recipe_path: params.fetch("recipe_path")
+        apply_path: apply_safe,
+        recipe_path: recipe_safe
       )
+    end
+
+    # Reject paths outside the resolved library directory (path traversal / arbitrary script execution).
+    def assert_artifact_path_in_library!(library, path, label)
+      lib_real = File.realpath(library_dir(library).to_s)
+      prefix = lib_real + File::SEPARATOR
+      expanded = Pathname.new(path.to_s).expand_path.to_s
+      resolved =
+        begin
+          File.realpath(expanded)
+        rescue Errno::ENOENT
+          expanded
+        end
+      unless resolved == lib_real || resolved.start_with?(prefix)
+        raise ArgumentError, "#{label} outside library directory"
+      end
+
+      resolved
     end
 
     def roughcut_prerequisites(name)

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -26,6 +26,8 @@ require_relative "lib/buttercut_ui_sidecar/stages/summarize"
 require_relative "lib/buttercut_ui_sidecar/brief_store"
 require_relative "lib/buttercut_ui_sidecar/presence"
 require_relative "lib/buttercut_ui_sidecar/roughcut_controller"
+require_relative "lib/buttercut_ui_sidecar/roughcut_exporter"
+require_relative "lib/buttercut_ui_sidecar/resolve_handoff"
 
 module ButtercutUiSidecar
   def self.run(libraries_root:, io_in: $stdin, io_out: $stdout)
@@ -168,8 +170,33 @@ module ButtercutUiSidecar
         brief_catalog_fork(params)
       when "start_roughcut"
         roughcut_start(params)
+      when "export_roughcut_artifacts"
+        export_roughcut_artifacts(params)
+      when "send_to_resolve"
+        send_to_resolve(params)
       else raise UnknownMethod, "unknown method: #{method}"
       end
+    end
+
+    def export_roughcut_artifacts(params)
+      library = params.fetch("library")
+      library_dir(library)
+      exporter = ButtercutUiSidecar::RoughcutExporter.new(repo_root: @repo_root.to_s)
+      exporter.export(
+        yaml_path: params.fetch("yaml_path"),
+        format: params.fetch("format"),
+        filename: params["filename"]
+      )
+    end
+
+    def send_to_resolve(params)
+      library = params.fetch("library")
+      library_dir(library)
+      handoff = ButtercutUiSidecar::ResolveHandoff.new
+      handoff.run(
+        apply_path: params.fetch("apply_path"),
+        recipe_path: params.fetch("recipe_path")
+      )
     end
 
     def roughcut_prerequisites(name)

--- a/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
@@ -3,9 +3,13 @@
 require "json"
 require "open3"
 require "pathname"
+require "timeout"
 
 module ButtercutUiSidecar
   class ResolveHandoff
+    OPEN_RESOLVE_TIMEOUT_SEC = 15
+    PRECHECK_TIMEOUT_SEC = 45
+    APPLY_SCRIPT_TIMEOUT_SEC = 300
     PRECHECK = <<~PY.freeze
       import json
       import sys
@@ -60,11 +64,16 @@ module ButtercutUiSidecar
       activate_resolve!
 
       recipe_obj = JSON.parse(recipe.read)
-      expected_timeline = recipe_obj["timeline"].to_s
+      expected_timeline = recipe_obj["timeline"].to_s.strip
+      if expected_timeline.empty?
+        raise "missing_recipe_timeline: Recipe JSON has no timeline name. Re-export the rough cut to regenerate the recipe."
+      end
       precheck = precheck_resolve(expected_timeline: expected_timeline)
       raise precheck_error(precheck) unless precheck["ok"]
 
-      out, status = Open3.capture2e("python3", apply.to_s)
+      out, status = with_handoff_timeout(APPLY_SCRIPT_TIMEOUT_SEC, "Apply script") do
+        Open3.capture2e("python3", apply.to_s)
+      end
       raise normalize_apply_failure(out) unless status.success?
 
       {
@@ -85,7 +94,9 @@ module ButtercutUiSidecar
     end
 
     def activate_resolve!
-      out, status = Open3.capture2e("open", "-a", "DaVinci Resolve")
+      out, status = with_handoff_timeout(OPEN_RESOLVE_TIMEOUT_SEC, "Open Resolve") do
+        Open3.capture2e("open", "-a", "DaVinci Resolve")
+      end
       return if status.success?
 
       detail = out.to_s.strip
@@ -94,12 +105,20 @@ module ButtercutUiSidecar
     end
 
     def precheck_resolve(expected_timeline:)
-      out, status = Open3.capture2e("python3", "-c", PRECHECK, expected_timeline.to_s)
+      out, status = with_handoff_timeout(PRECHECK_TIMEOUT_SEC, "Resolve precheck") do
+        Open3.capture2e("python3", "-c", PRECHECK, expected_timeline.to_s)
+      end
       raise "resolve_precheck_failed: #{out.strip}" unless status.success?
 
       JSON.parse(out)
     rescue JSON::ParserError
       raise "resolve_precheck_failed: #{out.to_s.strip}"
+    end
+
+    def with_handoff_timeout(seconds, label)
+      Timeout.timeout(seconds) { yield }
+    rescue Timeout::Error
+      raise "resolve_handoff_timeout: #{label} exceeded #{seconds}s — try again or restart Resolve if it is not responding."
     end
 
     def precheck_error(precheck)

--- a/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
@@ -14,43 +14,40 @@ module ButtercutUiSidecar
       try:
           import DaVinciResolveScript as dvr_script  # type: ignore
       except Exception:
-          result["error"] = "resolve_scripting_disabled"
-          print(json.dumps(result))
+          print(json.dumps({"ok": False, "error": "resolve_scripting_disabled"}))
           sys.exit(0)
 
       resolve = dvr_script.scriptapp("Resolve")
       if not resolve:
-          result["error"] = "resolve_scripting_disabled"
-          print(json.dumps(result))
+          print(json.dumps({"ok": False, "error": "resolve_scripting_disabled"}))
           sys.exit(0)
 
       project_manager = resolve.GetProjectManager()
       project = project_manager.GetCurrentProject() if project_manager else None
       if not project:
-          result["error"] = "resolve_no_active_project"
-          print(json.dumps(result))
+          print(json.dumps({"ok": False, "error": "resolve_no_active_project"}))
           sys.exit(0)
 
       timeline = project.GetCurrentTimeline()
       if not timeline:
-          result["error"] = "resolve_no_active_timeline"
-          print(json.dumps(result))
+          print(json.dumps({"ok": False, "error": "resolve_no_active_timeline"}))
           sys.exit(0)
 
       active_timeline = timeline.GetName() or ""
       if expected_timeline and expected_timeline != active_timeline:
-          result["error"] = "resolve_timeline_target_mismatch"
-          result["expected_timeline"] = expected_timeline
-          result["active_timeline"] = active_timeline
-          print(json.dumps(result))
+          print(json.dumps({
+              "ok": False,
+              "error": "resolve_timeline_target_mismatch",
+              "expected_timeline": expected_timeline,
+              "active_timeline": active_timeline,
+          }))
           sys.exit(0)
 
-      result = {
+      print(json.dumps({
           "ok": True,
           "project_name": project.GetName() or "",
           "active_timeline": active_timeline,
-      }
-      print(json.dumps(result))
+      }))
     PY
 
     def run(apply_path:, recipe_path:)
@@ -88,7 +85,12 @@ module ButtercutUiSidecar
     end
 
     def activate_resolve!
-      Open3.capture2("open", "-a", "DaVinci Resolve")
+      out, status = Open3.capture2e("open", "-a", "DaVinci Resolve")
+      return if status.success?
+
+      detail = out.to_s.strip
+      suffix = detail.empty? ? "" : " (#{detail})"
+      raise "resolve_launch_failed: Could not open DaVinci Resolve from the desktop. Open Resolve manually, then try Send to Resolve again.#{suffix}"
     end
 
     def precheck_resolve(expected_timeline:)
@@ -119,10 +121,21 @@ module ButtercutUiSidecar
 
     def normalize_apply_failure(output)
       text = output.to_s
-      return "missing_artifacts: recipe or apply script missing for this export." if text.include?("recipe not found")
-      return "resolve_scripting_disabled: Resolve scripting bridge not available. Enable Local scripting and restart Resolve." if text.include?("could not connect to Resolve")
-      return "resolve_no_active_project: No project is open in Resolve." if text.include?("no project open")
-      return "resolve_no_active_timeline: No timeline is active in Resolve. Import/open the rough cut timeline first." if text.include?("no timeline open")
+      if text.include?("recipe not found")
+        return "missing_recipe: The apply script could not find the recipe JSON on disk. Re-export the rough cut in ButterCut so the .recipe.json next to your XML is regenerated, then import the XML in Resolve and try again."
+      end
+      if text.include?("recipe version") && text.include?("unsupported")
+        return "resolve_apply_failed: This recipe version is not supported by the apply script. Re-export the rough cut to regenerate the recipe and _apply.py."
+      end
+      if text.include?("could not connect to Resolve")
+        return "resolve_scripting_disabled: Resolve scripting bridge not available. Enable Local scripting and restart Resolve."
+      end
+      if text.include?("no project open")
+        return "resolve_no_active_project: No project is open in Resolve."
+      end
+      if text.include?("no timeline open")
+        return "resolve_no_active_timeline: No timeline is active in Resolve. Import/open the rough cut timeline first."
+      end
 
       "resolve_apply_failed: #{text.strip}"
     end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+
+module ButtercutUiSidecar
+  class ResolveHandoff
+    PRECHECK = <<~PY.freeze
+      import json
+      import sys
+      import traceback
+
+      expected_timeline = sys.argv[1] if len(sys.argv) > 1 else ""
+      result = {"ok": False, "error": "unknown"}
+      try:
+          import DaVinciResolveScript as dvr_script  # type: ignore
+      except Exception:
+          result["error"] = "resolve_scripting_disabled"
+          print(json.dumps(result))
+          sys.exit(0)
+
+      resolve = dvr_script.scriptapp("Resolve")
+      if not resolve:
+          result["error"] = "resolve_scripting_disabled"
+          print(json.dumps(result))
+          sys.exit(0)
+
+      project_manager = resolve.GetProjectManager()
+      project = project_manager.GetCurrentProject() if project_manager else None
+      if not project:
+          result["error"] = "resolve_no_active_project"
+          print(json.dumps(result))
+          sys.exit(0)
+
+      timeline = project.GetCurrentTimeline()
+      if not timeline:
+          result["error"] = "resolve_no_active_timeline"
+          print(json.dumps(result))
+          sys.exit(0)
+
+      active_timeline = timeline.GetName() or ""
+      if expected_timeline and expected_timeline != active_timeline:
+          result["error"] = "resolve_timeline_target_mismatch"
+          result["expected_timeline"] = expected_timeline
+          result["active_timeline"] = active_timeline
+          print(json.dumps(result))
+          sys.exit(0)
+
+      result = {
+          "ok": True,
+          "project_name": project.GetName() or "",
+          "active_timeline": active_timeline,
+      }
+      print(json.dumps(result))
+    PY
+
+    def run(apply_path:, recipe_path:)
+      apply = Pathname.new(apply_path.to_s).expand_path
+      recipe = Pathname.new(recipe_path.to_s).expand_path
+      raise "missing_artifacts: apply script not found at #{apply}" unless apply.file?
+      raise "missing_artifacts: recipe not found at #{recipe}" unless recipe.file?
+
+      ensure_resolve_running!
+      activate_resolve!
+
+      recipe_obj = JSON.parse(recipe.read)
+      expected_timeline = recipe_obj["timeline"].to_s
+      precheck = precheck_resolve(expected_timeline: expected_timeline)
+      raise precheck_error(precheck) unless precheck["ok"]
+
+      out, status = Open3.capture2e("python3", apply.to_s)
+      raise normalize_apply_failure(out) unless status.success?
+
+      {
+        ok: true,
+        output: out,
+        project_name: precheck["project_name"].to_s,
+        timeline_name: precheck["active_timeline"].to_s
+      }
+    end
+
+    private
+
+    def ensure_resolve_running!
+      _out, status = Open3.capture2("pgrep", "-x", "Resolve")
+      return if status.success?
+
+      raise "resolve_not_running: Open DaVinci Resolve, open your project and timeline, then try Send to Resolve again."
+    end
+
+    def activate_resolve!
+      Open3.capture2("open", "-a", "DaVinci Resolve")
+    end
+
+    def precheck_resolve(expected_timeline:)
+      out, status = Open3.capture2e("python3", "-c", PRECHECK, expected_timeline.to_s)
+      raise "resolve_precheck_failed: #{out.strip}" unless status.success?
+
+      JSON.parse(out)
+    rescue JSON::ParserError
+      raise "resolve_precheck_failed: #{out.to_s.strip}"
+    end
+
+    def precheck_error(precheck)
+      case precheck["error"].to_s
+      when "resolve_scripting_disabled"
+        "resolve_scripting_disabled: Enable Resolve scripting (Preferences > System > General > External scripting using Local) and restart Resolve."
+      when "resolve_no_active_project"
+        "resolve_no_active_project: Open the Resolve project that contains your imported rough cut timeline."
+      when "resolve_no_active_timeline"
+        "resolve_no_active_timeline: Import/open the rough cut timeline in Resolve before sending."
+      when "resolve_timeline_target_mismatch"
+        expected = precheck["expected_timeline"].to_s
+        active = precheck["active_timeline"].to_s
+        "resolve_timeline_target_mismatch: Recipe targets '#{expected}' but Resolve has '#{active}' active. Switch to '#{expected}' and retry."
+      else
+        "resolve_precheck_failed: #{precheck["error"]}"
+      end
+    end
+
+    def normalize_apply_failure(output)
+      text = output.to_s
+      return "missing_artifacts: recipe or apply script missing for this export." if text.include?("recipe not found")
+      return "resolve_scripting_disabled: Resolve scripting bridge not available. Enable Local scripting and restart Resolve." if text.include?("could not connect to Resolve")
+      return "resolve_no_active_project: No project is open in Resolve." if text.include?("no project open")
+      return "resolve_no_active_timeline: No timeline is active in Resolve. Import/open the rough cut timeline first." if text.include?("no timeline open")
+
+      "resolve_apply_failed: #{text.strip}"
+    end
+  end
+end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/resolve_handoff.rb
@@ -9,10 +9,8 @@ module ButtercutUiSidecar
     PRECHECK = <<~PY.freeze
       import json
       import sys
-      import traceback
 
       expected_timeline = sys.argv[1] if len(sys.argv) > 1 else ""
-      result = {"ok": False, "error": "unknown"}
       try:
           import DaVinciResolveScript as dvr_script  # type: ignore
       except Exception:

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
@@ -29,12 +29,16 @@ module ButtercutUiSidecar
       xml_path = yaml.parent.join("#{stem}#{fmt[:ext]}")
       run_export!(yaml_path: yaml, xml_path: xml_path, editor: fmt[:editor])
       xml_base = xml_path.to_s.sub(/\.[^.]+\z/, "")
+      recipe_path = Pathname.new("#{xml_base}.recipe.json")
+      apply_path = Pathname.new("#{xml_base}_apply.py")
+      missing = [xml_path, recipe_path, apply_path].reject(&:file?)
+      raise "missing_artifacts: #{missing.map(&:to_s).join(', ')}" unless missing.empty?
 
       {
         yaml_path: yaml.to_s,
         xml_path: xml_path.to_s,
-        recipe_path: "#{xml_base}.recipe.json",
-        apply_path: "#{xml_base}_apply.py",
+        recipe_path: recipe_path.to_s,
+        apply_path: apply_path.to_s,
         format: format.to_s.strip.downcase
       }
     end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
@@ -58,10 +58,8 @@ module ButtercutUiSidecar
 
       gemfile = @repo_root.join("Gemfile").to_s
       cmd = ["bundle", "exec", "ruby", script.to_s, yaml_path.to_s, xml_path.to_s, editor]
-      out = nil
-      status = nil
-      Dir.chdir(@repo_root.to_s) do
-        out, status = Open3.capture2e({ "BUNDLE_GEMFILE" => gemfile }, *cmd)
+      out, status = Dir.chdir(@repo_root.to_s) do
+        Open3.capture2e({ "BUNDLE_GEMFILE" => gemfile }, *cmd)
       end
       raise "export_failed: #{out.to_s.strip}" unless status.success?
     end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_exporter.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+module ButtercutUiSidecar
+  class RoughcutExporter
+    FORMATS = {
+      "fcpx" => { editor: "fcpx", ext: ".fcpxml" },
+      "premiere" => { editor: "premiere", ext: ".xml" },
+      "resolve" => { editor: "resolve", ext: ".xml" }
+    }.freeze
+
+    def initialize(repo_root:)
+      raise ArgumentError, "repo_root required" if repo_root.nil? || repo_root.to_s.empty?
+
+      @repo_root = Pathname.new(repo_root)
+    end
+
+    def export(yaml_path:, format:, filename: nil)
+      yaml = Pathname.new(yaml_path.to_s).expand_path
+      raise ArgumentError, "yaml not found: #{yaml}" unless yaml.file?
+
+      fmt = FORMATS.fetch(format.to_s.strip.downcase) do
+        raise ArgumentError, "unsupported format: #{format}"
+      end
+
+      stem = pick_stem(yaml: yaml, filename: filename)
+      xml_path = yaml.parent.join("#{stem}#{fmt[:ext]}")
+      run_export!(yaml_path: yaml, xml_path: xml_path, editor: fmt[:editor])
+      xml_base = xml_path.to_s.sub(/\.[^.]+\z/, "")
+
+      {
+        yaml_path: yaml.to_s,
+        xml_path: xml_path.to_s,
+        recipe_path: "#{xml_base}.recipe.json",
+        apply_path: "#{xml_base}_apply.py",
+        format: format.to_s.strip.downcase
+      }
+    end
+
+    private
+
+    def pick_stem(yaml:, filename:)
+      candidate = filename.to_s.strip
+      return yaml.basename(".yaml").to_s if candidate.empty?
+
+      candidate = File.basename(candidate)
+      candidate = candidate.sub(/\.[^.]+\z/, "")
+      raise ArgumentError, "filename required" if candidate.empty?
+
+      candidate
+    end
+
+    def run_export!(yaml_path:, xml_path:, editor:)
+      script = @repo_root.join(".claude/skills/roughcut/export_to_fcpxml.rb")
+      raise "export script missing: #{script}" unless script.file?
+
+      gemfile = @repo_root.join("Gemfile").to_s
+      cmd = ["bundle", "exec", "ruby", script.to_s, yaml_path.to_s, xml_path.to_s, editor]
+      out = nil
+      status = nil
+      Dir.chdir(@repo_root.to_s) do
+        out, status = Open3.capture2e({ "BUNDLE_GEMFILE" => gemfile }, *cmd)
+      end
+      raise "export_failed: #{out.to_s.strip}" unless status.success?
+    end
+  end
+end

--- a/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+++ b/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
@@ -398,12 +398,37 @@ RSpec.describe ButtercutUiSidecar do
         expect(result.dig("result", "format")).to eq("resolve")
       end
     end
+
+    it "rejects yaml_path outside the library directory" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo", videos: [])
+        outside = File.join(root, "outside.yaml")
+        File.write(outside, "clips: []\n")
+
+        result = call(root, "export_roughcut_artifacts", {
+          library: "demo",
+          yaml_path: outside,
+          format: "resolve",
+          filename: "x"
+        })
+
+        expect(result["error"]).not_to be_nil
+        expect(result.dig("error", "message")).to match(/outside library directory/)
+      end
+    end
   end
 
   describe "send_to_resolve" do
     it "returns handoff result from Resolve runner" do
       Dir.mktmpdir do |root|
         LibraryFixture.build(root, name: "demo", videos: [])
+        rough = File.join(root, "demo", "roughcuts")
+        FileUtils.mkdir_p(rough)
+        apply_path = File.join(rough, "a_apply.py")
+        recipe_path = File.join(rough, "a.recipe.json")
+        File.write(apply_path, "#")
+        File.write(recipe_path, "{}")
+
         fake = instance_double(ButtercutUiSidecar::ResolveHandoff)
         allow(ButtercutUiSidecar::ResolveHandoff).to receive(:new).and_return(fake)
         allow(fake).to receive(:run).and_return({
@@ -415,12 +440,31 @@ RSpec.describe ButtercutUiSidecar do
 
         result = call(root, "send_to_resolve", {
           library: "demo",
-          apply_path: "/tmp/a_apply.py",
-          recipe_path: "/tmp/a.recipe.json"
+          apply_path: apply_path,
+          recipe_path: recipe_path
         })
 
         expect(result["error"]).to be_nil
         expect(result.dig("result", "ok")).to be(true)
+      end
+    end
+
+    it "rejects apply_path outside the library directory" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo", videos: [])
+        File.write(File.join(root, "evil_apply.py"), "#")
+        rdir = File.join(root, "demo", "roughcuts")
+        FileUtils.mkdir_p(rdir)
+        File.write(File.join(rdir, "r.recipe.json"), "{}")
+
+        result = call(root, "send_to_resolve", {
+          library: "demo",
+          apply_path: File.join(root, "evil_apply.py"),
+          recipe_path: File.join(rdir, "r.recipe.json")
+        })
+
+        expect(result["error"]).not_to be_nil
+        expect(result.dig("error", "message")).to match(/outside library directory/)
       end
     end
   end

--- a/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
+++ b/ui/sidecar/spec/buttercut_ui_sidecar_spec.rb
@@ -368,4 +368,60 @@ RSpec.describe ButtercutUiSidecar do
       end
     end
   end
+
+  describe "export_roughcut_artifacts" do
+    it "returns exported artifact paths" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo", videos: [])
+        yaml_path = File.join(root, "demo", "roughcuts", "roughcut_ui_1.yaml")
+        FileUtils.mkdir_p(File.dirname(yaml_path))
+        File.write(yaml_path, "clips: []\n")
+
+        fake = instance_double(ButtercutUiSidecar::RoughcutExporter)
+        allow(ButtercutUiSidecar::RoughcutExporter).to receive(:new).and_return(fake)
+        allow(fake).to receive(:export).and_return({
+          yaml_path: yaml_path,
+          xml_path: File.join(root, "demo", "roughcuts", "delivery.xml"),
+          recipe_path: File.join(root, "demo", "roughcuts", "delivery.recipe.json"),
+          apply_path: File.join(root, "demo", "roughcuts", "delivery_apply.py"),
+          format: "resolve"
+        })
+
+        result = call(root, "export_roughcut_artifacts", {
+          library: "demo",
+          yaml_path: yaml_path,
+          format: "resolve",
+          filename: "delivery"
+        })
+
+        expect(result["error"]).to be_nil
+        expect(result.dig("result", "format")).to eq("resolve")
+      end
+    end
+  end
+
+  describe "send_to_resolve" do
+    it "returns handoff result from Resolve runner" do
+      Dir.mktmpdir do |root|
+        LibraryFixture.build(root, name: "demo", videos: [])
+        fake = instance_double(ButtercutUiSidecar::ResolveHandoff)
+        allow(ButtercutUiSidecar::ResolveHandoff).to receive(:new).and_return(fake)
+        allow(fake).to receive(:run).and_return({
+          ok: true,
+          output: "[apply_recipe] applied",
+          project_name: "Demo",
+          timeline_name: "roughcut_ui_1"
+        })
+
+        result = call(root, "send_to_resolve", {
+          library: "demo",
+          apply_path: "/tmp/a_apply.py",
+          recipe_path: "/tmp/a.recipe.json"
+        })
+
+        expect(result["error"]).to be_nil
+        expect(result.dig("result", "ok")).to be(true)
+      end
+    end
+  end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ButtercutUiSidecar::ResolveHandoff do
       running = instance_double(Process::Status, success?: true)
       ok = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2).with("pgrep", "-x", "Resolve").and_return(["123\n", running])
-      allow(Open3).to receive(:capture2).with("open", "-a", "DaVinci Resolve").and_return(["", ok])
+      allow(Open3).to receive(:capture2e).with("open", "-a", "DaVinci Resolve").and_return(["", ok])
       allow(Open3).to receive(:capture2e).with("python3", "-c", described_class::PRECHECK, "Expected TL").and_return([
         JSON.dump({ ok: false, error: "resolve_timeline_target_mismatch", expected_timeline: "Expected TL", active_timeline: "Other TL" }),
         ok
@@ -32,6 +32,24 @@ RSpec.describe ButtercutUiSidecar::ResolveHandoff do
       expect {
         described_class.new.run(apply_path: apply_path, recipe_path: recipe_path)
       }.to raise_error(/resolve_timeline_target_mismatch/)
+    end
+  end
+
+  it "raises resolve_launch_failed when open -a DaVinci Resolve fails" do
+    Dir.mktmpdir do |root|
+      apply_path = File.join(root, "cut_apply.py")
+      recipe_path = File.join(root, "cut.recipe.json")
+      File.write(apply_path, "#!/usr/bin/env python3\n")
+      File.write(recipe_path, JSON.dump({ version: 1, timeline: "TL" }))
+
+      running = instance_double(Process::Status, success?: true)
+      open_fail = instance_double(Process::Status, success?: false)
+      allow(Open3).to receive(:capture2).with("pgrep", "-x", "Resolve").and_return(["123\n", running])
+      allow(Open3).to receive(:capture2e).with("open", "-a", "DaVinci Resolve").and_return(["Unable to find application named DaVinci Resolve", open_fail])
+
+      expect {
+        described_class.new.run(apply_path: apply_path, recipe_path: recipe_path)
+      }.to raise_error(/resolve_launch_failed/)
     end
   end
 end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "json"
+require_relative "../../../lib/buttercut_ui_sidecar/resolve_handoff"
+
+RSpec.describe ButtercutUiSidecar::ResolveHandoff do
+  it "maps resolve-not-running to actionable error" do
+    allow(Open3).to receive(:capture2).with("pgrep", "-x", "Resolve").and_return(["", instance_double(Process::Status, success?: false)])
+    expect {
+      described_class.new.send(:ensure_resolve_running!)
+    }.to raise_error(/resolve_not_running/)
+  end
+
+  it "raises timeline mismatch with expected/active names" do
+    Dir.mktmpdir do |root|
+      apply_path = File.join(root, "cut_apply.py")
+      recipe_path = File.join(root, "cut.recipe.json")
+      File.write(apply_path, "#!/usr/bin/env python3\n")
+      File.write(recipe_path, JSON.dump({ version: 1, timeline: "Expected TL" }))
+
+      running = instance_double(Process::Status, success?: true)
+      ok = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2).with("pgrep", "-x", "Resolve").and_return(["123\n", running])
+      allow(Open3).to receive(:capture2).with("open", "-a", "DaVinci Resolve").and_return(["", ok])
+      allow(Open3).to receive(:capture2e).with("python3", "-c", described_class::PRECHECK, "Expected TL").and_return([
+        JSON.dump({ ok: false, error: "resolve_timeline_target_mismatch", expected_timeline: "Expected TL", active_timeline: "Other TL" }),
+        ok
+      ])
+
+      expect {
+        described_class.new.run(apply_path: apply_path, recipe_path: recipe_path)
+      }.to raise_error(/resolve_timeline_target_mismatch/)
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/resolve_handoff_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe ButtercutUiSidecar::ResolveHandoff do
     end
   end
 
+  it "raises when recipe timeline is missing or blank" do
+    Dir.mktmpdir do |root|
+      apply_path = File.join(root, "cut_apply.py")
+      recipe_path = File.join(root, "cut.recipe.json")
+      File.write(apply_path, "#!/usr/bin/env python3\n")
+      File.write(recipe_path, JSON.dump({ version: 1 }))
+
+      running = instance_double(Process::Status, success?: true)
+      ok = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2).with("pgrep", "-x", "Resolve").and_return(["123\n", running])
+      allow(Open3).to receive(:capture2e).with("open", "-a", "DaVinci Resolve").and_return(["", ok])
+
+      expect {
+        described_class.new.run(apply_path: apply_path, recipe_path: recipe_path)
+      }.to raise_error(/missing_recipe_timeline/)
+    end
+  end
+
   it "raises resolve_launch_failed when open -a DaVinci Resolve fails" do
     Dir.mktmpdir do |root|
       apply_path = File.join(root, "cut_apply.py")

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_exporter_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_exporter_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe ButtercutUiSidecar::RoughcutExporter do
       File.write(yaml_path, YAML.dump("clips" => []))
 
       status = instance_double(Process::Status, success?: true)
-      allow(Open3).to receive(:capture2e).and_return(["ok", status])
+      allow(Open3).to receive(:capture2e) do
+        base = File.join(root, "roughcuts", "delivery_cut")
+        File.write("#{base}.xml", "<x/>")
+        File.write("#{base}.recipe.json", "{}")
+        File.write("#{base}_apply.py", "#!/usr/bin/env python3\n")
+        ["ok", status]
+      end
 
       result = described_class.new(repo_root: repo_root).export(
         yaml_path: yaml_path,
@@ -39,7 +45,13 @@ RSpec.describe ButtercutUiSidecar::RoughcutExporter do
       File.write(yaml_path, YAML.dump("clips" => []))
 
       status = instance_double(Process::Status, success?: true)
-      allow(Open3).to receive(:capture2e).and_return(["ok", status])
+      allow(Open3).to receive(:capture2e) do
+        base = File.join(root, "roughcuts", "roughcut_ui_20260504_120000")
+        File.write("#{base}.fcpxml", "<x/>")
+        File.write("#{base}.recipe.json", "{}")
+        File.write("#{base}_apply.py", "#!/usr/bin/env python3\n")
+        ["ok", status]
+      end
 
       result = described_class.new(repo_root: repo_root).export(
         yaml_path: yaml_path,

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_exporter_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/roughcut_exporter_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../lib/buttercut_ui_sidecar/roughcut_exporter"
+
+RSpec.describe ButtercutUiSidecar::RoughcutExporter do
+  def repo_root
+    File.expand_path("../../../../../", __dir__)
+  end
+
+  it "exports using requested format and filename stem" do
+    Dir.mktmpdir do |root|
+      yaml_path = File.join(root, "roughcuts", "roughcut_ui_20260504_120000.yaml")
+      FileUtils.mkdir_p(File.dirname(yaml_path))
+      File.write(yaml_path, YAML.dump("clips" => []))
+
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e).and_return(["ok", status])
+
+      result = described_class.new(repo_root: repo_root).export(
+        yaml_path: yaml_path,
+        format: "resolve",
+        filename: "delivery_cut"
+      )
+
+      expect(result[:xml_path]).to end_with("/roughcuts/delivery_cut.xml")
+      expect(result[:recipe_path]).to end_with("/roughcuts/delivery_cut.recipe.json")
+      expect(result[:apply_path]).to end_with("/roughcuts/delivery_cut_apply.py")
+      expect(Open3).to have_received(:capture2e)
+    end
+  end
+
+  it "uses .fcpxml for fcpx format" do
+    Dir.mktmpdir do |root|
+      yaml_path = File.join(root, "roughcuts", "roughcut_ui_20260504_120000.yaml")
+      FileUtils.mkdir_p(File.dirname(yaml_path))
+      File.write(yaml_path, YAML.dump("clips" => []))
+
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e).and_return(["ok", status])
+
+      result = described_class.new(repo_root: repo_root).export(
+        yaml_path: yaml_path,
+        format: "fcpx"
+      )
+
+      expect(result[:xml_path]).to end_with(".fcpxml")
+    end
+  end
+end

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -164,6 +164,36 @@ async fn start_roughcut(library: String, brief_id: String) -> Result<Value, Stri
     .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+async fn export_roughcut_artifacts(
+    library: String,
+    yaml_path: String,
+    format: String,
+    filename: Option<String>,
+) -> Result<Value, String> {
+    sidecar::call(
+        "export_roughcut_artifacts",
+        json!({
+            "library": library,
+            "yaml_path": yaml_path,
+            "format": format,
+            "filename": filename
+        }),
+    )
+    .await
+    .map_err(sidecar_error_payload)
+}
+
+#[tauri::command]
+async fn send_to_resolve(library: String, apply_path: String, recipe_path: String) -> Result<Value, String> {
+    sidecar::call(
+        "send_to_resolve",
+        json!({ "library": library, "apply_path": apply_path, "recipe_path": recipe_path }),
+    )
+    .await
+    .map_err(sidecar_error_payload)
+}
+
 /// Read a UTF-8 text file under the configured libraries root (for recipe.json, etc.).
 #[tauri::command]
 fn read_library_text_file(path: String) -> Result<String, String> {
@@ -340,6 +370,8 @@ pub fn run() {
             upsert_brief,
             fork_brief,
             start_roughcut,
+            export_roughcut_artifacts,
+            send_to_resolve,
             read_library_text_file
         ])
         .run(tauri::generate_context!())

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { ClipTranscripts, LibraryDetail } from "../routes/library/types";
+import type { RoughcutArtifactPaths } from "./events";
 
 export interface LibrarySummary {
   name: string;
@@ -117,6 +118,23 @@ export async function forkBrief(library: string, parentId: string): Promise<{ id
 
 export async function startRoughcut(library: string, briefId: string): Promise<{ job_id: string }> {
   return invoke("start_roughcut", { library, briefId });
+}
+
+export async function exportRoughcutArtifacts(
+  library: string,
+  yamlPath: string,
+  format: "resolve" | "premiere" | "fcpx",
+  filename?: string,
+): Promise<RoughcutArtifactPaths & { format: string }> {
+  return invoke("export_roughcut_artifacts", { library, yamlPath, format, filename: filename?.trim() || null });
+}
+
+export async function sendToResolve(
+  library: string,
+  applyPath: string,
+  recipePath: string,
+): Promise<{ ok: boolean; output: string; project_name: string; timeline_name: string }> {
+  return invoke("send_to_resolve", { library, applyPath, recipePath });
 }
 
 export async function readLibraryTextFile(path: string): Promise<string> {

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -1,13 +1,15 @@
 import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   cancelJob,
+  exportRoughcutArtifacts,
   forkBrief,
   hasApiKey,
   listBriefs,
   readLibraryTextFile,
   roughcutPrerequisites,
+  sendToResolve,
   startRoughcut,
   upsertBrief,
 } from "../../ipc/sidecar";
@@ -48,6 +50,29 @@ const ARTIFACT_PATH_KEYS: (keyof RoughcutArtifactPaths)[] = [
   "recipe_path",
   "apply_path",
 ];
+const EXPORT_FORMATS = ["resolve", "premiere", "fcpx"] as const;
+type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+function dirname(path: string): string {
+  const i = path.lastIndexOf("/");
+  if (i <= 0) return path;
+  return path.slice(0, i);
+}
+
+function basenameNoExt(path: string): string {
+  const leaf = path.split("/").pop() ?? path;
+  return leaf.replace(/\.[^.]+$/, "");
+}
+
+function normalizeSidecarError(error: unknown): string {
+  const text = String(error);
+  try {
+    const parsed = JSON.parse(text) as { message?: string };
+    return parsed.message ?? text;
+  } catch {
+    return text;
+  }
+}
 
 function disposeRoughcutListener(
   unlisten: () => void,
@@ -72,6 +97,11 @@ export default function BriefComposer({ library, videos }: { library: string; vi
   const [recipe, setRecipe] = useState<RecipeJson | null>(null);
   const [playheadSec, setPlayheadSec] = useState(0);
   const [playing, setPlaying] = useState(false);
+  const [exportFormat, setExportFormat] = useState<ExportFormat>("resolve");
+  const [exportFilename, setExportFilename] = useState("");
+  const [exportBusy, setExportBusy] = useState(false);
+  const [exportStatus, setExportStatus] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
   const activeJobIdRef = useRef<string | null>(null);
   const unlistenRef = useRef<(() => void) | null>(null);
   const recipeReadTokenRef = useRef(0);
@@ -103,6 +133,11 @@ export default function BriefComposer({ library, videos }: { library: string; vi
   useEffect(() => {
     setPlayheadSec(0);
     setPlaying(false);
+    if (donePaths?.yaml_path) {
+      setExportFilename(basenameNoExt(donePaths.yaml_path));
+      setExportStatus(null);
+      setExportError(null);
+    }
   }, [donePaths?.yaml_path]);
 
   async function handleSaveBrief() {
@@ -205,6 +240,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
               });
             setJobRunning(false);
             setPhaseMessage(null);
+            setExportFormat("resolve");
             activeJobIdRef.current = null;
             disposeRoughcutListener(unlisten, unlistenRef);
             break;
@@ -238,6 +274,55 @@ export default function BriefComposer({ library, videos }: { library: string; vi
     activeJobIdRef.current = null;
     setJobRunning(false);
     setPhaseMessage(null);
+  }
+
+  async function handleExportArtifacts(format: ExportFormat): Promise<RoughcutArtifactPaths | null> {
+    if (!donePaths) return null;
+    setExportBusy(true);
+    setExportError(null);
+    setExportStatus(format === "resolve" ? "Preparing Resolve export…" : "Exporting artifacts…");
+    try {
+      const next = await exportRoughcutArtifacts(library, donePaths.yaml_path, format, exportFilename);
+      setDonePaths(next);
+      setExportFormat(format);
+      setExportStatus(`Export complete (${format.toUpperCase()}).`);
+      try {
+        const raw = await readLibraryTextFile(next.recipe_path);
+        setRecipe(parseRoughcutRecipeJson(raw));
+      } catch {
+        setRecipe(null);
+      }
+      return next;
+    } catch (e) {
+      setExportStatus(null);
+      setExportError(normalizeSidecarError(e));
+      return null;
+    } finally {
+      setExportBusy(false);
+    }
+  }
+
+  async function handleSendToResolve() {
+    if (!donePaths) return;
+    setExportError(null);
+    setExportStatus("Sending to Resolve…");
+    let target = donePaths;
+    if (exportFormat !== "resolve") {
+      const exported = await handleExportArtifacts("resolve");
+      if (!exported) return;
+      target = exported;
+    }
+
+    setExportBusy(true);
+    try {
+      const result = await sendToResolve(library, target.apply_path, target.recipe_path);
+      setExportStatus(`Applied in Resolve project "${result.project_name}" on timeline "${result.timeline_name}".`);
+    } catch (e) {
+      setExportStatus(null);
+      setExportError(normalizeSidecarError(e));
+    } finally {
+      setExportBusy(false);
+    }
   }
 
   return (
@@ -415,18 +500,81 @@ export default function BriefComposer({ library, videos }: { library: string; vi
           </table>
 
           {donePaths && (
+            <div className="brief-composer__export-sheet">
+              <h3 className="brief-composer__results-title">Export</h3>
+              <p className="brief-composer__results-lead">
+                Export uses the generated rough cut YAML as source and writes XML, recipe, and apply artifacts to the roughcuts
+                folder.
+              </p>
+              <div className="brief-composer__export-grid">
+                <label className="brief-composer__label" htmlFor="export-format">
+                  Format
+                </label>
+                <select
+                  id="export-format"
+                  className="brief-composer__input"
+                  value={exportFormat}
+                  disabled={exportBusy}
+                  onChange={(e) => setExportFormat(e.target.value as ExportFormat)}
+                >
+                  <option value="resolve">DaVinci Resolve</option>
+                  <option value="premiere">Adobe Premiere</option>
+                  <option value="fcpx">Final Cut Pro</option>
+                </select>
+                <label className="brief-composer__label" htmlFor="export-filename">
+                  Filename (no extension)
+                </label>
+                <input
+                  id="export-filename"
+                  className="brief-composer__input"
+                  value={exportFilename}
+                  disabled={exportBusy}
+                  onChange={(e) => setExportFilename(e.target.value)}
+                />
+              </div>
+              <p className="brief-composer__paths-label">Output folder: {dirname(donePaths.yaml_path)}</p>
+              <div className="brief-composer__actions">
+                <button
+                  type="button"
+                  className="brief-composer__btn"
+                  disabled={exportBusy || !exportFilename.trim()}
+                  onClick={() => void handleExportArtifacts(exportFormat)}
+                >
+                  {exportBusy ? "Working…" : `Export ${exportFormat.toUpperCase()}`}
+                </button>
+                <button
+                  type="button"
+                  className="brief-composer__btn brief-composer__btn--primary"
+                  disabled={exportBusy || !exportFilename.trim()}
+                  onClick={() => void handleSendToResolve()}
+                >
+                  Send to Resolve
+                </button>
+              </div>
+              {exportStatus && <p className="brief-composer__phase">{exportStatus}</p>}
+              {exportError && <pre className="brief-composer__error">{exportError}</pre>}
+            </div>
+          )}
+
+          {donePaths && (
             <div className="brief-composer__paths">
-              <p className="brief-composer__paths-label">Artifacts (reveal in Finder)</p>
+              <p className="brief-composer__paths-label">Artifacts</p>
               <ul>
                 {ARTIFACT_PATH_KEYS.map((key) => (
                   <li key={key}>
-                    <button
-                      type="button"
-                      className="brief-composer__linkish"
-                      onClick={() => void revealItemInDir(donePaths[key])}
-                    >
-                      {donePaths[key]}
-                    </button>
+                    <span className="brief-composer__path-text">{donePaths[key]}</span>
+                    <span className="brief-composer__path-actions">
+                      <button type="button" className="brief-composer__linkish" onClick={() => void openPath(donePaths[key])}>
+                        Open
+                      </button>
+                      <button
+                        type="button"
+                        className="brief-composer__linkish"
+                        onClick={() => void revealItemInDir(donePaths[key])}
+                      >
+                        Reveal
+                      </button>
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -52,22 +52,38 @@ const ARTIFACT_PATH_KEYS: (keyof RoughcutArtifactPaths)[] = [
 ];
 type ExportFormat = "resolve" | "premiere" | "fcpx";
 
+function normalizeSlashes(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 function dirname(path: string): string {
-  const i = path.lastIndexOf("/");
-  if (i <= 0) return path;
-  return path.slice(0, i);
+  const n = normalizeSlashes(path).replace(/\/+$/, "");
+  if (!n) return ".";
+  const i = n.lastIndexOf("/");
+  if (i < 0) return ".";
+  if (i === 0) return "/";
+  return n.slice(0, i) || ".";
 }
 
 function basenameNoExt(path: string): string {
-  const leaf = path.split("/").pop() ?? path;
-  return leaf.replace(/\.[^.]+$/, "");
+  const n = normalizeSlashes(path);
+  const leaf = n.split("/").pop() ?? path;
+  const lastDot = leaf.lastIndexOf(".");
+  if (lastDot <= 0) return leaf;
+  return leaf.slice(0, lastDot);
 }
 
 function normalizeSidecarError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === "string" && msg.trim()) return msg.trim();
+  }
   const text = String(error);
   try {
     const parsed = JSON.parse(text) as { message?: string };
-    return parsed.message ?? text;
+    if (parsed.message && parsed.message.trim()) return parsed.message;
+    return text;
   } catch {
     return text;
   }
@@ -281,7 +297,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
     setExportError(null);
     setExportStatus(format === "resolve" ? "Preparing Resolve export…" : "Exporting artifacts…");
     try {
-      const next = await exportRoughcutArtifacts(library, donePaths.yaml_path, format, exportFilename);
+      const next = await exportRoughcutArtifacts(library, donePaths.yaml_path, format, exportFilename.trim());
       setDonePaths(next);
       setExportFormat(format);
       setExportStatus(`Export complete (${format.toUpperCase()}).`);

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -50,8 +50,7 @@ const ARTIFACT_PATH_KEYS: (keyof RoughcutArtifactPaths)[] = [
   "recipe_path",
   "apply_path",
 ];
-const EXPORT_FORMATS = ["resolve", "premiere", "fcpx"] as const;
-type ExportFormat = (typeof EXPORT_FORMATS)[number];
+type ExportFormat = "resolve" | "premiere" | "fcpx";
 
 function dirname(path: string): string {
   const i = path.lastIndexOf("/");

--- a/ui/src/routes/library/library.css
+++ b/ui/src/routes/library/library.css
@@ -787,6 +787,19 @@
   margin-top: 20px;
 }
 
+.brief-composer__export-sheet {
+  margin-top: 20px;
+  padding: 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.brief-composer__export-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
 .brief-composer__paths-label {
   font-family: var(--mono);
   font-size: 10px;
@@ -803,16 +816,35 @@
   gap: 6px;
 }
 
+.brief-composer__paths li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.brief-composer__path-text {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.brief-composer__path-actions {
+  display: inline-flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
 .brief-composer__linkish {
   font-family: var(--mono);
   font-size: 10px;
   color: var(--accent);
-  text-align: left;
+  text-align: right;
   background: none;
   border: none;
   cursor: pointer;
   padding: 0;
-  word-break: break-all;
   text-decoration: underline;
   text-underline-offset: 2px;
 }


### PR DESCRIPTION
## Summary

Closes the **M5** milestone from epic [#14](https://github.com/William-Hill/buttercut/issues/14): **Export** sheet in the Rough cut tab (format + filename), artifact **Open / Reveal**, and **Send to Resolve** that reuses the existing YAML → `export_to_fcpxml.rb` → XML + `.recipe.json` + `*_apply.py` pipeline, with explicit Resolve handoff errors.

## In scope

- Export sheet: DaVinci Resolve / Premiere / FCP (xmeml), filename stem, output folder line, **Export** and primary **Send to Resolve**
- Sidecar: `export_roughcut_artifacts` + `send_to_resolve` JSON-RPC; Tauri `export_roughcut_artifacts` / `send_to_resolve` commands
- Resolve: preflight (scripting, project, timeline, name match to recipe), run apply script; **`open -a` failure** surfacing; apply output mapping (`missing_recipe`, version mismatch, etc.)
- Simplify + follow-up fix: repair embedded precheck Python (valid JSON per branch; no undefined `result`)

## Out of scope

- Premiere / FCP “apply” beyond XML export (same as epic: Resolve apply path only for automation)
- Full NLE / timeline editing inside ButterCut

## Error states (user-facing prefixes)

- `resolve_not_running`, `resolve_launch_failed`, `resolve_scripting_disabled`, `resolve_no_active_project`, `resolve_no_active_timeline`, `resolve_timeline_target_mismatch`, `missing_recipe`, `resolve_apply_failed`, plus sidecar `missing_artifacts` when files are absent before run

## Follow-ups

- Non-macOS: replace `pgrep` / `open -a` with platform-specific process launch + detection

## Test plan

- `cd ui && npm run build`
- `cd ui/src-tauri && cargo check`
- `cd ui/sidecar && mise exec -- bundle exec rspec` (100 examples)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export roughcuts to Final Cut Pro, Premiere, and DaVinci Resolve; generate XML, recipe and apply artifacts
  * Send roughcuts directly to DaVinci Resolve with an integrated handoff flow
  * UI: export sheet with format selection, custom filename, status, and per-artifact Open/Reveal actions

* **Bug Fixes**
  * Reject artifact paths that resolve outside the selected library (prevents path traversal)

* **Style**
  * New/updated styling for the brief composer export sheet and artifact list layout

* **Tests**
  * Added coverage for export/send-to-Resolve flows and path-validation checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->