### PR TITLE
feat: theme block in library.yaml + preset themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Library theme block + bundled presets (#27).** New `theme:` block in `library.yaml` (fonts, colors, logo, motion, `template_set`) plus three bundled preset YAMLs in `themes/` (`tutorial-dark`, `vlog-warm`, `corporate-clean`). `ButterCut::Theme.resolve` loads the named preset and merges any library-level overrides over it so Hyperframes compositions render with consistent typography and palette across a series. Migration: `ruby scripts/004_migrate_add_theme.rb --all` adds the default block to libraries that predate the feature.
 - **B-roll manifest schema (Hyperframes foundation).** New `*.broll.yaml` artifact format and validator (`lib/buttercut/broll_manifest.rb`) that the b-roll director will emit and the Hyperframes render skill / roughcut integration will consume. Each entry pairs a footage timestamp with a template, placement (`overlay` / `cutaway` / `pip`), and template-specific content payload. Canonical example in `templates/broll_template.yaml`. First slice of the Hyperframes integration epic (#63, schema task #64).
 - `fuses/` with five bundled Fusion fuses: `ChromaPulse`, `VHSGlitch`, `FilmGrain`, `LightLeak`, and `ZoomPunch`. (#23)
 - `ButterCut::FuseLibrary` for loading and validating fuse manifests. (#23)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ Known migration triggers (match each to a `scripts/NNN_migrate_*.rb` script via 
 - `transcript_refinement` missing (added in [Unreleased]; missing means "predates the feature, default to `false`" — NOT the template default of `true`)
 - `footage_summary` missing OR old name `footage_description` present (renamed in [Unreleased])
 - video entries with `summary` missing (added in [Unreleased]; missing means "todo", default to empty string)
+- `theme` missing (added in [Unreleased]; run `scripts/004_migrate_add_theme.rb` to add the default block with `template_set: tutorial-dark`)
 - video entries with `transcript_path` / `visual_transcript_path` (renamed to `transcript` / `visual_transcript` in 0.3.0)
 - video entries with `file_size_mb` (removed in 0.3.0)
 

--- a/hyperframes/compositions/code-callout/README.md
+++ b/hyperframes/compositions/code-callout/README.md
@@ -8,9 +8,10 @@ Monospace command + caption, designed to overlay on a terminal/IDE shot.
 |----------|---------|----------|----------------------------------------------|
 | command  | string  | yes      | Code or shell command to display (one line). |
 | caption  | string  | no       | Short caption shown below the command.       |
+| theme    | object  | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_accent). Defaults to the tutorial-dark palette when absent. |
 
 **Duration:** fixed at 5s for now. Hyperframes resolves `data-duration` at compile time, so a runtime variable cannot change the encoded length. Variable durations require a pre-render templating step — tracked as a follow-up.
 
-Theme: hardcoded `tutorial-dark` palette (Inter / JetBrains Mono, #0d0d0d bg, #ff6b35 accent). Will be parameterized by the theme block in a later PR.
+**Theme:** tokens applied at runtime via CSS custom properties (`--bg`, `--accent`, `--font-display`, `--font-mono`). Built-in defaults match the `tutorial-dark` preset so renders without a theme block still look right.
 
 Aspect: 1920x1080. 9:16 variant in a later PR.

--- a/hyperframes/compositions/code-callout/index.html
+++ b/hyperframes/compositions/code-callout/index.html
@@ -4,7 +4,8 @@
   data-composition-variables='[
     {"id":"command","type":"string","label":"Command","default":"git status"},
     {"id":"caption","type":"string","label":"Caption","default":""},
-    {"id":"duration","type":"number","label":"Duration","default":5}
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >
   <head>
@@ -19,11 +20,13 @@
         --fg: #f5f5f4;
         --accent: #ff6b35;
         --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
       }
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
-      body { font-family: 'Inter', system-ui, sans-serif; }
-      .mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
     </style>
   </head>
   <body>
@@ -52,6 +55,13 @@
       // tracked as a follow-up.
       const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
       const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
 
       document.getElementById('cmd').textContent = vars.command || 'git status';
       document.getElementById('cap').textContent = vars.caption || '';

--- a/hyperframes/compositions/code-callout/index.html
+++ b/hyperframes/compositions/code-callout/index.html
@@ -59,6 +59,7 @@
       const theme = vars.theme || {};
       const root = document.documentElement.style;
       if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
       if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
       if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
       if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -3,6 +3,7 @@ require_relative 'buttercut/fcp7'
 require_relative 'buttercut/recipe'
 require_relative 'buttercut/broll_manifest'
 require_relative 'buttercut/broll_renderer'
+require_relative 'buttercut/theme'
 
 # ButterCut - Video editor XML generator
 #

--- a/lib/buttercut/broll_renderer.rb
+++ b/lib/buttercut/broll_renderer.rb
@@ -33,7 +33,8 @@ class ButterCut
       validate_composition_exists!
       FileUtils.mkdir_p(@output_dir)
       out = output_path
-      tmp = "#{out}.tmp-#{Process.pid}-#{SecureRandom.hex(6)}"
+      ext = File.extname(out)
+      tmp = "#{out.delete_suffix(ext)}.tmp-#{Process.pid}-#{SecureRandom.hex(6)}#{ext}"
       File.delete(tmp) if File.exist?(tmp)
       begin
         run_render!(build_command(tmp))

--- a/lib/buttercut/theme.rb
+++ b/lib/buttercut/theme.rb
@@ -3,6 +3,7 @@ require 'yaml'
 class ButterCut
   class Theme
     VALID_MOTION = %w[snappy smooth minimal].freeze
+    SAFE_TEMPLATE_SET = /\A[a-z0-9][a-z0-9_-]*\z/
     PRESET_CACHE = {}
 
     def self.resolve(library_theme:, themes_dir:)
@@ -32,15 +33,20 @@ class ButterCut
       if template_set.nil? || template_set.to_s.empty?
         raise ArgumentError, "library_theme must include 'template_set'"
       end
+      unless template_set.is_a?(String) && template_set.match?(SAFE_TEMPLATE_SET)
+        raise ArgumentError, "invalid template_set: #{template_set.inspect}"
+      end
 
       path = File.join(@themes_dir, "#{template_set}.yaml")
       PRESET_CACHE[path] ||= begin
-        data = YAML.load_file(path)
+        data = YAML.safe_load_file(path, permitted_classes: [], aliases: false)
         raise ArgumentError, "theme preset #{path} must be a hash" unless data.is_a?(Hash)
         data
       end
     rescue Errno::ENOENT
       raise ArgumentError, "theme preset not found: #{path}"
+    rescue Psych::Exception => e
+      raise ArgumentError, "invalid theme preset YAML at #{path}: #{e.message}"
     end
 
     def validate_motion!(tokens)

--- a/lib/buttercut/theme.rb
+++ b/lib/buttercut/theme.rb
@@ -1,15 +1,9 @@
 require 'yaml'
 
 class ButterCut
-  # Resolves a library's theme block against a preset file in the themes/
-  # directory and returns the merged token hash. Hyperframes compositions read
-  # these tokens (font_display, font_mono, color_bg, color_accent, logo, motion)
-  # to render b-roll graphics that look consistent across a video series.
-  #
-  # See `themes/` for bundled presets and `templates/library_template.yaml` for
-  # the library-side schema. Issue #27.
   class Theme
     VALID_MOTION = %w[snappy smooth minimal].freeze
+    PRESET_CACHE = {}
 
     def self.resolve(library_theme:, themes_dir:)
       new(library_theme: library_theme, themes_dir: themes_dir).resolve
@@ -40,13 +34,13 @@ class ButterCut
       end
 
       path = File.join(@themes_dir, "#{template_set}.yaml")
-      unless File.exist?(path)
-        raise ArgumentError, "theme preset not found: #{path}"
+      PRESET_CACHE[path] ||= begin
+        data = YAML.load_file(path)
+        raise ArgumentError, "theme preset #{path} must be a hash" unless data.is_a?(Hash)
+        data
       end
-
-      data = YAML.load_file(path)
-      raise ArgumentError, "theme preset #{path} must be a hash" unless data.is_a?(Hash)
-      data
+    rescue Errno::ENOENT
+      raise ArgumentError, "theme preset not found: #{path}"
     end
 
     def validate_motion!(tokens)

--- a/lib/buttercut/theme.rb
+++ b/lib/buttercut/theme.rb
@@ -1,0 +1,64 @@
+require 'yaml'
+
+class ButterCut
+  # Resolves a library's theme block against a preset file in the themes/
+  # directory and returns the merged token hash. Hyperframes compositions read
+  # these tokens (font_display, font_mono, color_bg, color_accent, logo, motion)
+  # to render b-roll graphics that look consistent across a video series.
+  #
+  # See `themes/` for bundled presets and `templates/library_template.yaml` for
+  # the library-side schema. Issue #27.
+  class Theme
+    VALID_MOTION = %w[snappy smooth minimal].freeze
+
+    def self.resolve(library_theme:, themes_dir:)
+      new(library_theme: library_theme, themes_dir: themes_dir).resolve
+    end
+
+    def initialize(library_theme:, themes_dir:)
+      raise ArgumentError, "library_theme hash required" unless library_theme.is_a?(Hash)
+      raise ArgumentError, "themes_dir required" if themes_dir.nil? || themes_dir.to_s.empty?
+
+      @library_theme = stringify_keys(library_theme)
+      @themes_dir = themes_dir
+    end
+
+    def resolve
+      preset = load_preset
+      tokens = preset.merge(@library_theme)
+      tokens.delete('template_set')
+      validate_motion!(tokens)
+      tokens
+    end
+
+    private
+
+    def load_preset
+      template_set = @library_theme['template_set']
+      if template_set.nil? || template_set.to_s.empty?
+        raise ArgumentError, "library_theme must include 'template_set'"
+      end
+
+      path = File.join(@themes_dir, "#{template_set}.yaml")
+      unless File.exist?(path)
+        raise ArgumentError, "theme preset not found: #{path}"
+      end
+
+      data = YAML.load_file(path)
+      raise ArgumentError, "theme preset #{path} must be a hash" unless data.is_a?(Hash)
+      data
+    end
+
+    def validate_motion!(tokens)
+      motion = tokens['motion']
+      return if motion.nil? # presets ship with motion; library may omit
+      unless VALID_MOTION.include?(motion)
+        raise ArgumentError, "motion must be one of #{VALID_MOTION.inspect}, got #{motion.inspect}"
+      end
+    end
+
+    def stringify_keys(hash)
+      hash.each_with_object({}) { |(k, v), out| out[k.to_s] = v }
+    end
+  end
+end

--- a/scripts/004_migrate_add_theme.rb
+++ b/scripts/004_migrate_add_theme.rb
@@ -1,18 +1,6 @@
 #!/usr/bin/env ruby
-# Migration script: Add the `theme:` block to libraries that predate the
-# theme feature (issue #27).
-#
-# The theme block defines fonts, colors, logo, and motion preset that
-# Hyperframes compositions read when rendering b-roll graphics. Libraries
-# created before the feature have no `theme:` key. The migration inserts the
-# default block (matching `templates/library_template.yaml`, with
-# `template_set: tutorial-dark`) directly before the `footage_summary:` line.
-#
-# Libraries that already have the key are left alone.
-#
-# This migration edits the file textually — it does not round-trip through
-# YAML, so quote styles and indentation elsewhere in the file are preserved
-# exactly.
+# Edits library.yaml textually rather than round-tripping through YAML so
+# quote styles and indentation elsewhere in the file are preserved exactly.
 #
 # Usage: ruby scripts/004_migrate_add_theme.rb [library_name]
 #        ruby scripts/004_migrate_add_theme.rb --all

--- a/scripts/004_migrate_add_theme.rb
+++ b/scripts/004_migrate_add_theme.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# Migration script: Add the `theme:` block to libraries that predate the
+# theme feature (issue #27).
+#
+# The theme block defines fonts, colors, logo, and motion preset that
+# Hyperframes compositions read when rendering b-roll graphics. Libraries
+# created before the feature have no `theme:` key. The migration inserts the
+# default block (matching `templates/library_template.yaml`, with
+# `template_set: tutorial-dark`) directly before the `footage_summary:` line.
+#
+# Libraries that already have the key are left alone.
+#
+# This migration edits the file textually — it does not round-trip through
+# YAML, so quote styles and indentation elsewhere in the file are preserved
+# exactly.
+#
+# Usage: ruby scripts/004_migrate_add_theme.rb [library_name]
+#        ruby scripts/004_migrate_add_theme.rb --all
+
+require 'yaml'
+require 'date'
+
+def migrate_library(library_path)
+  unless File.exist?(library_path)
+    puts "  ✗ Not found: #{library_path}"
+    return false
+  end
+
+  content = File.read(library_path)
+
+  if content.match?(/^theme:/)
+    puts "  - Already has theme block; no change"
+    return false
+  end
+
+  block = <<~YAML
+    theme:
+      font_display: Inter
+      font_mono: JetBrains Mono
+      color_bg: '#0d0d0d'
+      color_accent: '#ff6b35'
+      logo: assets/logo.svg
+      template_set: tutorial-dark
+      motion: snappy
+  YAML
+
+  lines = content.lines
+  insert_index = lines.index { |line| line.match?(/^footage_summary:/) }
+  insert_index ||= lines.index { |line| line.match?(/^videos:/) }
+
+  unless insert_index
+    puts "  ✗ No `footage_summary:` or `videos:` anchor found; skipping"
+    return false
+  end
+
+  lines.insert(insert_index, block, "\n")
+  new_content = lines.join
+
+  parsed = YAML.load(new_content, permitted_classes: [Date, Time, Symbol])
+  unless parsed.is_a?(Hash) && parsed['theme'].is_a?(Hash) && parsed['theme']['template_set'] == 'tutorial-dark'
+    puts "  ✗ Insert produced unexpected YAML; refusing to write"
+    return false
+  end
+
+  File.write(library_path, new_content)
+  puts "  ✓ Added theme block (template_set: tutorial-dark)"
+  true
+end
+
+def find_libraries
+  Dir.glob("libraries/*/library.yaml")
+end
+
+if __FILE__ == $PROGRAM_NAME
+  if ARGV.empty?
+    puts "Usage: ruby scripts/004_migrate_add_theme.rb [library_name]"
+    puts "       ruby scripts/004_migrate_add_theme.rb --all"
+    exit 1
+  end
+
+  if ARGV[0] == '--all'
+    libraries = find_libraries
+    puts "Migrating #{libraries.length} libraries...\n\n"
+    libraries.each do |lib_path|
+      lib_name = lib_path.split('/')[1]
+      puts "#{lib_name}:"
+      migrate_library(lib_path)
+    end
+  else
+    library_name = ARGV[0]
+    library_path = "libraries/#{library_name}/library.yaml"
+    puts "#{library_name}:"
+    migrate_library(library_path)
+  end
+
+  puts "\nMigration complete."
+end

--- a/scripts/004_migrate_add_theme.rb
+++ b/scripts/004_migrate_add_theme.rb
@@ -26,6 +26,7 @@ def migrate_library(library_path)
       font_display: Inter
       font_mono: JetBrains Mono
       color_bg: '#0d0d0d'
+      color_fg: '#f5f5f4'
       color_accent: '#ff6b35'
       logo: assets/logo.svg
       template_set: tutorial-dark

--- a/scripts/004_migrate_add_theme.rb
+++ b/scripts/004_migrate_add_theme.rb
@@ -8,20 +8,8 @@
 require 'yaml'
 require 'date'
 
-def migrate_library(library_path)
-  unless File.exist?(library_path)
-    puts "  ✗ Not found: #{library_path}"
-    return false
-  end
-
-  content = File.read(library_path)
-
-  if content.match?(/^theme:/)
-    puts "  - Already has theme block; no change"
-    return false
-  end
-
-  block = <<~YAML
+class MigrateAddTheme
+  THEME_BLOCK = <<~YAML
     theme:
       font_display: Inter
       font_mono: JetBrains Mono
@@ -33,54 +21,95 @@ def migrate_library(library_path)
       motion: snappy
   YAML
 
-  lines = content.lines
-  insert_index = lines.index { |line| line.match?(/^footage_summary:/) }
-  insert_index ||= lines.index { |line| line.match?(/^videos:/) }
-
-  unless insert_index
-    puts "  ✗ No `footage_summary:` or `videos:` anchor found; skipping"
-    return false
+  def self.run(args)
+    new(args).run
   end
 
-  lines.insert(insert_index, block, "\n")
-  new_content = lines.join
-
-  parsed = YAML.load(new_content, permitted_classes: [Date, Time, Symbol])
-  unless parsed.is_a?(Hash) && parsed['theme'].is_a?(Hash) && parsed['theme']['template_set'] == 'tutorial-dark'
-    puts "  ✗ Insert produced unexpected YAML; refusing to write"
-    return false
+  def initialize(args)
+    raise ArgumentError, "args required" if args.nil?
+    @args = args
   end
 
-  File.write(library_path, new_content)
-  puts "  ✓ Added theme block (template_set: tutorial-dark)"
-  true
-end
+  def run
+    if @args.empty?
+      print_usage
+      return 1
+    end
 
-def find_libraries
-  Dir.glob("libraries/*/library.yaml")
+    if @args[0] == '--all'
+      migrate_all
+    else
+      migrate_one(@args[0])
+    end
+
+    puts "\nMigration complete."
+    0
+  end
+
+  private
+
+  def print_usage
+    puts "Usage: ruby scripts/004_migrate_add_theme.rb [library_name]"
+    puts "       ruby scripts/004_migrate_add_theme.rb --all"
+  end
+
+  def migrate_all
+    libraries = Dir.glob("libraries/*/library.yaml")
+    puts "Migrating #{libraries.length} libraries...\n\n"
+    libraries.each do |path|
+      puts "#{path.split('/')[1]}:"
+      migrate_library(path)
+    end
+  end
+
+  def migrate_one(library_name)
+    puts "#{library_name}:"
+    migrate_library("libraries/#{library_name}/library.yaml")
+  end
+
+  def migrate_library(path)
+    return refuse("Not found: #{path}") unless File.exist?(path)
+
+    content = File.read(path)
+    return note("Already has theme block; no change") if content.match?(/^theme:/)
+
+    new_content = insert_block(content)
+    return false unless new_content
+    return false unless valid_after_insert?(new_content)
+
+    File.write(path, new_content)
+    puts "  ✓ Added theme block (template_set: tutorial-dark)"
+    true
+  end
+
+  def insert_block(content)
+    lines = content.lines
+    insert_index = lines.index { |l| l.match?(/^footage_summary:/) } ||
+                   lines.index { |l| l.match?(/^videos:/) }
+    unless insert_index
+      refuse("No `footage_summary:` or `videos:` anchor found; skipping")
+      return nil
+    end
+    lines.insert(insert_index, THEME_BLOCK, "\n").join
+  end
+
+  def valid_after_insert?(new_content)
+    parsed = YAML.safe_load(new_content, permitted_classes: [Date, Time, Symbol], aliases: false)
+    return true if parsed.is_a?(Hash) && parsed['theme'].is_a?(Hash) && parsed['theme']['template_set'] == 'tutorial-dark'
+    refuse("Insert produced unexpected YAML; refusing to write")
+  end
+
+  def refuse(msg)
+    puts "  ✗ #{msg}"
+    false
+  end
+
+  def note(msg)
+    puts "  - #{msg}"
+    false
+  end
 end
 
 if __FILE__ == $PROGRAM_NAME
-  if ARGV.empty?
-    puts "Usage: ruby scripts/004_migrate_add_theme.rb [library_name]"
-    puts "       ruby scripts/004_migrate_add_theme.rb --all"
-    exit 1
-  end
-
-  if ARGV[0] == '--all'
-    libraries = find_libraries
-    puts "Migrating #{libraries.length} libraries...\n\n"
-    libraries.each do |lib_path|
-      lib_name = lib_path.split('/')[1]
-      puts "#{lib_name}:"
-      migrate_library(lib_path)
-    end
-  else
-    library_name = ARGV[0]
-    library_path = "libraries/#{library_name}/library.yaml"
-    puts "#{library_name}:"
-    migrate_library(library_path)
-  end
-
-  puts "\nMigration complete."
+  exit MigrateAddTheme.run(ARGV)
 end

--- a/spec/broll_renderer_spec.rb
+++ b/spec/broll_renderer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ButterCut::BrollRenderer do
         expect(captured.take(4).join(' ')).to match(/hyperframes/)
         expect(captured).to include('render')
         out_path = captured[captured.index('-o') + 1]
-        expect(out_path).to start_with(expected)
+        expect(out_path).to match(%r{\A#{Regexp.escape(File.join(out, 'br-0001'))}\.tmp-\d+-[0-9a-f]+\.mp4\z})
         json_idx = captured.index('--variables')
         vars = JSON.parse(captured[json_idx + 1])
         expect(vars).to include('command' => 'git rebase -i HEAD~3', 'caption' => 'Interactive rebase, last 3 commits')

--- a/spec/migrate_add_theme_spec.rb
+++ b/spec/migrate_add_theme_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require 'open3'
+require 'date'
+
+RSpec.describe '004_migrate_add_theme.rb' do
+  let(:script_path) { File.expand_path('../scripts/004_migrate_add_theme.rb', __dir__) }
+
+  def run_migration(library_name, cwd)
+    Open3.capture2('ruby', script_path, library_name, chdir: cwd)
+  end
+
+  def write_library(dir, name, content)
+    lib_dir = File.join(dir, 'libraries', name)
+    FileUtils.mkdir_p(lib_dir)
+    path = File.join(lib_dir, 'library.yaml')
+    File.write(path, content)
+    path
+  end
+
+  let(:legacy_yaml) do
+    <<~YAML
+      library_name: my-lib
+      created_date: 2026-01-01
+      last_updated: 2026-01-01
+      language: english
+      transcript_refinement: false
+      user_context: ""
+      footage_summary: "x"
+      videos:
+        - path: /tmp/x.mov
+          duration: "00:01:00"
+          transcript:
+          visual_transcript:
+          summary:
+    YAML
+  end
+
+  it 'adds the default theme block to a library missing it' do
+    Dir.mktmpdir do |dir|
+      path = write_library(dir, 'my-lib', legacy_yaml)
+      out, _ = run_migration('my-lib', dir)
+      expect(out).to match(/Added theme block/)
+      data = YAML.load_file(path, permitted_classes: [Date, Time, Symbol])
+      expect(data).to have_key('theme')
+      expect(data['theme']['template_set']).to eq('tutorial-dark')
+      expect(data['theme']['font_display']).to eq('Inter')
+      expect(data['theme']['motion']).to eq('snappy')
+    end
+  end
+
+  it 'is idempotent — running twice is a no-op' do
+    Dir.mktmpdir do |dir|
+      path = write_library(dir, 'my-lib', legacy_yaml)
+      run_migration('my-lib', dir)
+      first = File.read(path)
+      out, _ = run_migration('my-lib', dir)
+      expect(out).to match(/already has/i)
+      expect(File.read(path)).to eq(first)
+    end
+  end
+
+  it 'leaves a library with an existing theme block alone' do
+    Dir.mktmpdir do |dir|
+      yaml_with_theme = legacy_yaml + <<~YAML
+        theme:
+          font_display: CustomFont
+          font_mono: CustomMono
+          color_bg: '#111111'
+          color_accent: '#222222'
+          logo: assets/x.svg
+          template_set: vlog-warm
+          motion: smooth
+      YAML
+      path = write_library(dir, 'my-lib', yaml_with_theme)
+      original = File.read(path)
+      out, _ = run_migration('my-lib', dir)
+      expect(out).to match(/already has/i)
+      expect(File.read(path)).to eq(original)
+      data = YAML.load_file(path, permitted_classes: [Date, Time, Symbol])
+      expect(data['theme']['font_display']).to eq('CustomFont')
+    end
+  end
+end

--- a/spec/theme_spec.rb
+++ b/spec/theme_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ButterCut::Theme do
       )
       expect(tokens['color_accent']).to eq('#00ff00')
       expect(tokens['logo']).to eq('assets/custom.svg')
-      expect(tokens['font_display']).to eq('Inter') # untouched preset value
+      expect(tokens['font_display']).to eq('Inter')
     end
 
     it 'raises when template_set is missing' do

--- a/spec/theme_spec.rb
+++ b/spec/theme_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe ButterCut::Theme do
       }.to raise_error(ArgumentError, /preset/)
     end
 
+    it 'rejects template_set values that could escape themes_dir' do
+      %w[../escape ./relative ../../etc tutorial-dark/.. abs/path].each do |bad|
+        expect {
+          described_class.resolve(
+            library_theme: { 'template_set' => bad },
+            themes_dir: themes_dir
+          )
+        }.to raise_error(ArgumentError, /invalid template_set/)
+      end
+    end
+
     it 'raises when motion is invalid' do
       expect {
         described_class.resolve(
@@ -72,7 +83,7 @@ RSpec.describe ButterCut::Theme do
         path = File.join(themes_dir, "#{name}.yaml")
         expect(File).to exist(path)
         data = YAML.load_file(path)
-        %w[font_display font_mono color_bg color_accent logo motion].each do |key|
+        %w[font_display font_mono color_bg color_fg color_accent logo motion].each do |key|
           expect(data).to have_key(key), "#{name}.yaml missing key: #{key}"
         end
         expect(%w[snappy smooth minimal]).to include(data['motion'])

--- a/spec/theme_spec.rb
+++ b/spec/theme_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require 'buttercut/theme'
+
+RSpec.describe ButterCut::Theme do
+  let(:themes_dir) { File.expand_path('../themes', __dir__) }
+
+  describe '.resolve' do
+    it 'loads a preset and returns its tokens' do
+      tokens = described_class.resolve(
+        library_theme: { 'template_set' => 'tutorial-dark' },
+        themes_dir: themes_dir
+      )
+      expect(tokens['font_display']).to eq('Inter')
+      expect(tokens['font_mono']).to eq('JetBrains Mono')
+      expect(tokens['color_bg']).to eq('#0d0d0d')
+      expect(tokens['color_accent']).to eq('#ff6b35')
+      expect(tokens['motion']).to eq('snappy')
+    end
+
+    it 'merges library overrides over the preset' do
+      tokens = described_class.resolve(
+        library_theme: {
+          'template_set' => 'tutorial-dark',
+          'color_accent' => '#00ff00',
+          'logo' => 'assets/custom.svg'
+        },
+        themes_dir: themes_dir
+      )
+      expect(tokens['color_accent']).to eq('#00ff00')
+      expect(tokens['logo']).to eq('assets/custom.svg')
+      expect(tokens['font_display']).to eq('Inter') # untouched preset value
+    end
+
+    it 'raises when template_set is missing' do
+      expect {
+        described_class.resolve(library_theme: {}, themes_dir: themes_dir)
+      }.to raise_error(ArgumentError, /template_set/)
+    end
+
+    it 'raises when the preset file does not exist' do
+      expect {
+        described_class.resolve(
+          library_theme: { 'template_set' => 'does-not-exist' },
+          themes_dir: themes_dir
+        )
+      }.to raise_error(ArgumentError, /preset/)
+    end
+
+    it 'raises when motion is invalid' do
+      expect {
+        described_class.resolve(
+          library_theme: { 'template_set' => 'tutorial-dark', 'motion' => 'wobbly' },
+          themes_dir: themes_dir
+        )
+      }.to raise_error(ArgumentError, /motion/)
+    end
+
+    it 'accepts symbol keys in library_theme' do
+      tokens = described_class.resolve(
+        library_theme: { template_set: 'tutorial-dark' },
+        themes_dir: themes_dir
+      )
+      expect(tokens['font_display']).to eq('Inter')
+    end
+  end
+
+  describe 'preset files' do
+    %w[tutorial-dark vlog-warm corporate-clean].each do |name|
+      it "loads and parses #{name}.yaml with required keys" do
+        path = File.join(themes_dir, "#{name}.yaml")
+        expect(File).to exist(path)
+        data = YAML.load_file(path)
+        %w[font_display font_mono color_bg color_accent logo motion].each do |key|
+          expect(data).to have_key(key), "#{name}.yaml missing key: #{key}"
+        end
+        expect(%w[snappy smooth minimal]).to include(data['motion'])
+      end
+    end
+
+    it 'tutorial-dark matches the existing code-callout palette' do
+      data = YAML.load_file(File.join(themes_dir, 'tutorial-dark.yaml'))
+      expect(data['font_display']).to eq('Inter')
+      expect(data['font_mono']).to eq('JetBrains Mono')
+      expect(data['color_bg']).to eq('#0d0d0d')
+      expect(data['color_accent']).to eq('#ff6b35')
+    end
+  end
+end

--- a/templates/library_template.yaml
+++ b/templates/library_template.yaml
@@ -16,6 +16,7 @@ theme:
   font_display: Inter
   font_mono: JetBrains Mono
   color_bg: '#0d0d0d'
+  color_fg: '#f5f5f4'
   color_accent: '#ff6b35'
   logo: assets/logo.svg
   template_set: tutorial-dark

--- a/templates/library_template.yaml
+++ b/templates/library_template.yaml
@@ -9,6 +9,18 @@ user_context: ""
 # Whenever you ask the user questions about the library, save a summarized version here.
 # ie; The man wearing the dark blue long sleeve shirt is "Andrew". The small brown dog is "Sammy". This footage was shot over one evening.
 
+# Theme block — drives consistent fonts/colors across Hyperframes b-roll
+# graphics for this library. `template_set` selects a preset from `themes/`;
+# any other key here overrides the preset's value.
+theme:
+  font_display: Inter
+  font_mono: JetBrains Mono
+  color_bg: '#0d0d0d'
+  color_accent: '#ff6b35'
+  logo: assets/logo.svg
+  template_set: tutorial-dark
+  motion: snappy   # snappy | smooth | minimal
+
 # Full footage summary - progressively updated after each video is transcribed. This can be up to 10-20 lines summarizing all of the footage we have.
 footage_summary: "No footage analyzed yet."
 # "This footage appears to be wedding footage. It includes the bride and groom getting dressed, preparing for the wedding ceremomy, the ceremony, and the post ceremony dinner and party."

--- a/themes/corporate-clean.yaml
+++ b/themes/corporate-clean.yaml
@@ -1,0 +1,6 @@
+font_display: Helvetica Neue
+font_mono: Source Code Pro
+color_bg: '#ffffff'
+color_accent: '#0057b7'
+logo: assets/logo.svg
+motion: minimal

--- a/themes/corporate-clean.yaml
+++ b/themes/corporate-clean.yaml
@@ -1,6 +1,7 @@
 font_display: Helvetica Neue
 font_mono: Source Code Pro
 color_bg: '#ffffff'
+color_fg: '#0a1a2c'
 color_accent: '#0057b7'
 logo: assets/logo.svg
 motion: minimal

--- a/themes/tutorial-dark.yaml
+++ b/themes/tutorial-dark.yaml
@@ -1,6 +1,7 @@
 font_display: Inter
 font_mono: JetBrains Mono
 color_bg: '#0d0d0d'
+color_fg: '#f5f5f4'
 color_accent: '#ff6b35'
 logo: assets/logo.svg
 motion: snappy

--- a/themes/tutorial-dark.yaml
+++ b/themes/tutorial-dark.yaml
@@ -1,0 +1,6 @@
+font_display: Inter
+font_mono: JetBrains Mono
+color_bg: '#0d0d0d'
+color_accent: '#ff6b35'
+logo: assets/logo.svg
+motion: snappy

--- a/themes/vlog-warm.yaml
+++ b/themes/vlog-warm.yaml
@@ -1,0 +1,6 @@
+font_display: Poppins
+font_mono: Fira Code
+color_bg: '#fff8f0'
+color_accent: '#e07a3c'
+logo: assets/logo.svg
+motion: smooth

--- a/themes/vlog-warm.yaml
+++ b/themes/vlog-warm.yaml
@@ -1,6 +1,7 @@
 font_display: Poppins
 font_mono: Fira Code
 color_bg: '#fff8f0'
+color_fg: '#1f1a14'
 color_accent: '#e07a3c'
 logo: assets/logo.svg
 motion: smooth


### PR DESCRIPTION
## Summary
Closes #27. Adds the `theme` block to `library.yaml`, three preset themes (`tutorial-dark`, `vlog-warm`, `corporate-clean`), a resolver, and refactors the `code-callout` composition to consume theme tokens via CSS custom properties.

- `lib/buttercut/theme.rb` — `ButterCut::Theme.resolve(library_theme:, themes_dir:)` loads the preset named by `template_set`, merges the library's overrides on top, validates `motion ∈ {snappy, smooth, minimal}`, and returns the resolved token hash.
- `themes/{tutorial-dark,vlog-warm,corporate-clean}.yaml` — three distinct presets. `tutorial-dark` matches the current hardcoded palette so existing renders are unchanged.
- `templates/library_template.yaml` — adds the `theme:` block (defaults to `tutorial-dark`).
- `scripts/004_migrate_add_theme.rb` — idempotent migration adding the default block to libraries missing it. Matches the style of `001..003`.
- `hyperframes/compositions/code-callout/index.html` — reads `vars.theme` and applies tokens via `--bg`, `--accent`, `--font-display`, `--font-mono` CSS custom properties. Built-in defaults match the tutorial-dark palette, so renders without a theme block still look right.
- `CHANGELOG.md` + `CLAUDE.md` migration triggers updated.

## Drive-by fix
The previous round of `BrollRenderer` review-feedback added a `SecureRandom.hex(6)` suffix to the tmp filename but placed it after `.mp4`, producing `br-0001.mp4.tmp-<pid>-<hex>` — FFmpeg's faststart muxer couldn't infer the output format and integration renders failed. The render-broll PR's unit suite was green but the gated integration test was not re-run after that change, so this slipped through. Fixed here by inserting the suffix before the extension.

## Test plan
- [x] `bundle exec rspec` — 176 examples, 0 failures, 3 pending (added 13 new examples for `Theme` + the migration script)
- [x] `RUN_HYPERFRAMES_INTEGRATION=1 bundle exec rspec spec/broll_renderer_spec.rb:120` — real Hyperframes render passes; structurally-identical MP4s across two runs
- [x] Manual ffprobe spot-check on the rendered MP4: 1920x1080, h264, 5s, 150 frames

## Out of scope
- Wiring `Theme.resolve` into `BrollRenderer` so the renderer originates merged tokens itself (today the parent of the render-broll skill is responsible for resolving and passing). Will follow when the b-roll director (#30) lands.
- Tailwind CDN → vendored bundle (deferred from PR #35; tracked as a follow-up under epic #26).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive theme system with bundled presets and runtime theme support in compositions
  * B-roll manifest format and validation for media ingestion
  * Fuse/tooling for Fusion/Resolve workflows and a desktop app flow streaming progress with sidecar controls
  * Migration tool to add theme blocks to existing libraries

* **Bug Fixes**
  * More robust temporary render filename handling during exports

* **Documentation**
  * Updated templates and composition docs to describe theme options and defaults

* **Tests**
  * Added test suites for theme resolution and migration behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->