### PR TITLE
feat: b-roll director (skill + UI button) (#30)

### DIFF
--- a/.claude/skills/broll-director/SKILL.md
+++ b/.claude/skills/broll-director/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: broll-director
+description: Authors a `<roughcut>.broll.yaml` manifest from an existing rough cut + the transcripts of the videos it references. Use after a rough cut is approved when the user wants AI-generated graphics placed on the timeline.
+---
+
+# Skill: B-Roll Director (parent brief)
+
+Editorial layer of the Hyperframes pipeline (#26 / #30). Reads a rough cut and emits a sibling `<roughcut>.broll.yaml` of candidate graphics with template, content, timing, placement, and score. The render skill (#28) and roughcut integration (#33) consume the manifest downstream.
+
+`SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.
+
+## Prerequisites
+
+- The rough cut YAML exists at `libraries/<library>/roughcuts/<stem>.yaml`.
+- Every `source_video` referenced by the rough cut has `transcript`, `visual_transcript`, AND `summary` populated in `library.yaml`. Abort with a clear message if not.
+
+## Inputs to gather (parent only — sub-agent does not read library.yaml)
+
+Use `ButterCut::BrollDirectorInputs.gather(library_dir:, roughcut_path:, hyperframes_dir:)` to collect:
+
+- `library_name`, `roughcut_stem`, `roughcut`, `theme`
+- `source_videos` (per-video audio transcript + visual transcript + summary)
+- `available_templates` (auto-discovered from `hyperframes/compositions/*/README.md`)
+
+Plus from the user / defaults:
+
+- `density` — `"low" | "medium" | "high"` (default `"medium"`)
+- `score_threshold` — float (default `0.5`)
+
+## Parallelism
+
+Launch **1** sub-agent per invocation. The director needs the full picture of the rough cut to make a coherent manifest; splitting per-video would produce overlapping or duplicate candidates.
+
+## What to pass the sub-agent
+
+Inline the entire contents of `agent_prompt.md`, then append a clearly delimited values block with the gathered inputs serialized as JSON (the prompt expects JSON-shaped values).
+
+## After the sub-agent returns
+
+1. Parse the returned JSON array. If parsing fails, send the parse error back to the model and ask for a corrected JSON. Give up after one retry.
+2. Call `ButterCut::BrollDirectorPostprocess.assemble(...)` with the candidates + the gathered inputs + density + score_threshold. This filters by template/threshold, maps source-relative timing to rough-cut-relative, applies the density budget, assigns ids, and validates against `ButterCut::BrollManifest`.
+3. If a manifest already exists at `libraries/<library>/roughcuts/<stem>.broll.yaml`, log a one-line warning naming the prior entry count, then overwrite. Existing rendered MP4s in `broll/` are NOT deleted (their entry ids will be orphans the user can clean up later).
+4. Write the manifest via `manifest.save(path)` (where `manifest = BrollManifest.from_hash(...)`).
+5. Print: `Wrote N entries to libraries/<library>/roughcuts/<stem>.broll.yaml (density=<density>)`.
+
+## Out of scope
+
+- Rendering — that's the `render-broll` skill.
+- Re-exporting the editor XML with the b-roll on the timeline — that's the existing roughcut export step (and #34 for late-render swap-in-place).

--- a/.claude/skills/broll-director/agent_prompt.md
+++ b/.claude/skills/broll-director/agent_prompt.md
@@ -1,0 +1,59 @@
+You are the b-roll director for ButterCut. Your job is to read a rough cut plus the transcripts of the videos it references and decide where motion graphics belong.
+
+You will be given the following values inline by the parent:
+
+- `LIBRARY_NAME` — string
+- `ROUGHCUT_STEM` — string
+- `ROUGHCUT_YAML` — the rough cut as parsed YAML, with an ordered `clips` array. Each clip has `source_video` (filename), `in` and `out` (HH:MM:SS.ss timecodes into the source video).
+- `THEME` — the library's theme block (read-only — affects placement defaults; see below).
+- `SOURCE_VIDEOS` — a hash keyed by source_video filename. Each value has:
+  - `audio_transcript` — the WhisperX JSON for that video
+  - `visual_transcript` — the visual JSON with frame-level descriptions
+  - `summary` — a short markdown summary
+- `AVAILABLE_TEMPLATES` — array of `{ name, readme_md }`. The README is the source of truth for that template's `content` shape. You MUST only emit candidates whose `template` is one of these names AND whose `content` matches the README.
+- `DENSITY` — `"low"` | `"medium"` | `"high"` (informational; the caller enforces a per-minute budget after you return)
+- `SCORE_THRESHOLD` — float (informational; the caller drops anything below this)
+
+Return ONLY a JSON array (no surrounding prose, no markdown fence). Each element is one candidate:
+
+```json
+{
+  "source_video": "tutorial_01.mov",
+  "source_start": 42.10,
+  "source_end":   47.80,
+  "template": "code-callout",
+  "placement": "overlay",
+  "content": { "command": "git rebase -i HEAD~3", "caption": "Interactive rebase, last 3 commits" },
+  "score": 0.84,
+  "rationale": "introduces a command verbally; terminal visible at this moment"
+}
+```
+
+Field rules:
+
+- `source_start`/`source_end` are seconds into the **source video** (not the rough cut). The caller maps these into rough-cut time. Only emit candidates whose `[source_start, source_end]` overlaps a clip in `ROUGHCUT_YAML` for that source_video.
+- `template` MUST be in `AVAILABLE_TEMPLATES`. If no template fits, drop the candidate.
+- `content` MUST match the chosen template's README schema.
+- `placement` is one of `overlay` | `cutaway` | `pip`. Pick by looking at the visual transcript description nearest the candidate's time:
+  - terminal/IDE visible AND the graphic relates to what's shown → `overlay`
+  - talking head only OR the graphic doesn't relate to what's shown → `cutaway`
+  - both are useful AND the source visual should remain partially visible → `pip`
+- `score` is `(novelty + emphasis + structural_role) / 3` in `0..1`:
+  - novelty — is this term/idea new in the video?
+  - emphasis — does the speaker dwell on it, repeat it, or call it out?
+  - structural_role — is it a step number, heading, named example, stat, or quote?
+- `rationale` is one short sentence explaining the score.
+
+Candidate selection — look for:
+- Named commands, files, functions, paths, error messages
+- Terms introduced verbally for the first time
+- Numbered or bulleted lists ("step one…", "first…", "second…")
+- Stats and quotes worth pulling out
+- Side-by-side comparisons
+
+Do NOT emit candidates for:
+- Generic filler ("um", "you know", "so basically")
+- Repetitions of something you already covered nearby
+- Anything outside the time spans the rough cut's clips actually include
+
+Return the array. Nothing else.

--- a/docs/superpowers/plans/2026-05-07-broll-director.md
+++ b/docs/superpowers/plans/2026-05-07-broll-director.md
@@ -1,0 +1,1367 @@
+# B-Roll Director Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author the editorial brain of the Hyperframes pipeline — given an existing rough cut and the transcripts/visual transcripts/summaries of the videos it references, decide where graphics belong, what they say, and how they sit in the frame, and write a `<roughcut>.broll.yaml` the existing render skill (#28) and roughcut integration (#33) consume. Ship a CLI skill **and** a UI button on each rough cut row, both backed by a single shared prompt file.
+
+**Architecture:** Per-rough-cut director (timing is rough-cut-relative, matching the shipped manifest schema). Pure-Ruby helpers under `lib/buttercut/` for input gathering and post-processing. One LLM call per invocation; the model returns candidate JSON; the caller validates against `ButterCut::BrollManifest` before writing. Two surfaces (skill + sidecar controller) share `.claude/skills/broll-director/agent_prompt.md` so behavior cannot drift.
+
+**Tech Stack:** Ruby (gem helpers + sidecar), RSpec, Anthropic SDK (already in sidecar), TypeScript/React (UI button).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-broll-director-design.md`
+
+---
+
+## File Structure
+
+**New (Ruby gem helpers — pure functions, no LLM, no I/O beyond what the caller passes):**
+- `lib/buttercut/broll_director_inputs.rb` — gathers transcripts/summaries/templates/theme for a given rough cut
+- `lib/buttercut/broll_director_postprocess.rb` — threshold filtering, source→cut timecode mapping, density pruning, id assignment, manifest assembly + validation hand-off
+
+**New (skill):**
+- `.claude/skills/broll-director/SKILL.md` — parent dispatch brief
+- `.claude/skills/broll-director/agent_prompt.md` — canonical director prompt
+
+**New (sidecar):**
+- `ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb` — mirrors `RoughcutController`; loads the same `agent_prompt.md`
+
+**Modify (sidecar):**
+- `ui/sidecar/buttercut_ui_sidecar.rb` — register `start_broll_director` op, wire controller, list rough cuts that have/haven't a manifest yet
+
+**New (UI):**
+- `ui/src/routes/library/AddBrollButton.tsx` — button + click handler + status display
+
+**Modify (UI):**
+- `ui/src/routes/library/RoughcutTimeline.tsx` — render the button per finished rough cut row
+
+**New (tests + fixtures):**
+- `spec/buttercut/broll_director_inputs_spec.rb`
+- `spec/buttercut/broll_director_postprocess_spec.rb`
+- `spec/fixtures/broll_director/sample_library/library.yaml`
+- `spec/fixtures/broll_director/sample_library/roughcuts/sample.yaml`
+- `spec/fixtures/broll_director/sample_library/transcripts/tutorial_01.json`
+- `spec/fixtures/broll_director/sample_library/transcripts/visual_tutorial_01.json`
+- `spec/fixtures/broll_director/sample_library/summaries/summary_tutorial_01.md`
+- `spec/fixtures/broll_director/canned_model_response.json`
+
+---
+
+### Task 1: Gem helper — `BrollDirectorInputs.gather`
+
+Pure-Ruby helper that the skill parent and the sidecar controller both call. Reads files only (no LLM). Returns a hash with everything the prompt needs.
+
+**Files:**
+- Create: `lib/buttercut/broll_director_inputs.rb`
+- Create: `spec/buttercut/broll_director_inputs_spec.rb`
+- Create: `spec/fixtures/broll_director/sample_library/library.yaml`
+- Create: `spec/fixtures/broll_director/sample_library/roughcuts/sample.yaml`
+- Create: `spec/fixtures/broll_director/sample_library/transcripts/tutorial_01.json`
+- Create: `spec/fixtures/broll_director/sample_library/transcripts/visual_tutorial_01.json`
+- Create: `spec/fixtures/broll_director/sample_library/summaries/summary_tutorial_01.md`
+
+- [ ] **Step 1: Create the fixture library.yaml**
+
+`spec/fixtures/broll_director/sample_library/library.yaml`:
+
+```yaml
+library_name: sample-library
+language: English
+editor: Final Cut Pro X
+transcript_refinement: true
+user_context: ""
+footage_summary: "A short tutorial covering interactive rebase."
+theme:
+  font_display: Inter
+  font_mono: JetBrains Mono
+  color_bg: '#0d0d0d'
+  color_fg: '#f5f5f4'
+  color_accent: '#ff6b35'
+  template_set: tutorial-dark
+  motion: snappy
+videos:
+  - path: /fixtures/tutorial_01.mov
+    duration: "00:02:00"
+    transcript: tutorial_01.json
+    visual_transcript: visual_tutorial_01.json
+    summary: summary_tutorial_01.md
+```
+
+- [ ] **Step 2: Create the fixture rough cut**
+
+`spec/fixtures/broll_director/sample_library/roughcuts/sample.yaml`:
+
+```yaml
+project: sample
+clips:
+  - source_video: tutorial_01.mov
+    in:  "00:00:30.00"
+    out: "00:01:00.00"
+  - source_video: tutorial_01.mov
+    in:  "00:01:20.00"
+    out: "00:01:50.00"
+```
+
+- [ ] **Step 3: Create fixture audio transcript**
+
+`spec/fixtures/broll_director/sample_library/transcripts/tutorial_01.json`:
+
+```json
+{
+  "video_path": "/fixtures/tutorial_01.mov",
+  "language": "en",
+  "segments": [
+    { "start": 30.0, "end": 35.0, "text": "Today we'll look at git rebase interactive." },
+    { "start": 35.0, "end": 45.0, "text": "Run git rebase -i HEAD~3 to edit the last three commits." },
+    { "start": 45.0, "end": 60.0, "text": "Pick, squash, fixup, reword - those are your main options." },
+    { "start": 80.0, "end": 90.0, "text": "Step one: stash any uncommitted changes first." },
+    { "start": 90.0, "end": 110.0, "text": "Step two: run git status to confirm a clean tree." }
+  ]
+}
+```
+
+- [ ] **Step 4: Create fixture visual transcript**
+
+`spec/fixtures/broll_director/sample_library/transcripts/visual_tutorial_01.json`:
+
+```json
+{
+  "video_path": "/fixtures/tutorial_01.mov",
+  "frames": [
+    { "t": 32.0, "description": "Talking head of presenter, no terminal visible." },
+    { "t": 40.0, "description": "Terminal visible showing a git log." },
+    { "t": 50.0, "description": "Terminal with interactive rebase editor open." },
+    { "t": 85.0, "description": "Talking head only." },
+    { "t": 100.0, "description": "Terminal running git status." }
+  ]
+}
+```
+
+- [ ] **Step 5: Create fixture summary**
+
+`spec/fixtures/broll_director/sample_library/summaries/summary_tutorial_01.md`:
+
+```markdown
+# tutorial_01.mov
+
+A short walk-through of `git rebase -i`, demonstrated against a tutorial repo.
+
+## Key visuals
+- Talking head intro
+- Terminal with git log
+- Interactive rebase editor
+
+## Notable dialogue
+- "Today we'll look at git rebase interactive"
+- "Step one: stash any uncommitted changes first"
+```
+
+- [ ] **Step 6: Write the failing spec**
+
+`spec/buttercut/broll_director_inputs_spec.rb`:
+
+```ruby
+require "spec_helper"
+require "buttercut/broll_director_inputs"
+
+RSpec.describe ButterCut::BrollDirectorInputs do
+  let(:fixtures) { File.expand_path("../fixtures/broll_director", __dir__) }
+  let(:lib_dir) { File.join(fixtures, "sample_library") }
+  let(:roughcut_path) { File.join(lib_dir, "roughcuts", "sample.yaml") }
+  let(:hyperframes_dir) { File.expand_path("../../../hyperframes", __dir__) }
+
+  it "gathers everything the director prompt needs" do
+    result = described_class.gather(
+      library_dir: lib_dir,
+      roughcut_path: roughcut_path,
+      hyperframes_dir: hyperframes_dir
+    )
+
+    expect(result[:library_name]).to eq("sample-library")
+    expect(result[:roughcut_stem]).to eq("sample")
+    expect(result[:roughcut]["clips"].length).to eq(2)
+    expect(result[:theme]["template_set"]).to eq("tutorial-dark")
+
+    sources = result[:source_videos]
+    expect(sources.keys).to contain_exactly("tutorial_01.mov")
+    src = sources["tutorial_01.mov"]
+    expect(src[:audio_transcript]["segments"].first["text"]).to include("git rebase")
+    expect(src[:visual_transcript]["frames"].length).to eq(5)
+    expect(src[:summary]).to include("git rebase")
+
+    templates = result[:available_templates]
+    template_names = templates.map { |t| t[:name] }
+    expect(template_names).to include("code-callout")
+    callout = templates.find { |t| t[:name] == "code-callout" }
+    expect(callout[:readme_md]).to be_a(String)
+    expect(callout[:readme_md]).not_to be_empty
+  end
+
+  it "raises if a referenced source_video is missing transcripts in library.yaml" do
+    Dir.mktmpdir do |tmp|
+      bad_lib = File.join(tmp, "lib")
+      FileUtils.mkdir_p(File.join(bad_lib, "roughcuts"))
+      File.write(File.join(bad_lib, "library.yaml"), {
+        "library_name" => "x",
+        "theme" => {},
+        "videos" => [{ "path" => "/x/tutorial_01.mov" }]
+      }.to_yaml)
+      File.write(File.join(bad_lib, "roughcuts", "r.yaml"), {
+        "clips" => [{ "source_video" => "tutorial_01.mov", "in" => "00:00:00.00", "out" => "00:00:05.00" }]
+      }.to_yaml)
+
+      expect {
+        described_class.gather(
+          library_dir: bad_lib,
+          roughcut_path: File.join(bad_lib, "roughcuts", "r.yaml"),
+          hyperframes_dir: hyperframes_dir
+        )
+      }.to raise_error(ArgumentError, /missing transcripts.*tutorial_01\.mov/i)
+    end
+  end
+end
+```
+
+- [ ] **Step 7: Run the spec, confirm it fails**
+
+Run: `bundle exec rspec spec/buttercut/broll_director_inputs_spec.rb`
+Expected: FAIL with `LoadError: cannot load such file -- buttercut/broll_director_inputs`.
+
+- [ ] **Step 8: Implement the helper**
+
+`lib/buttercut/broll_director_inputs.rb`:
+
+```ruby
+require "yaml"
+require "json"
+require "date"
+require "pathname"
+
+class ButterCut
+  # Pure-Ruby gathering of everything the b-roll director prompt needs.
+  # No LLM, no writes — just reads files the caller points at.
+  class BrollDirectorInputs
+    REQUIRED_VIDEO_KEYS = %w[transcript visual_transcript summary].freeze
+
+    def self.gather(library_dir:, roughcut_path:, hyperframes_dir:)
+      new(
+        library_dir: library_dir,
+        roughcut_path: roughcut_path,
+        hyperframes_dir: hyperframes_dir
+      ).gather
+    end
+
+    def initialize(library_dir:, roughcut_path:, hyperframes_dir:)
+      raise ArgumentError, "library_dir required" if library_dir.to_s.empty?
+      raise ArgumentError, "roughcut_path required" if roughcut_path.to_s.empty?
+      raise ArgumentError, "hyperframes_dir required" if hyperframes_dir.to_s.empty?
+
+      @library_dir = Pathname.new(library_dir)
+      @roughcut_path = Pathname.new(roughcut_path)
+      @hyperframes_dir = Pathname.new(hyperframes_dir)
+    end
+
+    def gather
+      library = load_library
+      roughcut = load_roughcut
+      sources = load_source_videos(library, roughcut)
+      {
+        library_name: library["library_name"] || @library_dir.basename.to_s,
+        roughcut_stem: @roughcut_path.basename.sub_ext("").to_s,
+        roughcut: roughcut,
+        theme: library["theme"] || {},
+        source_videos: sources,
+        available_templates: load_templates
+      }
+    end
+
+    private
+
+    def load_library
+      path = @library_dir.join("library.yaml")
+      raise ArgumentError, "library.yaml not found at #{path}" unless path.file?
+      YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def load_roughcut
+      raise ArgumentError, "rough cut not found at #{@roughcut_path}" unless @roughcut_path.file?
+      data = YAML.safe_load(@roughcut_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+      raise ArgumentError, "rough cut has no clips" unless data["clips"].is_a?(Array) && !data["clips"].empty?
+      data
+    end
+
+    def load_source_videos(library, roughcut)
+      videos_by_basename = (library["videos"] || []).each_with_object({}) do |v, h|
+        h[File.basename(v["path"].to_s)] = v
+      end
+
+      referenced = roughcut["clips"].map { |c| c["source_video"] }.uniq
+      missing_meta = []
+      result = {}
+
+      referenced.each do |basename|
+        video = videos_by_basename[basename]
+        if video.nil?
+          missing_meta << basename
+          next
+        end
+        absent = REQUIRED_VIDEO_KEYS.reject { |k| !video[k].to_s.empty? }
+        if !absent.empty?
+          missing_meta << "#{basename} (missing #{absent.join(', ')})"
+          next
+        end
+        result[basename] = {
+          audio_transcript: load_json(@library_dir.join("transcripts", video["transcript"])),
+          visual_transcript: load_json(@library_dir.join("transcripts", video["visual_transcript"])),
+          summary: @library_dir.join("summaries", video["summary"]).read
+        }
+      end
+
+      unless missing_meta.empty?
+        raise ArgumentError, "missing transcripts/summaries for: #{missing_meta.join('; ')}"
+      end
+
+      result
+    end
+
+    def load_json(path)
+      raise ArgumentError, "transcript not found at #{path}" unless path.file?
+      JSON.parse(path.read)
+    end
+
+    def load_templates
+      compositions_dir = @hyperframes_dir.join("compositions")
+      return [] unless compositions_dir.directory?
+
+      compositions_dir.children.select(&:directory?).sort.filter_map do |dir|
+        readme = dir.join("README.md")
+        next nil unless readme.file?
+        { name: dir.basename.to_s, readme_md: readme.read }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 9: Run the spec, confirm it passes**
+
+Run: `bundle exec rspec spec/buttercut/broll_director_inputs_spec.rb`
+Expected: 2 examples, 0 failures.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/buttercut/broll_director_inputs.rb \
+        spec/buttercut/broll_director_inputs_spec.rb \
+        spec/fixtures/broll_director/
+git commit -m "feat: BrollDirectorInputs gathers transcripts + templates for the director (#30)"
+```
+
+---
+
+### Task 2: Gem helper — `BrollDirectorPostprocess.assemble`
+
+Takes the candidate array the model returns, plus the rough cut, and produces a validated, ready-to-write manifest hash. Pure functions: threshold → source-to-cut timecode mapping → density pruning → id assignment → schema validation.
+
+**Files:**
+- Create: `lib/buttercut/broll_director_postprocess.rb`
+- Create: `spec/buttercut/broll_director_postprocess_spec.rb`
+- Create: `spec/fixtures/broll_director/canned_model_response.json`
+
+- [ ] **Step 1: Create the canned model response fixture**
+
+`spec/fixtures/broll_director/canned_model_response.json`:
+
+```json
+[
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 35.0,
+    "source_end": 40.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git rebase -i HEAD~3", "caption": "Interactive rebase, last 3 commits" },
+    "score": 0.9,
+    "rationale": "introduces command, terminal visible"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 36.0,
+    "source_end": 38.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git log --oneline" },
+    "score": 0.4,
+    "rationale": "low-novelty filler"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 100.0,
+    "source_end": 105.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git status", "caption": "Confirm a clean tree" },
+    "score": 0.7,
+    "rationale": "structural beat, terminal visible"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 200.0,
+    "source_end": 205.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "out-of-cut" },
+    "score": 0.95,
+    "rationale": "outside any clip"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 95.0,
+    "source_end": 99.0,
+    "template": "no-such-template",
+    "placement": "overlay",
+    "content": { "x": "y" },
+    "score": 0.8,
+    "rationale": "unknown template"
+  }
+]
+```
+
+- [ ] **Step 2: Write the failing spec**
+
+`spec/buttercut/broll_director_postprocess_spec.rb`:
+
+```ruby
+require "spec_helper"
+require "json"
+require "buttercut/broll_director_postprocess"
+require "buttercut/broll_manifest"
+
+RSpec.describe ButterCut::BrollDirectorPostprocess do
+  let(:fixtures) { File.expand_path("../fixtures/broll_director", __dir__) }
+  let(:roughcut) {
+    {
+      "clips" => [
+        { "source_video" => "tutorial_01.mov", "in" => "00:00:30.00", "out" => "00:01:00.00" },
+        { "source_video" => "tutorial_01.mov", "in" => "00:01:20.00", "out" => "00:01:50.00" }
+      ]
+    }
+  }
+  let(:candidates) { JSON.parse(File.read(File.join(fixtures, "canned_model_response.json"))) }
+  let(:available_templates) { [{ name: "code-callout", readme_md: "" }] }
+
+  def call(opts = {})
+    described_class.assemble(
+      library_name: "sample-library",
+      roughcut_stem: "sample",
+      roughcut: roughcut,
+      candidates: candidates,
+      available_templates: available_templates,
+      density: opts.fetch(:density, "medium"),
+      score_threshold: opts.fetch(:score_threshold, 0.5)
+    )
+  end
+
+  it "drops candidates below the score threshold, outside any clip, or with an unknown template" do
+    manifest = call
+    contents = manifest["entries"].map { |e| e["content"] }
+    commands = contents.map { |c| c["command"] }
+    expect(commands).to contain_exactly("git rebase -i HEAD~3", "git status")
+  end
+
+  it "remaps source-relative timing to rough-cut-relative timing" do
+    manifest = call
+    rebase = manifest["entries"].find { |e| e["content"]["command"] == "git rebase -i HEAD~3" }
+    # source 35.0 - clip[0].in (30.0) = 5.0 into the cut
+    expect(rebase["start"]).to eq(5.0)
+    expect(rebase["end"]).to eq(10.0)
+    status = manifest["entries"].find { |e| e["content"]["command"] == "git status" }
+    # clip[0] is 30s long (0..30), clip[1] starts at 30 in the cut
+    # source 100.0 - clip[1].in (80.0) = 20.0 into clip[1] -> 30 + 20 = 50.0 in cut
+    expect(status["start"]).to eq(50.0)
+    expect(status["end"]).to eq(55.0)
+  end
+
+  it "assigns sequential ids in time order" do
+    manifest = call
+    expect(manifest["entries"].map { |e| e["id"] }).to eq(["br-0001", "br-0002"])
+    starts = manifest["entries"].map { |e| e["start"] }
+    expect(starts).to eq(starts.sort)
+  end
+
+  it "applies a density budget per minute" do
+    many = (0..9).map do |i|
+      {
+        "source_video" => "tutorial_01.mov",
+        "source_start" => 30.0 + i, "source_end" => 31.0 + i,
+        "template" => "code-callout", "placement" => "overlay",
+        "content" => { "command" => "cmd_#{i}" },
+        "score" => 0.5 + i * 0.05
+      }
+    end
+    manifest = described_class.assemble(
+      library_name: "x", roughcut_stem: "y", roughcut: roughcut,
+      candidates: many, available_templates: available_templates,
+      density: "low", score_threshold: 0.0
+    )
+    expect(manifest["entries"].length).to eq(2)  # low = 2/min, all in minute 0
+    kept = manifest["entries"].map { |e| e["content"]["command"] }
+    expect(kept).to contain_exactly("cmd_9", "cmd_8")
+  end
+
+  it "produces a manifest that validates via BrollManifest" do
+    manifest = call
+    expect { ButterCut::BrollManifest.from_hash(manifest) }.not_to raise_error
+  end
+
+  it "rejects unsupported density" do
+    expect { call(density: "extreme") }.to raise_error(ArgumentError, /density/)
+  end
+end
+```
+
+- [ ] **Step 3: Run the spec, confirm it fails**
+
+Run: `bundle exec rspec spec/buttercut/broll_director_postprocess_spec.rb`
+Expected: `LoadError: cannot load such file -- buttercut/broll_director_postprocess`.
+
+- [ ] **Step 4: Implement the post-processor**
+
+`lib/buttercut/broll_director_postprocess.rb`:
+
+```ruby
+require_relative "broll_manifest"
+
+class ButterCut
+  # Turns candidate JSON from the director model into a validated manifest hash
+  # ready for ButterCut::BrollManifest.from_hash. Pure functions only.
+  class BrollDirectorPostprocess
+    DENSITY_BUDGETS = { "low" => 2, "medium" => 4, "high" => 8 }.freeze
+
+    def self.assemble(library_name:, roughcut_stem:, roughcut:, candidates:,
+                      available_templates:, density:, score_threshold:)
+      new(
+        library_name: library_name,
+        roughcut_stem: roughcut_stem,
+        roughcut: roughcut,
+        candidates: candidates,
+        available_templates: available_templates,
+        density: density,
+        score_threshold: score_threshold
+      ).assemble
+    end
+
+    def initialize(library_name:, roughcut_stem:, roughcut:, candidates:,
+                   available_templates:, density:, score_threshold:)
+      @library_name = library_name
+      @roughcut_stem = roughcut_stem
+      @roughcut = roughcut
+      @candidates = candidates
+      @template_names = available_templates.map { |t| t[:name] || t["name"] }.to_set
+      @budget = DENSITY_BUDGETS.fetch(density) {
+        raise ArgumentError, "density must be one of #{DENSITY_BUDGETS.keys.inspect}, got #{density.inspect}"
+      }
+      @score_threshold = score_threshold.to_f
+    end
+
+    def assemble
+      mapped = @candidates.filter_map { |c| map_candidate(c) }
+      mapped.sort_by! { |e| e["start"] }
+      mapped = apply_density(mapped)
+      mapped.each_with_index { |e, i| e["id"] = format("br-%04d", i + 1) }
+      manifest = {
+        "version" => ButterCut::BrollManifest::SCHEMA_VERSION,
+        "library" => @library_name,
+        "roughcut" => @roughcut_stem,
+        "entries" => mapped
+      }
+      ButterCut::BrollManifest.from_hash(manifest)  # raises if invalid
+      manifest
+    end
+
+    private
+
+    def map_candidate(c)
+      return nil unless @template_names.include?(c["template"])
+      score = c["score"].to_f
+      return nil if score < @score_threshold
+
+      mapping = locate_in_cut(c)
+      return nil if mapping.nil?
+
+      {
+        "source_video" => c["source_video"],
+        "start" => mapping[:start],
+        "end" => mapping[:end],
+        "template" => c["template"],
+        "placement" => c["placement"],
+        "score" => score,
+        "content" => c["content"],
+        "rendered" => nil,
+        "notes" => c["rationale"].to_s
+      }
+    end
+
+    # Walk the rough cut's clips in order, accumulating a cut-time offset.
+    # If [source_start, source_end] falls (even partially) inside a clip
+    # of the matching source_video, return its position in the cut.
+    def locate_in_cut(c)
+      cursor = 0.0
+      @roughcut["clips"].each do |clip|
+        clip_in = parse_tc(clip["in"])
+        clip_out = parse_tc(clip["out"])
+        clip_len = clip_out - clip_in
+
+        if clip["source_video"] == c["source_video"]
+          s = c["source_start"].to_f
+          e = c["source_end"].to_f
+          if e > clip_in && s < clip_out
+            mapped_start = cursor + [s, clip_in].max - clip_in
+            mapped_end   = cursor + [e, clip_out].min - clip_in
+            return nil if mapped_end <= mapped_start
+            return { start: mapped_start.round(2), end: mapped_end.round(2) }
+          end
+        end
+
+        cursor += clip_len
+      end
+      nil
+    end
+
+    def parse_tc(tc)
+      h, m, s = tc.to_s.split(":")
+      h.to_i * 3600 + m.to_i * 60 + s.to_f
+    end
+
+    def apply_density(entries)
+      buckets = entries.group_by { |e| (e["start"] / 60.0).floor }
+      buckets.values.flat_map { |list|
+        list.sort_by { |e| -e["score"] }.first(@budget)
+      }.sort_by { |e| e["start"] }
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run the spec, confirm it passes**
+
+Run: `bundle exec rspec spec/buttercut/broll_director_postprocess_spec.rb`
+Expected: 6 examples, 0 failures.
+
+- [ ] **Step 6: Run the full gem suite to make sure nothing else broke**
+
+Run: `bundle exec rspec`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/buttercut/broll_director_postprocess.rb \
+        spec/buttercut/broll_director_postprocess_spec.rb \
+        spec/fixtures/broll_director/canned_model_response.json
+git commit -m "feat: BrollDirectorPostprocess maps candidates to a validated manifest (#30)"
+```
+
+---
+
+### Task 3: Skill — `broll-director`
+
+The CLI surface. Parent reads `SKILL.md`, gathers inputs via `BrollDirectorInputs`, dispatches one sub-agent with `agent_prompt.md` inlined, post-processes the returned JSON, and writes the manifest.
+
+**Files:**
+- Create: `.claude/skills/broll-director/SKILL.md`
+- Create: `.claude/skills/broll-director/agent_prompt.md`
+
+- [ ] **Step 1: Write `agent_prompt.md` (the canonical director prompt)**
+
+`.claude/skills/broll-director/agent_prompt.md`:
+
+````markdown
+You are the b-roll director for ButterCut. Your job is to read a rough cut plus the transcripts of the videos it references and decide where motion graphics belong.
+
+You will be given the following values inline by the parent:
+
+- `LIBRARY_NAME` — string
+- `ROUGHCUT_STEM` — string
+- `ROUGHCUT_YAML` — the rough cut as parsed YAML, with an ordered `clips` array. Each clip has `source_video` (filename), `in` and `out` (HH:MM:SS.ss timecodes into the source video).
+- `THEME` — the library's theme block (read-only — affects placement defaults; see below).
+- `SOURCE_VIDEOS` — a hash keyed by source_video filename. Each value has:
+  - `audio_transcript` — the WhisperX JSON for that video
+  - `visual_transcript` — the visual JSON with frame-level descriptions
+  - `summary` — a short markdown summary
+- `AVAILABLE_TEMPLATES` — array of `{ name, readme_md }`. The README is the source of truth for that template's `content` shape. You MUST only emit candidates whose `template` is one of these names AND whose `content` matches the README.
+- `DENSITY` — `"low"` | `"medium"` | `"high"` (informational; the caller enforces a per-minute budget after you return)
+- `SCORE_THRESHOLD` — float (informational; the caller drops anything below this)
+
+Return ONLY a JSON array (no surrounding prose, no markdown fence). Each element is one candidate:
+
+```json
+{
+  "source_video": "tutorial_01.mov",
+  "source_start": 42.10,
+  "source_end":   47.80,
+  "template": "code-callout",
+  "placement": "overlay",
+  "content": { "command": "git rebase -i HEAD~3", "caption": "Interactive rebase, last 3 commits" },
+  "score": 0.84,
+  "rationale": "introduces a command verbally; terminal visible at this moment"
+}
+```
+
+Field rules:
+
+- `source_start`/`source_end` are seconds into the **source video** (not the rough cut). The caller maps these into rough-cut time. Only emit candidates whose `[source_start, source_end]` overlaps a clip in `ROUGHCUT_YAML` for that source_video.
+- `template` MUST be in `AVAILABLE_TEMPLATES`. If no template fits, drop the candidate.
+- `content` MUST match the chosen template's README schema.
+- `placement` is one of `overlay` | `cutaway` | `pip`. Pick by looking at the visual transcript description nearest the candidate's time:
+  - terminal/IDE visible AND the graphic relates to what's shown → `overlay`
+  - talking head only OR the graphic doesn't relate to what's shown → `cutaway`
+  - both are useful AND the source visual should remain partially visible → `pip`
+- `score` is `(novelty + emphasis + structural_role) / 3` in `0..1`:
+  - novelty — is this term/idea new in the video?
+  - emphasis — does the speaker dwell on it, repeat it, or call it out?
+  - structural_role — is it a step number, heading, named example, stat, or quote?
+- `rationale` is one short sentence explaining the score.
+
+Candidate selection — look for:
+- Named commands, files, functions, paths, error messages
+- Terms introduced verbally for the first time
+- Numbered or bulleted lists ("step one…", "first…", "second…")
+- Stats and quotes worth pulling out
+- Side-by-side comparisons
+
+Do NOT emit candidates for:
+- Generic filler ("um", "you know", "so basically")
+- Repetitions of something you already covered nearby
+- Anything outside the time spans the rough cut's clips actually include
+
+Return the array. Nothing else.
+````
+
+- [ ] **Step 2: Write `SKILL.md` (parent dispatch brief)**
+
+`.claude/skills/broll-director/SKILL.md`:
+
+````markdown
+---
+name: broll-director
+description: Authors a `<roughcut>.broll.yaml` manifest from an existing rough cut + the transcripts of the videos it references. Use after a rough cut is approved when the user wants AI-generated graphics placed on the timeline.
+---
+
+# Skill: B-Roll Director (parent brief)
+
+Editorial layer of the Hyperframes pipeline (#26 / #30). Reads a rough cut and emits a sibling `<roughcut>.broll.yaml` of candidate graphics with template, content, timing, placement, and score. The render skill (#28) and roughcut integration (#33) consume the manifest downstream.
+
+`SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.
+
+## Prerequisites
+
+- The rough cut YAML exists at `libraries/<library>/roughcuts/<stem>.yaml`.
+- Every `source_video` referenced by the rough cut has `transcript`, `visual_transcript`, AND `summary` populated in `library.yaml`. Abort with a clear message if not.
+
+## Inputs to gather (parent only — sub-agent does not read library.yaml)
+
+Use `ButterCut::BrollDirectorInputs.gather(library_dir:, roughcut_path:, hyperframes_dir:)` to collect:
+
+- `library_name`, `roughcut_stem`, `roughcut`, `theme`
+- `source_videos` (per-video audio transcript + visual transcript + summary)
+- `available_templates` (auto-discovered from `hyperframes/compositions/*/README.md`)
+
+Plus from the user / defaults:
+
+- `density` — `"low" | "medium" | "high"` (default `"medium"`)
+- `score_threshold` — float (default `0.5`)
+
+## Parallelism
+
+Launch **1** sub-agent per invocation. The director needs the full picture of the rough cut to make a coherent manifest; splitting per-video would produce overlapping or duplicate candidates.
+
+## What to pass the sub-agent
+
+Inline the entire contents of `agent_prompt.md`, then append a clearly delimited values block with the gathered inputs serialized as JSON (the prompt expects JSON-shaped values).
+
+## After the sub-agent returns
+
+1. Parse the returned JSON array. If parsing fails, send the parse error back to the model and ask for a corrected JSON. Give up after one retry.
+2. Call `ButterCut::BrollDirectorPostprocess.assemble(...)` with the candidates + the gathered inputs + density + score_threshold. This filters by template/threshold, maps source-relative timing to rough-cut-relative, applies the density budget, assigns ids, and validates against `ButterCut::BrollManifest`.
+3. If a manifest already exists at `libraries/<library>/roughcuts/<stem>.broll.yaml`, log a one-line warning naming the prior entry count, then overwrite. Existing rendered MP4s in `broll/` are NOT deleted (their entry ids will be orphans the user can clean up later).
+4. Write the manifest via `manifest.save(path)` (where `manifest = BrollManifest.from_hash(...)`).
+5. Print: `Wrote N entries to libraries/<library>/roughcuts/<stem>.broll.yaml (density=<density>)`.
+
+## Out of scope
+
+- Rendering — that's the `render-broll` skill.
+- Re-exporting the editor XML with the b-roll on the timeline — that's the existing roughcut export step (and #34 for late-render swap-in-place).
+````
+
+- [ ] **Step 3: Verify both files load and `agent_prompt.md` is non-trivial**
+
+Run: `wc -l .claude/skills/broll-director/*.md`
+Expected: both files exist, agent_prompt is at least 50 lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/broll-director/
+git commit -m "feat: broll-director skill (parent brief + canonical agent prompt) (#30)"
+```
+
+---
+
+### Task 4: Sidecar — `BrollDirectorController`
+
+UI surface. Mirrors `RoughcutController`'s job/notifier shape; loads the same `agent_prompt.md` as the skill so the two surfaces never drift.
+
+**Files:**
+- Create: `ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb`
+- Create: `ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb`
+
+- [ ] **Step 1: Write the failing spec**
+
+`ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb`:
+
+```ruby
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "yaml"
+require "buttercut_ui_sidecar/broll_director_controller"
+
+RSpec.describe ButtercutUiSidecar::BrollDirectorController do
+  let(:repo_root) { File.expand_path("../../../../..", __dir__) }
+  let(:notifier) { double("notifier", notify: nil) }
+  let(:registry) {
+    Class.new {
+      def initialize; @jobs = {}; end
+      def create(_); id = "job-#{@jobs.size + 1}"; @jobs[id] = { canceled: false }; id; end
+      def canceled?(id); @jobs[id][:canceled]; end
+    }.new
+  }
+
+  let(:fixture_lib) {
+    File.expand_path("../../../../../spec/fixtures/broll_director/sample_library", __dir__)
+  }
+
+  def with_libraries_root
+    Dir.mktmpdir do |tmp|
+      FileUtils.cp_r(fixture_lib, File.join(tmp, "sample-library"))
+      yield Pathname.new(tmp)
+    end
+  end
+
+  it "writes a validated manifest using a stubbed model response" do
+    canned = File.read(File.expand_path(
+      "../../../../../spec/fixtures/broll_director/canned_model_response.json", __dir__
+    ))
+    client = double("anthropic_client")
+    allow(client).to receive(:complete).and_return(canned)
+
+    with_libraries_root do |root|
+      controller = described_class.new(
+        libraries_root: root.to_s,
+        repo_root: repo_root,
+        notifier: notifier,
+        registry: registry,
+        client: client
+      )
+      result = controller.run!(
+        library: "sample-library",
+        roughcut_stem: "sample",
+        density: "medium",
+        score_threshold: 0.5
+      )
+
+      expect(result[:entries_written]).to be > 0
+      manifest_path = root.join("sample-library/roughcuts/sample.broll.yaml")
+      expect(manifest_path.file?).to be true
+      data = YAML.safe_load(manifest_path.read, permitted_classes: [Date, Time])
+      expect(data["library"]).to eq("sample-library")
+      expect(data["roughcut"]).to eq("sample")
+      expect(data["entries"]).not_to be_empty
+    end
+  end
+
+  it "raises when the rough cut does not exist" do
+    with_libraries_root do |root|
+      controller = described_class.new(
+        libraries_root: root.to_s, repo_root: repo_root,
+        notifier: notifier, registry: registry,
+        client: double("c")
+      )
+      expect {
+        controller.run!(library: "sample-library", roughcut_stem: "nope",
+                        density: "medium", score_threshold: 0.5)
+      }.to raise_error(/rough cut not found/)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the spec, confirm it fails**
+
+Run: `cd ui/sidecar && bundle exec rspec spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb`
+Expected: `LoadError: cannot load such file -- buttercut_ui_sidecar/broll_director_controller`.
+
+- [ ] **Step 3: Implement the controller**
+
+`ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+require "yaml"
+
+require "buttercut/broll_director_inputs"
+require "buttercut/broll_director_postprocess"
+require "buttercut/broll_manifest"
+
+require_relative "anthropic_client"
+
+module ButtercutUiSidecar
+  # UI-driven b-roll director. Mirrors RoughcutController's shape; loads the
+  # same agent prompt as the broll-director skill so behavior cannot drift.
+  class BrollDirectorController
+    PROMPT_RELATIVE_PATH = ".claude/skills/broll-director/agent_prompt.md"
+    DEFAULT_DENSITY = "medium"
+    DEFAULT_SCORE_THRESHOLD = 0.5
+    MODEL = AnthropicClient::VISION_MODEL
+
+    def initialize(libraries_root:, repo_root:, notifier:, registry:, client:)
+      raise ArgumentError, "libraries_root required" if libraries_root.to_s.empty?
+      raise ArgumentError, "repo_root required" if repo_root.to_s.empty?
+      raise ArgumentError, "notifier required" if notifier.nil?
+      raise ArgumentError, "registry required" if registry.nil?
+      raise ArgumentError, "client required" if client.nil?
+
+      @libraries_root = Pathname.new(libraries_root)
+      @repo_root = Pathname.new(repo_root)
+      @notifier = notifier
+      @registry = registry
+      @client = client
+    end
+
+    def validate_and_start!(library:, roughcut_stem:, density: DEFAULT_DENSITY,
+                            score_threshold: DEFAULT_SCORE_THRESHOLD)
+      job_id = @registry.create(library)
+      Thread.new do
+        begin
+          run!(
+            library: library, roughcut_stem: roughcut_stem,
+            density: density, score_threshold: score_threshold,
+            job_id: job_id
+          )
+        rescue StandardError => e
+          warn "[broll-director #{job_id}] FAILED #{e.class}: #{e.message}"
+          @notifier.notify("broll_job_failed", job_id: job_id, message: e.message)
+        end
+      end
+      job_id
+    end
+
+    def run!(library:, roughcut_stem:, density:, score_threshold:, job_id: nil)
+      lib_dir = @libraries_root.join(library)
+      roughcut_path = lib_dir.join("roughcuts", "#{roughcut_stem}.yaml")
+      raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
+
+      notify(job_id, "broll_job_started", library: library, roughcut_stem: roughcut_stem)
+      notify(job_id, "broll_phase", phase: "gather", message: "Gathering transcripts and templates…")
+
+      inputs = ButterCut::BrollDirectorInputs.gather(
+        library_dir: lib_dir.to_s,
+        roughcut_path: roughcut_path.to_s,
+        hyperframes_dir: @repo_root.join("hyperframes").to_s
+      )
+
+      notify(job_id, "broll_phase", phase: "model", message: "Asking the director for candidates…")
+      raw = call_model(inputs, density, score_threshold)
+      candidates = parse_or_retry(raw, inputs, density, score_threshold)
+
+      notify(job_id, "broll_phase", phase: "write", message: "Validating and writing manifest…")
+      manifest_hash = ButterCut::BrollDirectorPostprocess.assemble(
+        library_name: inputs[:library_name],
+        roughcut_stem: inputs[:roughcut_stem],
+        roughcut: inputs[:roughcut],
+        candidates: candidates,
+        available_templates: inputs[:available_templates],
+        density: density,
+        score_threshold: score_threshold
+      )
+
+      manifest_path = lib_dir.join("roughcuts", "#{roughcut_stem}.broll.yaml")
+      warn_if_overwriting(manifest_path)
+      ButterCut::BrollManifest.from_hash(manifest_hash).save(manifest_path.to_s)
+
+      notify(job_id, "broll_job_done",
+             manifest_path: manifest_path.to_s,
+             entries_written: manifest_hash["entries"].length,
+             density: density)
+
+      { manifest_path: manifest_path.to_s, entries_written: manifest_hash["entries"].length }
+    end
+
+    private
+
+    def notify(job_id, event, **payload)
+      return if job_id.nil?
+      @notifier.notify(event, job_id: job_id, **payload)
+    end
+
+    def call_model(inputs, density, score_threshold)
+      system = prompt_text
+      user = JSON.pretty_generate(
+        LIBRARY_NAME: inputs[:library_name],
+        ROUGHCUT_STEM: inputs[:roughcut_stem],
+        ROUGHCUT_YAML: inputs[:roughcut],
+        THEME: inputs[:theme],
+        SOURCE_VIDEOS: inputs[:source_videos],
+        AVAILABLE_TEMPLATES: inputs[:available_templates],
+        DENSITY: density,
+        SCORE_THRESHOLD: score_threshold
+      )
+      @client.complete(system: system, user: user, model: MODEL)
+    end
+
+    def parse_or_retry(raw, inputs, density, score_threshold)
+      JSON.parse(raw)
+    rescue JSON::ParserError => e
+      retry_user = "Your previous response was not valid JSON: #{e.message}\n\nReturn ONLY the JSON array, no surrounding text."
+      raw2 = @client.complete(system: prompt_text, user: retry_user, model: MODEL)
+      JSON.parse(raw2)
+    end
+
+    def prompt_text
+      path = @repo_root.join(PROMPT_RELATIVE_PATH)
+      raise "broll-director prompt missing: #{path}" unless path.file?
+      path.read
+    end
+
+    def warn_if_overwriting(path)
+      return unless path.file?
+      prior = YAML.safe_load(path.read, permitted_classes: [Date, Time]) rescue {}
+      n = (prior["entries"] || []).length
+      warn "[broll-director] overwriting existing manifest at #{path} (#{n} prior entries)"
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Add `complete` to `AnthropicClient` if it doesn't exist yet**
+
+Run: `grep -n "def complete\|def call\|def messages" ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb`
+
+If `complete(system:, user:, model:)` already exists, skip. Otherwise add it. Open the file and inspect; if missing, add at the bottom of the class:
+
+```ruby
+def complete(system:, user:, model:)
+  resp = messages.create(
+    model: model,
+    max_tokens: 8192,
+    system: system,
+    messages: [{ role: "user", content: user }]
+  )
+  resp.content.map { |b| b.respond_to?(:text) ? b.text : b["text"] }.compact.join
+end
+```
+
+(Use whatever method on the existing client equates to "send a single user message and return the text" — the test stubs `complete` directly, so the spec passes regardless of how the production method is named, but production code in `BrollDirectorController#call_model` MUST call the real method that exists. If the existing client uses a different name, change `call_model` to call that name and stub that name in the spec.)
+
+- [ ] **Step 5: Run the spec, confirm it passes**
+
+Run: `cd ui/sidecar && bundle exec rspec spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb`
+Expected: 2 examples, 0 failures.
+
+- [ ] **Step 6: Run the full sidecar suite**
+
+Run: `cd ui/sidecar && bundle exec rspec`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb \
+        ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb \
+        ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
+git commit -m "feat: BrollDirectorController for the UI surface (#30)"
+```
+
+---
+
+### Task 5: Sidecar — register the `start_broll_director` op
+
+Wire the controller into the sidecar's op dispatch (the JSON-RPC-style switch in `buttercut_ui_sidecar.rb`).
+
+**Files:**
+- Modify: `ui/sidecar/buttercut_ui_sidecar.rb`
+
+- [ ] **Step 1: Add the require**
+
+Find the line `require_relative "lib/buttercut_ui_sidecar/roughcut_controller"` and add immediately after:
+
+```ruby
+require_relative "lib/buttercut_ui_sidecar/broll_director_controller"
+```
+
+- [ ] **Step 2: Add the op handler**
+
+Find the `case op` switch with `when "start_roughcut"` and add a new branch immediately below the `when "export_roughcut_artifacts"` branch:
+
+```ruby
+when "start_broll_director"
+  broll_director_start(params)
+```
+
+- [ ] **Step 3: Add the handler method**
+
+Add a new method, modeled on `roughcut_start`, immediately after the `roughcut_start` method:
+
+```ruby
+def broll_director_start(params)
+  lib = params.fetch("library")
+  library_dir(lib)
+  api_key = @settings.api_key
+  raise StandardError, "missing_api_key" if api_key.nil? || api_key.empty?
+
+  client = ButtercutUiSidecar::AnthropicClient.new(api_key: api_key)
+  controller = ButtercutUiSidecar::BrollDirectorController.new(
+    libraries_root: @libraries_root.to_s,
+    repo_root: @repo_root.to_s,
+    notifier: @notifier,
+    registry: @registry,
+    client: client
+  )
+  controller.validate_and_start!(
+    library: lib,
+    roughcut_stem: params.fetch("roughcut_stem"),
+    density: params["density"] || ButtercutUiSidecar::BrollDirectorController::DEFAULT_DENSITY,
+    score_threshold: params["score_threshold"] || ButtercutUiSidecar::BrollDirectorController::DEFAULT_SCORE_THRESHOLD
+  )
+end
+```
+
+- [ ] **Step 4: Run the sidecar suite to confirm nothing regressed**
+
+Run: `cd ui/sidecar && bundle exec rspec`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/sidecar/buttercut_ui_sidecar.rb
+git commit -m "feat: register start_broll_director op (#30)"
+```
+
+---
+
+### Task 6: UI — `AddBrollButton` component
+
+A small button that POSTs `start_broll_director` and listens for `broll_phase` / `broll_job_done` / `broll_job_failed` events.
+
+**Files:**
+- Create: `ui/src/routes/library/AddBrollButton.tsx`
+
+- [ ] **Step 1: Read sibling files for component conventions**
+
+Run: `cat ui/src/routes/library/RoughcutTimeline.tsx | head -80`
+
+You need to know how existing buttons are styled (className conventions), how the sidecar IPC client is imported, and how phase events are subscribed to. Look for an existing button-with-job-progress pattern (search for `start_roughcut` usage) and mirror it.
+
+- [ ] **Step 2: Create the component**
+
+`ui/src/routes/library/AddBrollButton.tsx`:
+
+```tsx
+import { useState, useEffect } from "react";
+// Import the sidecar client + event subscription helper using whatever
+// import path the existing buttons (e.g. the one that fires start_roughcut)
+// use. If the project has a useSidecar() hook, prefer it.
+
+type Props = {
+  library: string;
+  roughcutStem: string;
+  hasManifest: boolean;
+  manifestEntryCount?: number;
+};
+
+type Phase = "idle" | "gather" | "model" | "write" | "done" | "error";
+
+export function AddBrollButton({ library, roughcutStem, hasManifest, manifestEntryCount }: Props) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [message, setMessage] = useState<string>("");
+  const [entries, setEntries] = useState<number | undefined>(manifestEntryCount);
+
+  useEffect(() => {
+    // Subscribe to broll_* events. Replace this with the actual subscription
+    // helper used elsewhere in this codebase (search for "roughcut_phase" to
+    // find the pattern). Filter by roughcutStem to ignore other rough cuts'
+    // jobs.
+    const unsubscribe = subscribeToSidecarEvents((event: any) => {
+      if (event.roughcut_stem && event.roughcut_stem !== roughcutStem) return;
+      switch (event.type) {
+        case "broll_phase":
+          setPhase(event.phase as Phase);
+          setMessage(event.message ?? "");
+          break;
+        case "broll_job_done":
+          setPhase("done");
+          setEntries(event.entries_written);
+          setMessage(`${event.entries_written} graphics ready to render`);
+          break;
+        case "broll_job_failed":
+          setPhase("error");
+          setMessage(event.message ?? "Director failed");
+          break;
+      }
+    });
+    return unsubscribe;
+  }, [roughcutStem]);
+
+  const running = phase !== "idle" && phase !== "done" && phase !== "error";
+
+  const handleClick = async () => {
+    if (running) return;
+    setPhase("gather");
+    setMessage("Starting…");
+    try {
+      await callSidecar("start_broll_director", {
+        library,
+        roughcut_stem: roughcutStem,
+      });
+    } catch (err: any) {
+      setPhase("error");
+      setMessage(err?.message ?? String(err));
+    }
+  };
+
+  const label = (() => {
+    if (running) return message || "Working…";
+    if (phase === "done") return `B-Roll ready (${entries})`;
+    if (phase === "error") return `Failed — retry`;
+    if (hasManifest) return `Re-run B-Roll Director (${manifestEntryCount ?? "?"} entries)`;
+    return "Add B-Roll";
+  })();
+
+  return (
+    <button
+      type="button"
+      className="add-broll-button"
+      disabled={running}
+      onClick={handleClick}
+      aria-busy={running}
+      title={hasManifest ? "Replaces existing manifest" : "Generate b-roll manifest from this rough cut"}
+    >
+      {label}
+    </button>
+  );
+}
+
+// --- Replace these with actual project utilities ---
+declare function callSidecar(op: string, params: Record<string, unknown>): Promise<any>;
+declare function subscribeToSidecarEvents(handler: (event: any) => void): () => void;
+```
+
+> **Note for the engineer:** The two `declare function` lines at the bottom are placeholders for whatever IPC + event-bus utilities this project actually exposes. **Delete them and replace the imports/calls with the real ones the existing buttons use.** Search `ui/src` for an existing button that fires `start_roughcut` to see the pattern.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/routes/library/AddBrollButton.tsx
+git commit -m "feat: AddBrollButton component (#30)"
+```
+
+---
+
+### Task 7: UI — wire button into `RoughcutTimeline.tsx`
+
+Render the button on each finished rough cut row. A "finished" rough cut is one whose YAML exists; whether it has a manifest yet drives the button label.
+
+**Files:**
+- Modify: `ui/src/routes/library/RoughcutTimeline.tsx`
+
+- [ ] **Step 1: Inspect the file to find where rough cut rows render**
+
+Run: `wc -l ui/src/routes/library/RoughcutTimeline.tsx && grep -n "roughcut\|fcpxml\|export\|button" ui/src/routes/library/RoughcutTimeline.tsx | head -40`
+
+Identify the JSX block that renders the per-rough-cut artifacts (YAML link, XML link, etc.). The button goes there.
+
+- [ ] **Step 2: Import and render the button**
+
+At the top of the file:
+
+```tsx
+import { AddBrollButton } from "./AddBrollButton";
+```
+
+In the per-rough-cut row JSX, immediately after the existing artifact links/buttons for that row, add:
+
+```tsx
+<AddBrollButton
+  library={libraryName}
+  roughcutStem={roughcut.stem}
+  hasManifest={Boolean(roughcut.brollManifest)}
+  manifestEntryCount={roughcut.brollManifest?.entryCount}
+/>
+```
+
+> **Note for the engineer:** if `roughcut.brollManifest` is not already a field on the rough cut row's data, pass `hasManifest={false}` for now and file a follow-up to surface the count from the sidecar's library listing. The button still works (it just always shows "Add B-Roll" / never the entry count).
+
+- [ ] **Step 3: Verify the file still type-checks**
+
+Run: `cd ui && pnpm tsc --noEmit` (or whatever this project's typecheck command is — check `ui/package.json` scripts).
+Expected: no new TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/routes/library/RoughcutTimeline.tsx
+git commit -m "feat: surface AddBrollButton on each finished rough cut row (#30)"
+```
+
+---
+
+### Task 8: End-to-end smoke check
+
+Run the full test suites and a manual smoke through the skill on the fixture library to confirm the slice works.
+
+- [ ] **Step 1: Run the gem suite**
+
+Run: `bundle exec rspec`
+Expected: all green.
+
+- [ ] **Step 2: Run the sidecar suite**
+
+Run: `cd ui/sidecar && bundle exec rspec`
+Expected: all green.
+
+- [ ] **Step 3: Manual skill smoke (no API key required)**
+
+The director is exercised end-to-end by the controller spec (which uses a stubbed model response). For a real end-to-end run with the live model, the user can invoke the skill on a real library — that is not part of this plan's acceptance because it requires API spend.
+
+Document this clearly in the PR body: "automated coverage stops at the post-processing layer; live-model exercise is a manual smoke."
+
+- [ ] **Step 4: Confirm acceptance criteria from issue #30**
+
+Tick off each item in the spec's "Acceptance" section against the implementation:
+
+- Output validates against PR #25 schema → `BrollDirectorPostprocess` calls `BrollManifest.from_hash` before write
+- Sub-agent contract: no library.yaml reads/writes → parent (skill) and controller (UI) both gather inputs; sub-agent receives only inline values
+- Smoke test on a sample tutorial transcript produces non-empty, well-typed manifest → `BrollDirectorController` spec runs the full pipeline against the canned model response
+
+Plus the spec's extra acceptance items:
+
+- UI button on each finished rough cut row produces the same manifest as the skill for the same inputs → both surfaces share `agent_prompt.md` + `BrollDirectorInputs` + `BrollDirectorPostprocess`
+- Re-running overwrites with a warning; existing renders untouched → `BrollDirectorController#warn_if_overwriting` + skill brief documents the behavior
+
+- [ ] **Step 5: Open the PR**
+
+Branch off `main` (or whatever the current sprint branch is — check `git status`), push, and open a PR titled `feat: b-roll director (skill + UI button) (#30)`. Body should reference the spec and plan paths and the issue number.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: every section of the design doc maps to a task — gathering helper (Task 1), post-processing helper (Task 2), skill (Task 3), sidecar controller (Task 4), op registration (Task 5), button (Task 6), wiring (Task 7), acceptance (Task 8).
+- Type consistency: `BrollDirectorInputs.gather` returns the keys `:library_name`, `:roughcut_stem`, `:roughcut`, `:theme`, `:source_videos`, `:available_templates` — used identically in the postprocess spec and the controller.
+- Placeholder check: Task 6 explicitly flags the IPC import as a project-specific replacement. No other placeholders.
+- Risk explicitly noted in plan body: Task 4 Step 4 asks the engineer to verify the AnthropicClient method name; the spec stubs are robust to either name.

--- a/docs/superpowers/specs/2026-05-07-broll-director-design.md
+++ b/docs/superpowers/specs/2026-05-07-broll-director-design.md
@@ -23,7 +23,7 @@ The vertical slice for Hyperframes already runs end-to-end when the manifest is 
 
 ## Architecture
 
-```
+```text
 .claude/skills/broll-director/
   SKILL.md                           # parent dispatch brief
   agent_prompt.md                    # canonical director prompt (single source of truth)
@@ -32,7 +32,8 @@ ui/sidecar/lib/buttercut_ui_sidecar/
   broll_director_controller.rb       # mirrors RoughcutController; loads .claude/skills/broll-director/agent_prompt.md directly
 
 ui/src/routes/library/
-  RoughcutTimeline.tsx               # adds "Add B-Roll" button per finished rough cut row
+  AddBrollButton.tsx                 # renders inside BriefComposer's done sheet
+  BriefComposer.tsx                  # mounts AddBrollButton next to the existing artifact buttons
 
 lib/buttercut/
   broll_director_inputs.rb           # pure-Ruby gathering of inputs from disk (used by both surfaces)
@@ -41,6 +42,9 @@ lib/buttercut/
 spec/buttercut/
   broll_director_inputs_spec.rb
   broll_director_postprocess_spec.rb
+
+ui/sidecar/spec/lib/buttercut_ui_sidecar/
+  broll_director_controller_spec.rb  # exercises the full controller pipeline against a stubbed model response
 
 spec/fixtures/broll_director/
   sample_library/                    # minimal library with one rough cut + transcripts
@@ -80,14 +84,14 @@ Density mapping (hardcoded in this spec; #31 will move it to library.yaml):
 
 The model is asked to return a JSON array of candidate entries. Each candidate has:
 
-```
+```jsonc
 {
   "source_video": "tutorial_01.mov",
   "source_start": 42.10,        // seconds into the SOURCE video
   "source_end":   47.80,
   "template": "code-callout",
   "placement": "overlay",       // overlay | cutaway | pip
-  "content": { ...template-specific... },
+  "content": { "command": "git rebase -i HEAD~3" },
   "score": 0.84,                // 0..1
   "rationale": "introduces `git rebase -i`, terminal visible, structural beat"
 }
@@ -128,17 +132,18 @@ Caller-side post-processing (in `broll_director_postprocess.rb`):
 
 ### UI button
 
-- New endpoint: `POST /libraries/:library/roughcuts/:stem/broll`
+- New sidecar op: `start_broll_director` (Tauri `invoke`, JSON-RPC-style dispatch in `buttercut_ui_sidecar.rb`).
 - `BrollDirectorController`:
-  - Same shape as `RoughcutController`: job registry, notifier, phase events (`gather`, `model`, `write`)
-  - Reads `agent_prompt.md` as system instructions, calls Anthropic API with the same inputs the skill passes
-  - Streams phase events to the UI
-  - Runs the same post-processing pipeline (`BrollDirectorPostprocess`) and writes the manifest
-- `RoughcutTimeline.tsx`:
-  - "Add B-Roll" button on each finished rough cut row
-  - Disabled while a director job is running for that rough cut
-  - On `broll_job_done` event, refresh the row to show entry count + a hint that rendering is the next step
-  - Stops at manifest write — no render trigger, no XML re-export
+  - Same shape as `RoughcutController`: real `JobRegistry`, notifier, phase events (`gather`, `model`, `write`).
+  - Reads `agent_prompt.md` as system instructions, calls the Anthropic API with the same inputs the skill passes.
+  - Validates `roughcut_stem` is a basename before any path joining (rejects `../`, slashes, empty).
+  - Streams phase events to the UI over the `sidecar-event:{jobId}` channel.
+  - Runs the same post-processing pipeline (`BrollDirectorPostprocess`) and writes the manifest.
+- `AddBrollButton.tsx` mounted inside `BriefComposer.tsx`:
+  - Renders next to the existing artifact buttons in the rough-cut "done" sheet.
+  - Disabled while its own director job is running.
+  - On `broll_job_done`, shows entry count + the implicit "rendering is next".
+  - Stops at manifest write — no render trigger, no XML re-export.
 
 ## Acceptance (from issue #30)
 
@@ -161,10 +166,11 @@ Plus:
 
 ## Tests
 
-- `spec/buttercut/broll_director_inputs_spec.rb` — gathering helpers: rough-cut clip enumeration, transcript-window slicing per clip, source→cut timecode mapping
-- `spec/buttercut/broll_director_postprocess_spec.rb` — pure functions: threshold filtering, density bucket pruning, id assignment, manifest assembly, validation hand-off
+- `spec/buttercut/broll_director_inputs_spec.rb` — gathering helpers: rough-cut clip enumeration, transcript-window slicing per clip, path-traversal rejection
+- `spec/buttercut/broll_director_postprocess_spec.rb` — pure functions: threshold filtering, density bucket pruning, id assignment, manifest assembly, validation hand-off, density / score_threshold input validation
+- `ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb` — exercises the full controller pipeline end-to-end against a stubbed model response (uses the real `JobRegistry`); also covers `roughcut_stem` traversal rejection
 - Smoke: a fixture rough cut + canned model response (JSON file) → post-processing produces a schema-valid manifest with the expected entry count
-- No tests added for the sidecar controller or the React button (consistent with how `RoughcutController` ships today)
+- No automated test for the React button (consistent with how the rest of the React UI ships today)
 
 ## Risks / open questions
 

--- a/docs/superpowers/specs/2026-05-07-broll-director-design.md
+++ b/docs/superpowers/specs/2026-05-07-broll-director-design.md
@@ -29,11 +29,7 @@ The vertical slice for Hyperframes already runs end-to-end when the manifest is 
   agent_prompt.md                    # canonical director prompt (single source of truth)
 
 ui/sidecar/lib/buttercut_ui_sidecar/
-  broll_director_controller.rb       # mirrors RoughcutController; uses Anthropic API directly
-
-ui/sidecar/prompts/
-  broll_director.md                  # mirror of .claude/skills/broll-director/agent_prompt.md
-                                     # (kept in sync via a tiny pre-load step in the controller)
+  broll_director_controller.rb       # mirrors RoughcutController; loads .claude/skills/broll-director/agent_prompt.md directly
 
 ui/src/routes/library/
   RoughcutTimeline.tsx               # adds "Add B-Roll" button per finished rough cut row

--- a/docs/superpowers/specs/2026-05-07-broll-director-design.md
+++ b/docs/superpowers/specs/2026-05-07-broll-director-design.md
@@ -1,0 +1,177 @@
+# B-Roll Director — Design (Issue #30)
+
+**Status:** Approved 2026-05-07
+**Issue:** [#30 — Hyperframes: b-roll director skill](https://github.com/William-Hill/buttercut/issues/30)
+**Epic:** [#26 — Hyperframes integration for AI-generated b-roll](https://github.com/William-Hill/buttercut/issues/26)
+
+## Goal
+
+Author the editorial brain of the Hyperframes pipeline: given an existing rough cut and the transcripts/summaries of the videos it references, decide *where graphics belong, what they say, and how they sit in the frame*, and emit a `<roughcut>.broll.yaml` that the existing render skill (#28) and roughcut integration (#33) can consume.
+
+## Why
+
+The vertical slice for Hyperframes already runs end-to-end when the manifest is hand-written: `BrollManifest` schema (PR #25), `render-broll` skill (#28), theme block (#27), and roughcut integration (#33) all shipped. What's missing is the only step a human shouldn't have to do — picking moments, picking templates, and writing the manifest. This spec fills that gap.
+
+## Scope decisions (settled in brainstorming)
+
+1. **Per-rough-cut, cut-relative timing.** Director runs *after* a rough cut exists. `start`/`end` in the manifest are seconds into the rough cut, matching the schema as shipped. (Rejected: per-video candidate pool with later remap; per-video at analysis time. Both add machinery for a benefit — cross-cut reuse — we don't yet need.)
+2. **Two surfaces, one prompt.** A new `broll-director` skill *and* a UI button shipped together. Both load the exact same agent prompt file so behavior cannot drift. (Rejected: skill-only with UI as a follow-up — the prompt is the asset, building both surfaces at once forces a clean shared prompt.)
+3. **Template discovery from filesystem.** Director auto-discovers templates by listing `hyperframes/compositions/*/README.md` and feeding the READMEs into its prompt as the source of truth for each template's `content` shape. New templates land in #29 without director changes.
+4. **Density and threshold are caller inputs, not library.yaml plumbing.** #30 takes `density` (low/medium/high → 2/4/8 graphics-per-minute budget) and `score_threshold` (default 0.5) as args. #31 will later add the `broll:` block in library.yaml that sets defaults; the director's interface doesn't change.
+5. **Re-running overwrites.** A second director run on a rough cut that already has a manifest replaces it, with a one-line warning. Existing rendered MP4s in `broll/` are not deleted (entry ids change on re-run, so old files become orphans the user can clean up).
+6. **UI button stops at manifest write.** Click → manifest. Render and re-export are #34's territory (late-render workflow). The button surfaces "12 b-roll graphics ready to render" and that's it.
+
+## Architecture
+
+```
+.claude/skills/broll-director/
+  SKILL.md                           # parent dispatch brief
+  agent_prompt.md                    # canonical director prompt (single source of truth)
+
+ui/sidecar/lib/buttercut_ui_sidecar/
+  broll_director_controller.rb       # mirrors RoughcutController; uses Anthropic API directly
+
+ui/sidecar/prompts/
+  broll_director.md                  # mirror of .claude/skills/broll-director/agent_prompt.md
+                                     # (kept in sync via a tiny pre-load step in the controller)
+
+ui/src/routes/library/
+  RoughcutTimeline.tsx               # adds "Add B-Roll" button per finished rough cut row
+
+lib/buttercut/
+  broll_director_inputs.rb           # pure-Ruby gathering of inputs from disk (used by both surfaces)
+  broll_director_postprocess.rb      # pure-Ruby scoring/threshold/density pruning + id assignment
+
+spec/buttercut/
+  broll_director_inputs_spec.rb
+  broll_director_postprocess_spec.rb
+
+spec/fixtures/broll_director/
+  sample_library/                    # minimal library with one rough cut + transcripts
+```
+
+The Ruby helpers under `lib/buttercut/` are deliberately pure functions (no LLM, no I/O beyond reading inputs the caller passes paths for). Both the skill driver and the sidecar controller use them. The LLM call is the only piece that lives separately in each surface.
+
+### Single source of truth: the prompt
+
+`.claude/skills/broll-director/agent_prompt.md` is canonical. The sidecar controller reads it at job start (resolving the path via the repo root that `RoughcutController` already computes), so any prompt change ships to both surfaces without coordination. We do not maintain two copies.
+
+## Inputs (gathered by the caller, passed to the model)
+
+The caller — skill parent or sidecar controller — gathers these from disk and passes them inline:
+
+- `library_name` (string)
+- `roughcut_stem` (filename stem, no extension)
+- `roughcut` (parsed YAML of the rough cut: ordered clips with `source_video`, `in`, `out`)
+- `theme` (the `theme:` block from library.yaml)
+- For each unique `source_video` referenced by the rough cut:
+  - `audio_transcript` (parsed JSON)
+  - `visual_transcript` (parsed JSON)
+  - `summary` (markdown string)
+- `available_templates` — array of `{ name: string, readme_md: string }` discovered by listing `hyperframes/compositions/*/README.md`
+- `density` — `"low" | "medium" | "high"` (default `"medium"`)
+- `score_threshold` — float in `0.0..1.0` (default `0.5`)
+
+Density mapping (hardcoded in this spec; #31 will move it to library.yaml):
+
+| density | graphics per minute |
+|---------|---------------------|
+| low     | 2                   |
+| medium  | 4                   |
+| high    | 8                   |
+
+## Director behavior
+
+The model is asked to return a JSON array of candidate entries. Each candidate has:
+
+```
+{
+  "source_video": "tutorial_01.mov",
+  "source_start": 42.10,        // seconds into the SOURCE video
+  "source_end":   47.80,
+  "template": "code-callout",
+  "placement": "overlay",       // overlay | cutaway | pip
+  "content": { ...template-specific... },
+  "score": 0.84,                // 0..1
+  "rationale": "introduces `git rebase -i`, terminal visible, structural beat"
+}
+```
+
+The model is given the rough cut so it knows what spans are actually in the cut, and it's asked to only emit candidates that fall inside a clip. The director prompt instructs it to:
+
+1. Walk each clip in the rough cut. For each clip, scope to the transcript window covering `[in, out]` of the corresponding `source_video`.
+2. Identify candidates from that window: terms introduced verbally, named commands/files/functions, lists, structural beats ("step 1"), stats, quotes, comparisons.
+3. Pick the best matching template from `available_templates` (skip the candidate if no template fits).
+4. Fill the template's `content` payload from transcript words. (Code-string normalization beyond what the model produces naturally is #32's job.)
+5. Pick `placement` from the visual transcript context covering that span: terminal/IDE visible → `overlay`; talking head only → `cutaway`; mixed/PiP-friendly → `pip`.
+6. Score `(novelty + emphasis + structural_role) / 3` in `0..1`.
+
+Caller-side post-processing (in `broll_director_postprocess.rb`):
+
+7. Drop any candidate with `score < score_threshold`.
+8. Map `source_start`/`source_end` → rough-cut-relative `start`/`end` using the clip's offset in the cut and its source `in` point. Clamp to the clip's bounds.
+9. Apply density budget: bin candidates by rough-cut-time minute; within each minute, keep top-N by score where N is the per-minute budget.
+10. Assign sequential ids (`br-0001`, `br-0002`, …) in time order.
+11. Set `rendered: null`, `notes: ""` on every entry. Set manifest `roughcut:` to `roughcut_stem`, `library:` to `library_name`, `version: 2`.
+12. Validate via `ButterCut::BrollManifest.from_hash`. Abort with a readable error if invalid (do not write a partial manifest).
+13. Write to `libraries/<library>/roughcuts/<roughcut_stem>.broll.yaml`. If a manifest already exists at that path, log a one-line warning naming the prior entry count, then overwrite.
+
+## Surfaces
+
+### Skill (`broll-director`)
+
+`SKILL.md` (parent brief):
+- Lists prerequisites: rough cut YAML exists; every `source_video` referenced by it has `transcript`, `visual_transcript`, and `summary` populated in library.yaml. Aborts with a clear message if not.
+- Dispatches **one** sub-agent per invocation (the work doesn't parallelize across videos cleanly when the goal is a single coherent manifest).
+- Inlines `agent_prompt.md` into the sub-agent prompt; passes inputs as listed above.
+- After the sub-agent returns, runs the post-processing pipeline and writes the manifest. Prints: `Wrote N entries to libraries/<lib>/roughcuts/<stem>.broll.yaml (density=<d>)`.
+
+`agent_prompt.md`:
+- Self-contained. Describes the director's job, the candidate JSON shape, the template list (passed inline), placement rules, and scoring rubric.
+- Returns a JSON array. No file I/O — the parent does all writes.
+
+### UI button
+
+- New endpoint: `POST /libraries/:library/roughcuts/:stem/broll`
+- `BrollDirectorController`:
+  - Same shape as `RoughcutController`: job registry, notifier, phase events (`gather`, `model`, `write`)
+  - Reads `agent_prompt.md` as system instructions, calls Anthropic API with the same inputs the skill passes
+  - Streams phase events to the UI
+  - Runs the same post-processing pipeline (`BrollDirectorPostprocess`) and writes the manifest
+- `RoughcutTimeline.tsx`:
+  - "Add B-Roll" button on each finished rough cut row
+  - Disabled while a director job is running for that rough cut
+  - On `broll_job_done` event, refresh the row to show entry count + a hint that rendering is the next step
+  - Stops at manifest write — no render trigger, no XML re-export
+
+## Acceptance (from issue #30)
+
+- [x] Output validates against PR #25 schema → enforced by `BrollManifest.from_hash` before write
+- [x] Sub-agent contract: no library.yaml reads/writes → parent gathers everything; sub-agent receives only inline values
+- [x] Smoke test on a sample tutorial transcript produces non-empty, well-typed manifest → fixture under `spec/fixtures/broll_director/sample_library/` + spec that runs post-processing on a canned model response
+
+Plus:
+
+- [x] UI button on each finished rough cut row produces the same manifest as the skill for the same inputs (shared prompt + shared post-processing)
+- [x] Re-running overwrites with a warning; existing renders untouched
+
+## Out of scope for #30
+
+- Late-render workflow / non-destructive swap-in-place (#34)
+- `broll:` block in library.yaml + migration (#31)
+- Code-string normalization with self-correction loop (#32)
+- New templates beyond `code-callout` (#29) — director will only emit `code-callout` entries today; that's correct
+- Auto-running director after rough cut completion (the UI button is explicit; auto-chaining is #34's call)
+
+## Tests
+
+- `spec/buttercut/broll_director_inputs_spec.rb` — gathering helpers: rough-cut clip enumeration, transcript-window slicing per clip, source→cut timecode mapping
+- `spec/buttercut/broll_director_postprocess_spec.rb` — pure functions: threshold filtering, density bucket pruning, id assignment, manifest assembly, validation hand-off
+- Smoke: a fixture rough cut + canned model response (JSON file) → post-processing produces a schema-valid manifest with the expected entry count
+- No tests added for the sidecar controller or the React button (consistent with how `RoughcutController` ships today)
+
+## Risks / open questions
+
+- **Model returns malformed JSON.** Wrap parse + validation in a single retry: if the first response fails to parse or validate, send the validation error back to the model and ask for a corrected JSON. Give up after one retry and surface the error.
+- **No template fits a strong candidate.** Acceptable — the candidate is dropped. With only `code-callout` available today, the director will mostly emit code callouts. As #29 lands, coverage broadens automatically (no director change).
+- **Sidecar prompt path coupling.** Sidecar reads `.claude/skills/broll-director/agent_prompt.md` directly. If repo layout shifts, both surfaces break together — which is the desired failure mode.

--- a/lib/buttercut/broll_director_inputs.rb
+++ b/lib/buttercut/broll_director_inputs.rb
@@ -1,0 +1,109 @@
+require "yaml"
+require "json"
+require "date"
+require "pathname"
+
+class ButterCut
+  # Pure-Ruby gathering of everything the b-roll director prompt needs.
+  # No LLM, no writes — just reads files the caller points at.
+  class BrollDirectorInputs
+    REQUIRED_VIDEO_KEYS = %w[transcript visual_transcript summary].freeze
+
+    def self.gather(library_dir:, roughcut_path:, hyperframes_dir:)
+      new(
+        library_dir: library_dir,
+        roughcut_path: roughcut_path,
+        hyperframes_dir: hyperframes_dir
+      ).gather
+    end
+
+    def initialize(library_dir:, roughcut_path:, hyperframes_dir:)
+      raise ArgumentError, "library_dir required" if library_dir.to_s.empty?
+      raise ArgumentError, "roughcut_path required" if roughcut_path.to_s.empty?
+      raise ArgumentError, "hyperframes_dir required" if hyperframes_dir.to_s.empty?
+
+      @library_dir = Pathname.new(library_dir)
+      @roughcut_path = Pathname.new(roughcut_path)
+      @hyperframes_dir = Pathname.new(hyperframes_dir)
+    end
+
+    def gather
+      library = load_library
+      roughcut = load_roughcut
+      sources = load_source_videos(library, roughcut)
+      {
+        library_name: library["library_name"] || @library_dir.basename.to_s,
+        roughcut_stem: @roughcut_path.basename.sub_ext("").to_s,
+        roughcut: roughcut,
+        theme: library["theme"] || {},
+        source_videos: sources,
+        available_templates: load_templates
+      }
+    end
+
+    private
+
+    def load_library
+      path = @library_dir.join("library.yaml")
+      raise ArgumentError, "library.yaml not found at #{path}" unless path.file?
+      YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+
+    def load_roughcut
+      raise ArgumentError, "rough cut not found at #{@roughcut_path}" unless @roughcut_path.file?
+      data = YAML.safe_load(@roughcut_path.read, permitted_classes: [Date, Time], aliases: true) || {}
+      raise ArgumentError, "rough cut has no clips" unless data["clips"].is_a?(Array) && !data["clips"].empty?
+      data
+    end
+
+    def load_source_videos(library, roughcut)
+      videos_by_basename = (library["videos"] || []).each_with_object({}) do |v, h|
+        h[File.basename(v["path"].to_s)] = v
+      end
+
+      referenced = roughcut["clips"].map { |c| c["source_video"] }.uniq
+      missing_meta = []
+      result = {}
+
+      referenced.each do |basename|
+        video = videos_by_basename[basename]
+        if video.nil?
+          missing_meta << basename
+          next
+        end
+        absent = REQUIRED_VIDEO_KEYS.reject { |k| !video[k].to_s.empty? }
+        if !absent.empty?
+          missing_meta << "#{basename} (missing #{absent.join(', ')})"
+          next
+        end
+        result[basename] = {
+          audio_transcript: load_json(@library_dir.join("transcripts", video["transcript"])),
+          visual_transcript: load_json(@library_dir.join("transcripts", video["visual_transcript"])),
+          summary: @library_dir.join("summaries", video["summary"]).read
+        }
+      end
+
+      unless missing_meta.empty?
+        raise ArgumentError, "missing transcripts/summaries for: #{missing_meta.join('; ')}"
+      end
+
+      result
+    end
+
+    def load_json(path)
+      raise ArgumentError, "transcript not found at #{path}" unless path.file?
+      JSON.parse(path.read)
+    end
+
+    def load_templates
+      compositions_dir = @hyperframes_dir.join("compositions")
+      return [] unless compositions_dir.directory?
+
+      compositions_dir.children.select(&:directory?).sort.filter_map do |dir|
+        readme = dir.join("README.md")
+        next nil unless readme.file?
+        { name: dir.basename.to_s, readme_md: readme.read }
+      end
+    end
+  end
+end

--- a/lib/buttercut/broll_director_inputs.rb
+++ b/lib/buttercut/broll_director_inputs.rb
@@ -58,7 +58,16 @@ class ButterCut
     end
 
     def load_source_videos(library, roughcut)
-      videos_by_basename = (library["videos"] || []).each_with_object({}) do |v, h|
+      videos = library["videos"] || []
+      duplicates = videos
+        .group_by { |v| File.basename(v["path"].to_s) }
+        .select { |basename, items| !basename.empty? && items.length > 1 }
+        .keys
+      unless duplicates.empty?
+        raise ArgumentError, "duplicate source video basenames in library.yaml: #{duplicates.join(', ')}"
+      end
+
+      videos_by_basename = videos.each_with_object({}) do |v, h|
         h[File.basename(v["path"].to_s)] = v
       end
 

--- a/lib/buttercut/broll_director_inputs.rb
+++ b/lib/buttercut/broll_director_inputs.rb
@@ -3,11 +3,12 @@ require "json"
 require "date"
 require "pathname"
 
+require_relative "timecode"
+
 class ButterCut
-  # Pure-Ruby gathering of everything the b-roll director prompt needs.
-  # No LLM, no writes — just reads files the caller points at.
   class BrollDirectorInputs
     REQUIRED_VIDEO_KEYS = %w[transcript visual_transcript summary].freeze
+    SLICE_PAD_SECONDS = 2.0
 
     def self.gather(library_dir:, roughcut_path:, hyperframes_dir:)
       new(
@@ -61,25 +62,30 @@ class ButterCut
         h[File.basename(v["path"].to_s)] = v
       end
 
-      referenced = roughcut["clips"].map { |c| c["source_video"] }.uniq
+      windows_by_source = clip_windows(roughcut["clips"])
       missing_meta = []
       result = {}
 
-      referenced.each do |basename|
+      windows_by_source.each do |basename, windows|
         video = videos_by_basename[basename]
         if video.nil?
           missing_meta << basename
           next
         end
-        absent = REQUIRED_VIDEO_KEYS.reject { |k| !video[k].to_s.empty? }
-        if !absent.empty?
+        absent = REQUIRED_VIDEO_KEYS.select { |k| video[k].to_s.empty? }
+        unless absent.empty?
           missing_meta << "#{basename} (missing #{absent.join(', ')})"
           next
         end
+
+        audio = load_json(safe_transcript_path(video["transcript"]))
+        visual = load_json(safe_transcript_path(video["visual_transcript"]))
+        summary = safe_summary_path(video["summary"]).read
+
         result[basename] = {
-          audio_transcript: load_json(@library_dir.join("transcripts", video["transcript"])),
-          visual_transcript: load_json(@library_dir.join("transcripts", video["visual_transcript"])),
-          summary: @library_dir.join("summaries", video["summary"]).read
+          audio_transcript: slice_audio(audio, windows),
+          visual_transcript: slice_visual(visual, windows),
+          summary: summary
         }
       end
 
@@ -88,6 +94,52 @@ class ButterCut
       end
 
       result
+    end
+
+    # { source_video => [[in_s, out_s], ...] } sorted, padded.
+    def clip_windows(clips)
+      clips.each_with_object({}) do |clip, h|
+        src = clip["source_video"]
+        in_s = ButterCut::Timecode.to_seconds(clip["in"])
+        out_s = ButterCut::Timecode.to_seconds(clip["out"])
+        (h[src] ||= []) << [[in_s - SLICE_PAD_SECONDS, 0].max, out_s + SLICE_PAD_SECONDS]
+      end
+    end
+
+    def in_any_window?(t, windows)
+      windows.any? { |a, b| t >= a && t <= b }
+    end
+
+    def overlaps_any_window?(a, b, windows)
+      windows.any? { |wa, wb| b >= wa && a <= wb }
+    end
+
+    def slice_audio(audio, windows)
+      segs = audio["segments"] || []
+      kept = segs.select { |s| overlaps_any_window?(s["start"].to_f, s["end"].to_f, windows) }
+      audio.merge("segments" => kept)
+    end
+
+    def slice_visual(visual, windows)
+      frames = visual["frames"] || []
+      kept = frames.select { |f| in_any_window?(f["t"].to_f, windows) }
+      visual.merge("frames" => kept)
+    end
+
+    def safe_transcript_path(filename)
+      safe_subpath(@library_dir.join("transcripts"), filename)
+    end
+
+    def safe_summary_path(filename)
+      safe_subpath(@library_dir.join("summaries"), filename)
+    end
+
+    # Reject absolute paths and traversal — accept basenames only.
+    def safe_subpath(base, filename)
+      s = filename.to_s
+      raise ArgumentError, "invalid path reference: #{filename.inspect}" if Pathname.new(s).absolute?
+      raise ArgumentError, "invalid path reference: #{filename.inspect}" if s != File.basename(s)
+      base.expand_path.join(s)
     end
 
     def load_json(path)

--- a/lib/buttercut/broll_director_postprocess.rb
+++ b/lib/buttercut/broll_director_postprocess.rb
@@ -1,9 +1,8 @@
 require "set"
 require_relative "broll_manifest"
+require_relative "timecode"
 
 class ButterCut
-  # Turns candidate JSON from the director model into a validated manifest hash
-  # ready for ButterCut::BrollManifest.from_hash. Pure functions only.
   class BrollDirectorPostprocess
     DENSITY_BUDGETS = { "low" => 2, "medium" => 4, "high" => 8 }.freeze
 
@@ -35,7 +34,6 @@ class ButterCut
 
     def assemble
       mapped = @candidates.filter_map { |c| map_candidate(c) }
-      mapped.sort_by! { |e| e["start"] }
       mapped = apply_density(mapped)
       mapped.each_with_index { |e, i| e["id"] = format("br-%04d", i + 1) }
       manifest = {
@@ -44,7 +42,7 @@ class ButterCut
         "roughcut" => @roughcut_stem,
         "entries" => mapped
       }
-      ButterCut::BrollManifest.from_hash(manifest)  # raises if invalid
+      ButterCut::BrollManifest.from_hash(manifest)
       manifest
     end
 
@@ -71,14 +69,11 @@ class ButterCut
       }
     end
 
-    # Walk the rough cut's clips in order, accumulating a cut-time offset.
-    # If [source_start, source_end] falls (even partially) inside a clip
-    # of the matching source_video, return its position in the cut.
     def locate_in_cut(c)
       cursor = 0.0
       @roughcut["clips"].each do |clip|
-        clip_in = parse_tc(clip["in"])
-        clip_out = parse_tc(clip["out"])
+        clip_in = ButterCut::Timecode.to_seconds(clip["in"])
+        clip_out = ButterCut::Timecode.to_seconds(clip["out"])
         clip_len = clip_out - clip_in
 
         if clip["source_video"] == c["source_video"]
@@ -95,11 +90,6 @@ class ButterCut
         cursor += clip_len
       end
       nil
-    end
-
-    def parse_tc(tc)
-      h, m, s = tc.to_s.split(":")
-      h.to_i * 3600 + m.to_i * 60 + s.to_f
     end
 
     def apply_density(entries)

--- a/lib/buttercut/broll_director_postprocess.rb
+++ b/lib/buttercut/broll_director_postprocess.rb
@@ -21,6 +21,10 @@ class ButterCut
 
     def initialize(library_name:, roughcut_stem:, roughcut:, candidates:,
                    available_templates:, density:, score_threshold:)
+      raise ArgumentError, "candidates must be an array, got #{candidates.class}" unless candidates.is_a?(Array)
+      bad = candidates.reject { |c| c.is_a?(Hash) }
+      raise ArgumentError, "every candidate must be a hash; got #{bad.first.class} at index #{candidates.index(bad.first)}" unless bad.empty?
+
       @library_name = library_name
       @roughcut_stem = roughcut_stem
       @roughcut = roughcut

--- a/lib/buttercut/broll_director_postprocess.rb
+++ b/lib/buttercut/broll_director_postprocess.rb
@@ -33,7 +33,15 @@ class ButterCut
       @budget = DENSITY_BUDGETS.fetch(density) {
         raise ArgumentError, "density must be one of #{DENSITY_BUDGETS.keys.inspect}, got #{density.inspect}"
       }
-      @score_threshold = score_threshold.to_f
+      threshold = begin
+        Float(score_threshold)
+      rescue TypeError, ArgumentError
+        raise ArgumentError, "score_threshold must be a finite number between 0.0 and 1.0, got #{score_threshold.inspect}"
+      end
+      unless threshold.finite? && threshold.between?(0.0, 1.0)
+        raise ArgumentError, "score_threshold must be a finite number between 0.0 and 1.0, got #{score_threshold.inspect}"
+      end
+      @score_threshold = threshold
     end
 
     def assemble

--- a/lib/buttercut/broll_director_postprocess.rb
+++ b/lib/buttercut/broll_director_postprocess.rb
@@ -1,0 +1,112 @@
+require "set"
+require_relative "broll_manifest"
+
+class ButterCut
+  # Turns candidate JSON from the director model into a validated manifest hash
+  # ready for ButterCut::BrollManifest.from_hash. Pure functions only.
+  class BrollDirectorPostprocess
+    DENSITY_BUDGETS = { "low" => 2, "medium" => 4, "high" => 8 }.freeze
+
+    def self.assemble(library_name:, roughcut_stem:, roughcut:, candidates:,
+                      available_templates:, density:, score_threshold:)
+      new(
+        library_name: library_name,
+        roughcut_stem: roughcut_stem,
+        roughcut: roughcut,
+        candidates: candidates,
+        available_templates: available_templates,
+        density: density,
+        score_threshold: score_threshold
+      ).assemble
+    end
+
+    def initialize(library_name:, roughcut_stem:, roughcut:, candidates:,
+                   available_templates:, density:, score_threshold:)
+      @library_name = library_name
+      @roughcut_stem = roughcut_stem
+      @roughcut = roughcut
+      @candidates = candidates
+      @template_names = available_templates.map { |t| t[:name] || t["name"] }.to_set
+      @budget = DENSITY_BUDGETS.fetch(density) {
+        raise ArgumentError, "density must be one of #{DENSITY_BUDGETS.keys.inspect}, got #{density.inspect}"
+      }
+      @score_threshold = score_threshold.to_f
+    end
+
+    def assemble
+      mapped = @candidates.filter_map { |c| map_candidate(c) }
+      mapped.sort_by! { |e| e["start"] }
+      mapped = apply_density(mapped)
+      mapped.each_with_index { |e, i| e["id"] = format("br-%04d", i + 1) }
+      manifest = {
+        "version" => ButterCut::BrollManifest::SCHEMA_VERSION,
+        "library" => @library_name,
+        "roughcut" => @roughcut_stem,
+        "entries" => mapped
+      }
+      ButterCut::BrollManifest.from_hash(manifest)  # raises if invalid
+      manifest
+    end
+
+    private
+
+    def map_candidate(c)
+      return nil unless @template_names.include?(c["template"])
+      score = c["score"].to_f
+      return nil if score < @score_threshold
+
+      mapping = locate_in_cut(c)
+      return nil if mapping.nil?
+
+      {
+        "source_video" => c["source_video"],
+        "start" => mapping[:start],
+        "end" => mapping[:end],
+        "template" => c["template"],
+        "placement" => c["placement"],
+        "score" => score,
+        "content" => c["content"],
+        "rendered" => nil,
+        "notes" => c["rationale"].to_s
+      }
+    end
+
+    # Walk the rough cut's clips in order, accumulating a cut-time offset.
+    # If [source_start, source_end] falls (even partially) inside a clip
+    # of the matching source_video, return its position in the cut.
+    def locate_in_cut(c)
+      cursor = 0.0
+      @roughcut["clips"].each do |clip|
+        clip_in = parse_tc(clip["in"])
+        clip_out = parse_tc(clip["out"])
+        clip_len = clip_out - clip_in
+
+        if clip["source_video"] == c["source_video"]
+          s = c["source_start"].to_f
+          e = c["source_end"].to_f
+          if e > clip_in && s < clip_out
+            mapped_start = cursor + [s, clip_in].max - clip_in
+            mapped_end   = cursor + [e, clip_out].min - clip_in
+            return nil if mapped_end <= mapped_start
+            return { start: mapped_start.round(2), end: mapped_end.round(2) }
+          end
+        end
+
+        cursor += clip_len
+      end
+      nil
+    end
+
+    def parse_tc(tc)
+      h, m, s = tc.to_s.split(":")
+      h.to_i * 3600 + m.to_i * 60 + s.to_f
+    end
+
+    def apply_density(entries)
+      buckets = entries.group_by { |e| (e["start"] / 60.0).floor }
+      buckets.values.flat_map { |list|
+        list.sort_by { |e| -e["score"] }.first(@budget)
+      }.sort_by { |e| e["start"] }
+    end
+  end
+end

--- a/lib/buttercut/timecode.rb
+++ b/lib/buttercut/timecode.rb
@@ -1,0 +1,10 @@
+class ButterCut
+  module Timecode
+    module_function
+
+    def to_seconds(tc)
+      h, m, s = tc.to_s.split(":")
+      h.to_i * 3600 + m.to_i * 60 + s.to_f
+    end
+  end
+end

--- a/spec/buttercut/broll_director_inputs_spec.rb
+++ b/spec/buttercut/broll_director_inputs_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "yaml"
+require "buttercut/broll_director_inputs"
+
+RSpec.describe ButterCut::BrollDirectorInputs do
+  let(:fixtures) { File.expand_path("../fixtures/broll_director", __dir__) }
+  let(:lib_dir) { File.join(fixtures, "sample_library") }
+  let(:roughcut_path) { File.join(lib_dir, "roughcuts", "sample.yaml") }
+  let(:hyperframes_dir) { File.expand_path("../../hyperframes", __dir__) }
+
+  it "gathers everything the director prompt needs" do
+    result = described_class.gather(
+      library_dir: lib_dir,
+      roughcut_path: roughcut_path,
+      hyperframes_dir: hyperframes_dir
+    )
+
+    expect(result[:library_name]).to eq("sample-library")
+    expect(result[:roughcut_stem]).to eq("sample")
+    expect(result[:roughcut]["clips"].length).to eq(2)
+    expect(result[:theme]["template_set"]).to eq("tutorial-dark")
+
+    sources = result[:source_videos]
+    expect(sources.keys).to contain_exactly("tutorial_01.mov")
+    src = sources["tutorial_01.mov"]
+    expect(src[:audio_transcript]["segments"].first["text"]).to include("git rebase")
+    expect(src[:visual_transcript]["frames"].length).to eq(5)
+    expect(src[:summary]).to include("git rebase")
+
+    templates = result[:available_templates]
+    template_names = templates.map { |t| t[:name] }
+    expect(template_names).to include("code-callout")
+    callout = templates.find { |t| t[:name] == "code-callout" }
+    expect(callout[:readme_md]).to be_a(String)
+    expect(callout[:readme_md]).not_to be_empty
+  end
+
+  it "raises if a referenced source_video is missing transcripts in library.yaml" do
+    Dir.mktmpdir do |tmp|
+      bad_lib = File.join(tmp, "lib")
+      FileUtils.mkdir_p(File.join(bad_lib, "roughcuts"))
+      File.write(File.join(bad_lib, "library.yaml"), {
+        "library_name" => "x",
+        "theme" => {},
+        "videos" => [{ "path" => "/x/tutorial_01.mov" }]
+      }.to_yaml)
+      File.write(File.join(bad_lib, "roughcuts", "r.yaml"), {
+        "clips" => [{ "source_video" => "tutorial_01.mov", "in" => "00:00:00.00", "out" => "00:00:05.00" }]
+      }.to_yaml)
+
+      expect {
+        described_class.gather(
+          library_dir: bad_lib,
+          roughcut_path: File.join(bad_lib, "roughcuts", "r.yaml"),
+          hyperframes_dir: hyperframes_dir
+        )
+      }.to raise_error(ArgumentError, /missing transcripts.*tutorial_01\.mov/i)
+    end
+  end
+end

--- a/spec/buttercut/broll_director_inputs_spec.rb
+++ b/spec/buttercut/broll_director_inputs_spec.rb
@@ -37,6 +37,49 @@ RSpec.describe ButterCut::BrollDirectorInputs do
     expect(callout[:readme_md]).not_to be_empty
   end
 
+  it "slices transcripts to the rough cut's clip windows (with pad)" do
+    result = described_class.gather(
+      library_dir: lib_dir,
+      roughcut_path: roughcut_path,
+      hyperframes_dir: hyperframes_dir
+    )
+    src = result[:source_videos]["tutorial_01.mov"]
+    seg_starts = src[:audio_transcript]["segments"].map { |s| s["start"] }
+    expect(seg_starts).to all(be_between(28.0, 112.0))
+    frame_ts = src[:visual_transcript]["frames"].map { |f| f["t"] }
+    expect(frame_ts).to all(be_between(28.0, 112.0))
+  end
+
+  it "rejects transcript references with absolute paths or traversal" do
+    Dir.mktmpdir do |tmp|
+      bad_lib = File.join(tmp, "lib")
+      FileUtils.mkdir_p(File.join(bad_lib, "roughcuts"))
+      FileUtils.mkdir_p(File.join(bad_lib, "transcripts"))
+      FileUtils.mkdir_p(File.join(bad_lib, "summaries"))
+      File.write(File.join(bad_lib, "library.yaml"), {
+        "library_name" => "x",
+        "theme" => {},
+        "videos" => [{
+          "path" => "/x/tutorial_01.mov",
+          "transcript" => "/etc/passwd",
+          "visual_transcript" => "v.json",
+          "summary" => "s.md"
+        }]
+      }.to_yaml)
+      File.write(File.join(bad_lib, "roughcuts", "r.yaml"), {
+        "clips" => [{ "source_video" => "tutorial_01.mov", "in" => "00:00:00.00", "out" => "00:00:05.00" }]
+      }.to_yaml)
+
+      expect {
+        described_class.gather(
+          library_dir: bad_lib,
+          roughcut_path: File.join(bad_lib, "roughcuts", "r.yaml"),
+          hyperframes_dir: hyperframes_dir
+        )
+      }.to raise_error(ArgumentError, /invalid path reference/)
+    end
+  end
+
   it "raises if a referenced source_video is missing transcripts in library.yaml" do
     Dir.mktmpdir do |tmp|
       bad_lib = File.join(tmp, "lib")

--- a/spec/buttercut/broll_director_postprocess_spec.rb
+++ b/spec/buttercut/broll_director_postprocess_spec.rb
@@ -83,4 +83,12 @@ RSpec.describe ButterCut::BrollDirectorPostprocess do
   it "rejects unsupported density" do
     expect { call(density: "extreme") }.to raise_error(ArgumentError, /density/)
   end
+
+  it "rejects non-numeric or out-of-range score_threshold instead of coercing to 0.0" do
+    expect { call(score_threshold: nil) }.to raise_error(ArgumentError, /score_threshold/)
+    expect { call(score_threshold: "abc") }.to raise_error(ArgumentError, /score_threshold/)
+    expect { call(score_threshold: -0.1) }.to raise_error(ArgumentError, /score_threshold/)
+    expect { call(score_threshold: 1.1) }.to raise_error(ArgumentError, /score_threshold/)
+    expect { call(score_threshold: Float::INFINITY) }.to raise_error(ArgumentError, /score_threshold/)
+  end
 end

--- a/spec/buttercut/broll_director_postprocess_spec.rb
+++ b/spec/buttercut/broll_director_postprocess_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+require "json"
+require "buttercut/broll_director_postprocess"
+require "buttercut/broll_manifest"
+
+RSpec.describe ButterCut::BrollDirectorPostprocess do
+  let(:fixtures) { File.expand_path("../fixtures/broll_director", __dir__) }
+  let(:roughcut) {
+    {
+      "clips" => [
+        { "source_video" => "tutorial_01.mov", "in" => "00:00:30.00", "out" => "00:01:00.00" },
+        { "source_video" => "tutorial_01.mov", "in" => "00:01:20.00", "out" => "00:01:50.00" }
+      ]
+    }
+  }
+  let(:candidates) { JSON.parse(File.read(File.join(fixtures, "canned_model_response.json"))) }
+  let(:available_templates) { [{ name: "code-callout", readme_md: "" }] }
+
+  def call(opts = {})
+    described_class.assemble(
+      library_name: "sample-library",
+      roughcut_stem: "sample",
+      roughcut: roughcut,
+      candidates: candidates,
+      available_templates: available_templates,
+      density: opts.fetch(:density, "medium"),
+      score_threshold: opts.fetch(:score_threshold, 0.5)
+    )
+  end
+
+  it "drops candidates below the score threshold, outside any clip, or with an unknown template" do
+    manifest = call
+    contents = manifest["entries"].map { |e| e["content"] }
+    commands = contents.map { |c| c["command"] }
+    expect(commands).to contain_exactly("git rebase -i HEAD~3", "git status")
+  end
+
+  it "remaps source-relative timing to rough-cut-relative timing" do
+    manifest = call
+    rebase = manifest["entries"].find { |e| e["content"]["command"] == "git rebase -i HEAD~3" }
+    # source 35.0 - clip[0].in (30.0) = 5.0 into the cut
+    expect(rebase["start"]).to eq(5.0)
+    expect(rebase["end"]).to eq(10.0)
+    status = manifest["entries"].find { |e| e["content"]["command"] == "git status" }
+    # clip[0] is 30s long (0..30), clip[1] starts at 30 in the cut
+    # source 100.0 - clip[1].in (80.0) = 20.0 into clip[1] -> 30 + 20 = 50.0 in cut
+    expect(status["start"]).to eq(50.0)
+    expect(status["end"]).to eq(55.0)
+  end
+
+  it "assigns sequential ids in time order" do
+    manifest = call
+    expect(manifest["entries"].map { |e| e["id"] }).to eq(["br-0001", "br-0002"])
+    starts = manifest["entries"].map { |e| e["start"] }
+    expect(starts).to eq(starts.sort)
+  end
+
+  it "applies a density budget per minute" do
+    many = (0..9).map do |i|
+      {
+        "source_video" => "tutorial_01.mov",
+        "source_start" => 30.0 + i, "source_end" => 31.0 + i,
+        "template" => "code-callout", "placement" => "overlay",
+        "content" => { "command" => "cmd_#{i}" },
+        "score" => 0.5 + i * 0.05
+      }
+    end
+    manifest = described_class.assemble(
+      library_name: "x", roughcut_stem: "y", roughcut: roughcut,
+      candidates: many, available_templates: available_templates,
+      density: "low", score_threshold: 0.0
+    )
+    expect(manifest["entries"].length).to eq(2)  # low = 2/min, all in minute 0
+    kept = manifest["entries"].map { |e| e["content"]["command"] }
+    expect(kept).to contain_exactly("cmd_9", "cmd_8")
+  end
+
+  it "produces a manifest that validates via BrollManifest" do
+    manifest = call
+    expect { ButterCut::BrollManifest.from_hash(manifest) }.not_to raise_error
+  end
+
+  it "rejects unsupported density" do
+    expect { call(density: "extreme") }.to raise_error(ArgumentError, /density/)
+  end
+end

--- a/spec/fixtures/broll_director/canned_model_response.json
+++ b/spec/fixtures/broll_director/canned_model_response.json
@@ -1,0 +1,52 @@
+[
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 35.0,
+    "source_end": 40.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git rebase -i HEAD~3", "caption": "Interactive rebase, last 3 commits" },
+    "score": 0.9,
+    "rationale": "introduces command, terminal visible"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 36.0,
+    "source_end": 38.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git log --oneline" },
+    "score": 0.4,
+    "rationale": "low-novelty filler"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 100.0,
+    "source_end": 105.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "git status", "caption": "Confirm a clean tree" },
+    "score": 0.7,
+    "rationale": "structural beat, terminal visible"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 200.0,
+    "source_end": 205.0,
+    "template": "code-callout",
+    "placement": "overlay",
+    "content": { "command": "out-of-cut" },
+    "score": 0.95,
+    "rationale": "outside any clip"
+  },
+  {
+    "source_video": "tutorial_01.mov",
+    "source_start": 95.0,
+    "source_end": 99.0,
+    "template": "no-such-template",
+    "placement": "overlay",
+    "content": { "x": "y" },
+    "score": 0.8,
+    "rationale": "unknown template"
+  }
+]

--- a/spec/fixtures/broll_director/sample_library/library.yaml
+++ b/spec/fixtures/broll_director/sample_library/library.yaml
@@ -1,0 +1,20 @@
+library_name: sample-library
+language: English
+editor: Final Cut Pro X
+transcript_refinement: true
+user_context: ""
+footage_summary: "A short tutorial covering interactive rebase."
+theme:
+  font_display: Inter
+  font_mono: JetBrains Mono
+  color_bg: '#0d0d0d'
+  color_fg: '#f5f5f4'
+  color_accent: '#ff6b35'
+  template_set: tutorial-dark
+  motion: snappy
+videos:
+  - path: /fixtures/tutorial_01.mov
+    duration: "00:02:00"
+    transcript: tutorial_01.json
+    visual_transcript: visual_tutorial_01.json
+    summary: summary_tutorial_01.md

--- a/spec/fixtures/broll_director/sample_library/roughcuts/sample.yaml
+++ b/spec/fixtures/broll_director/sample_library/roughcuts/sample.yaml
@@ -1,0 +1,8 @@
+project: sample
+clips:
+  - source_video: tutorial_01.mov
+    in:  "00:00:30.00"
+    out: "00:01:00.00"
+  - source_video: tutorial_01.mov
+    in:  "00:01:20.00"
+    out: "00:01:50.00"

--- a/spec/fixtures/broll_director/sample_library/summaries/summary_tutorial_01.md
+++ b/spec/fixtures/broll_director/sample_library/summaries/summary_tutorial_01.md
@@ -1,0 +1,12 @@
+# tutorial_01.mov
+
+A short walk-through of `git rebase -i`, demonstrated against a tutorial repo.
+
+## Key visuals
+- Talking head intro
+- Terminal with git log
+- Interactive rebase editor
+
+## Notable dialogue
+- "Today we'll look at git rebase interactive"
+- "Step one: stash any uncommitted changes first"

--- a/spec/fixtures/broll_director/sample_library/transcripts/tutorial_01.json
+++ b/spec/fixtures/broll_director/sample_library/transcripts/tutorial_01.json
@@ -1,0 +1,11 @@
+{
+  "video_path": "/fixtures/tutorial_01.mov",
+  "language": "en",
+  "segments": [
+    { "start": 30.0, "end": 35.0, "text": "Today we'll look at git rebase interactive." },
+    { "start": 35.0, "end": 45.0, "text": "Run git rebase -i HEAD~3 to edit the last three commits." },
+    { "start": 45.0, "end": 60.0, "text": "Pick, squash, fixup, reword - those are your main options." },
+    { "start": 80.0, "end": 90.0, "text": "Step one: stash any uncommitted changes first." },
+    { "start": 90.0, "end": 110.0, "text": "Step two: run git status to confirm a clean tree." }
+  ]
+}

--- a/spec/fixtures/broll_director/sample_library/transcripts/visual_tutorial_01.json
+++ b/spec/fixtures/broll_director/sample_library/transcripts/visual_tutorial_01.json
@@ -1,0 +1,10 @@
+{
+  "video_path": "/fixtures/tutorial_01.mov",
+  "frames": [
+    { "t": 32.0, "description": "Talking head of presenter, no terminal visible." },
+    { "t": 40.0, "description": "Terminal visible showing a git log." },
+    { "t": 50.0, "description": "Terminal with interactive rebase editor open." },
+    { "t": 85.0, "description": "Talking head only." },
+    { "t": 100.0, "description": "Terminal running git status." }
+  ]
+}

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -26,6 +26,7 @@ require_relative "lib/buttercut_ui_sidecar/stages/summarize"
 require_relative "lib/buttercut_ui_sidecar/brief_store"
 require_relative "lib/buttercut_ui_sidecar/presence"
 require_relative "lib/buttercut_ui_sidecar/roughcut_controller"
+require_relative "lib/buttercut_ui_sidecar/broll_director_controller"
 require_relative "lib/buttercut_ui_sidecar/roughcut_exporter"
 require_relative "lib/buttercut_ui_sidecar/resolve_handoff"
 
@@ -174,6 +175,8 @@ module ButtercutUiSidecar
         roughcut_start(params)
       when "export_roughcut_artifacts"
         export_roughcut_artifacts(params)
+      when "start_broll_director"
+        broll_director_start(params)
       when "send_to_resolve"
         send_to_resolve(params)
       else raise UnknownMethod, "unknown method: #{method}"
@@ -267,6 +270,28 @@ module ButtercutUiSidecar
         client: client
       )
       rc.validate_and_start!(library: lib, brief_id: params.fetch("brief_id"))
+    end
+
+    def broll_director_start(params)
+      lib = params.fetch("library")
+      library_dir(lib)
+      api_key = @settings.api_key
+      raise StandardError, "missing_api_key" if api_key.nil? || api_key.empty?
+
+      client = ButtercutUiSidecar::AnthropicClient.new(api_key: api_key)
+      controller = ButtercutUiSidecar::BrollDirectorController.new(
+        libraries_root: @libraries_root.to_s,
+        repo_root: @repo_root.to_s,
+        notifier: @notifier,
+        registry: @registry,
+        client: client
+      )
+      controller.validate_and_start!(
+        library: lib,
+        roughcut_stem: params.fetch("roughcut_stem"),
+        density: params["density"] || ButtercutUiSidecar::BrollDirectorController::DEFAULT_DENSITY,
+        score_threshold: params["score_threshold"] || ButtercutUiSidecar::BrollDirectorController::DEFAULT_SCORE_THRESHOLD
+      )
     end
 
     def list_libraries

--- a/ui/sidecar/buttercut_ui_sidecar.rb
+++ b/ui/sidecar/buttercut_ui_sidecar.rb
@@ -26,6 +26,12 @@ require_relative "lib/buttercut_ui_sidecar/stages/summarize"
 require_relative "lib/buttercut_ui_sidecar/brief_store"
 require_relative "lib/buttercut_ui_sidecar/presence"
 require_relative "lib/buttercut_ui_sidecar/roughcut_controller"
+
+# The b-roll controller depends on the parent gem's lib/. Wire its load path
+# here at the entry point rather than from inside the controller file.
+gem_lib = File.expand_path("../../lib", __dir__)
+$LOAD_PATH.unshift(gem_lib) unless $LOAD_PATH.include?(gem_lib)
+
 require_relative "lib/buttercut_ui_sidecar/broll_director_controller"
 require_relative "lib/buttercut_ui_sidecar/roughcut_exporter"
 require_relative "lib/buttercut_ui_sidecar/resolve_handoff"

--- a/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/anthropic_client.rb
@@ -35,6 +35,18 @@ module ButtercutUiSidecar
       raise InvalidApiKey, e.message
     end
 
+    # Convenience wrapper: send a single user message with a system prompt and
+    # return the assistant's text content as a string.
+    def complete(system:, user:, model:)
+      response = messages_create(
+        model: model,
+        max_tokens: 8192,
+        system: system,
+        messages: [{ role: "user", content: user }]
+      )
+      self.class.message_body_text(response)
+    end
+
     # Normalizes SDK response objects (or Hash) to a single assistant text string.
     def self.message_body_text(response)
       return "" if response.nil?

--- a/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
@@ -5,12 +5,6 @@ require "pathname"
 require "yaml"
 require "date"
 
-# Make the parent gem's lib/ available so we can require buttercut/* helpers.
-# Sidecar lives at <repo>/ui/sidecar/lib/buttercut_ui_sidecar/, so the gem's
-# lib/ is four levels up.
-gem_lib = File.expand_path("../../../../lib", __dir__)
-$LOAD_PATH.unshift(gem_lib) unless $LOAD_PATH.include?(gem_lib)
-
 require "buttercut/broll_director_inputs"
 require "buttercut/broll_director_postprocess"
 require "buttercut/broll_manifest"
@@ -18,13 +12,20 @@ require "buttercut/broll_manifest"
 require_relative "anthropic_client"
 
 module ButtercutUiSidecar
-  # UI-driven b-roll director. Mirrors RoughcutController's shape; loads the
-  # same agent prompt as the broll-director skill so behavior cannot drift.
   class BrollDirectorController
     PROMPT_RELATIVE_PATH = ".claude/skills/broll-director/agent_prompt.md"
     DEFAULT_DENSITY = "medium"
     DEFAULT_SCORE_THRESHOLD = 0.5
     MODEL = AnthropicClient::VISION_MODEL
+
+    EVENT_STARTED = "broll_job_started"
+    EVENT_PHASE   = "broll_phase"
+    EVENT_DONE    = "broll_job_done"
+    EVENT_FAILED  = "broll_job_failed"
+
+    PHASE_GATHER = "gather"
+    PHASE_MODEL  = "model"
+    PHASE_WRITE  = "write"
 
     def initialize(libraries_root:, repo_root:, notifier:, registry:, client:)
       raise ArgumentError, "libraries_root required" if libraries_root.to_s.empty?
@@ -42,6 +43,9 @@ module ButtercutUiSidecar
 
     def validate_and_start!(library:, roughcut_stem:, density: DEFAULT_DENSITY,
                             score_threshold: DEFAULT_SCORE_THRESHOLD)
+      roughcut_path = @libraries_root.join(library, "roughcuts", "#{roughcut_stem}.yaml")
+      raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
+
       job_id = @registry.create(library)
       Thread.new do
         begin
@@ -52,7 +56,7 @@ module ButtercutUiSidecar
           )
         rescue StandardError => e
           warn "[broll-director #{job_id}] FAILED #{e.class}: #{e.message}"
-          @notifier.notify("broll_job_failed", job_id: job_id, message: e.message)
+          @notifier.notify(EVENT_FAILED, job_id: job_id, message: e.message)
         end
       end
       job_id
@@ -63,8 +67,8 @@ module ButtercutUiSidecar
       roughcut_path = lib_dir.join("roughcuts", "#{roughcut_stem}.yaml")
       raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
 
-      notify(job_id, "broll_job_started", library: library, roughcut_stem: roughcut_stem)
-      notify(job_id, "broll_phase", phase: "gather", message: "Gathering transcripts and templates…")
+      notify(job_id, EVENT_STARTED, library: library, roughcut_stem: roughcut_stem)
+      notify(job_id, EVENT_PHASE, phase: PHASE_GATHER, message: "Gathering transcripts and templates…")
 
       inputs = ButterCut::BrollDirectorInputs.gather(
         library_dir: lib_dir.to_s,
@@ -72,11 +76,10 @@ module ButtercutUiSidecar
         hyperframes_dir: @repo_root.join("hyperframes").to_s
       )
 
-      notify(job_id, "broll_phase", phase: "model", message: "Asking the director for candidates…")
-      raw = call_model(inputs, density, score_threshold)
-      candidates = parse_or_retry(raw, inputs, density, score_threshold)
+      notify(job_id, EVENT_PHASE, phase: PHASE_MODEL, message: "Asking the director for candidates…")
+      candidates = JSON.parse(call_model(inputs, density, score_threshold))
 
-      notify(job_id, "broll_phase", phase: "write", message: "Validating and writing manifest…")
+      notify(job_id, EVENT_PHASE, phase: PHASE_WRITE, message: "Validating and writing manifest…")
       manifest_hash = ButterCut::BrollDirectorPostprocess.assemble(
         library_name: inputs[:library_name],
         roughcut_stem: inputs[:roughcut_stem],
@@ -91,7 +94,7 @@ module ButtercutUiSidecar
       warn_if_overwriting(manifest_path)
       ButterCut::BrollManifest.from_hash(manifest_hash).save(manifest_path.to_s)
 
-      notify(job_id, "broll_job_done",
+      notify(job_id, EVENT_DONE,
              manifest_path: manifest_path.to_s,
              entries_written: manifest_hash["entries"].length,
              density: density)
@@ -107,8 +110,7 @@ module ButtercutUiSidecar
     end
 
     def call_model(inputs, density, score_threshold)
-      system = prompt_text
-      user = JSON.pretty_generate(
+      user = JSON.generate(
         LIBRARY_NAME: inputs[:library_name],
         ROUGHCUT_STEM: inputs[:roughcut_stem],
         ROUGHCUT_YAML: inputs[:roughcut],
@@ -118,33 +120,23 @@ module ButtercutUiSidecar
         DENSITY: density,
         SCORE_THRESHOLD: score_threshold
       )
-      @client.complete(system: system, user: user, model: MODEL)
-    end
-
-    def parse_or_retry(raw, _inputs, _density, _score_threshold)
-      JSON.parse(raw)
-    rescue JSON::ParserError => e
-      retry_user = "Your previous response was not valid JSON: #{e.message}\n\n" \
-                   "Return ONLY the JSON array, no surrounding text."
-      raw2 = @client.complete(system: prompt_text, user: retry_user, model: MODEL)
-      JSON.parse(raw2)
+      @client.complete(system: prompt_text, user: user, model: MODEL)
     end
 
     def prompt_text
-      path = @repo_root.join(PROMPT_RELATIVE_PATH)
-      raise "broll-director prompt missing: #{path}" unless path.file?
-      path.read
+      @prompt_text ||= begin
+        path = @repo_root.join(PROMPT_RELATIVE_PATH)
+        raise "broll-director prompt missing: #{path}" unless path.file?
+        path.read
+      end
     end
 
     def warn_if_overwriting(path)
-      return unless path.file?
-      prior = begin
-        YAML.safe_load(path.read, permitted_classes: [Date, Time])
-      rescue StandardError
-        {}
-      end
+      prior = YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true)
       n = (prior["entries"] || []).length
       warn "[broll-director] overwriting existing manifest at #{path} (#{n} prior entries)"
+    rescue Errno::ENOENT
+      nil
     end
   end
 end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "pathname"
+require "securerandom"
 require "yaml"
 require "date"
 
@@ -9,6 +10,7 @@ require "buttercut/broll_director_inputs"
 require "buttercut/broll_director_postprocess"
 require "buttercut/broll_manifest"
 
+require_relative "analysis_job"
 require_relative "anthropic_client"
 
 module ButtercutUiSidecar
@@ -43,31 +45,37 @@ module ButtercutUiSidecar
 
     def validate_and_start!(library:, roughcut_stem:, density: DEFAULT_DENSITY,
                             score_threshold: DEFAULT_SCORE_THRESHOLD)
-      roughcut_path = @libraries_root.join(library, "roughcuts", "#{roughcut_stem}.yaml")
+      stem = safe_roughcut_stem!(roughcut_stem)
+      roughcut_path = @libraries_root.join(library, "roughcuts", "#{stem}.yaml")
       raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
 
-      job_id = @registry.create(library)
+      job_id = "job-#{SecureRandom.hex(6)}"
+      @registry.put(job_id, AnalysisJob.new(id: job_id, library: library))
+
       Thread.new do
         begin
           run!(
-            library: library, roughcut_stem: roughcut_stem,
+            library: library, roughcut_stem: stem,
             density: density, score_threshold: score_threshold,
             job_id: job_id
           )
         rescue StandardError => e
           warn "[broll-director #{job_id}] FAILED #{e.class}: #{e.message}"
           @notifier.notify(EVENT_FAILED, job_id: job_id, message: e.message)
+        ensure
+          @registry.delete(job_id)
         end
       end
       job_id
     end
 
     def run!(library:, roughcut_stem:, density:, score_threshold:, job_id: nil)
+      stem = safe_roughcut_stem!(roughcut_stem)
       lib_dir = @libraries_root.join(library)
-      roughcut_path = lib_dir.join("roughcuts", "#{roughcut_stem}.yaml")
+      roughcut_path = lib_dir.join("roughcuts", "#{stem}.yaml")
       raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
 
-      notify(job_id, EVENT_STARTED, library: library, roughcut_stem: roughcut_stem)
+      notify(job_id, EVENT_STARTED, library: library, roughcut_stem: stem)
       notify(job_id, EVENT_PHASE, phase: PHASE_GATHER, message: "Gathering transcripts and templates…")
 
       inputs = ButterCut::BrollDirectorInputs.gather(
@@ -90,7 +98,7 @@ module ButtercutUiSidecar
         score_threshold: score_threshold
       )
 
-      manifest_path = lib_dir.join("roughcuts", "#{roughcut_stem}.broll.yaml")
+      manifest_path = lib_dir.join("roughcuts", "#{stem}.broll.yaml")
       warn_if_overwriting(manifest_path)
       ButterCut::BrollManifest.from_hash(manifest_hash).save(manifest_path.to_s)
 
@@ -103,6 +111,14 @@ module ButtercutUiSidecar
     end
 
     private
+
+    def safe_roughcut_stem!(roughcut_stem)
+      stem = roughcut_stem.to_s
+      if stem.empty? || stem != File.basename(stem) || stem.include?("/") || stem.include?("\\")
+        raise ArgumentError, "invalid roughcut_stem: #{roughcut_stem.inspect}"
+      end
+      stem
+    end
 
     def notify(job_id, event, **payload)
       return if job_id.nil?
@@ -132,10 +148,13 @@ module ButtercutUiSidecar
     end
 
     def warn_if_overwriting(path)
-      prior = YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true)
-      n = (prior["entries"] || []).length
+      prior = YAML.safe_load(path.read, permitted_classes: [Date, Time], aliases: true) || {}
+      n = Array(prior["entries"]).length
       warn "[broll-director] overwriting existing manifest at #{path} (#{n} prior entries)"
     rescue Errno::ENOENT
+      nil
+    rescue Psych::Exception, TypeError => e
+      warn "[broll-director] overwriting unreadable manifest at #{path} (#{e.class}: #{e.message})"
       nil
     end
   end

--- a/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/broll_director_controller.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+require "yaml"
+require "date"
+
+# Make the parent gem's lib/ available so we can require buttercut/* helpers.
+# Sidecar lives at <repo>/ui/sidecar/lib/buttercut_ui_sidecar/, so the gem's
+# lib/ is four levels up.
+gem_lib = File.expand_path("../../../../lib", __dir__)
+$LOAD_PATH.unshift(gem_lib) unless $LOAD_PATH.include?(gem_lib)
+
+require "buttercut/broll_director_inputs"
+require "buttercut/broll_director_postprocess"
+require "buttercut/broll_manifest"
+
+require_relative "anthropic_client"
+
+module ButtercutUiSidecar
+  # UI-driven b-roll director. Mirrors RoughcutController's shape; loads the
+  # same agent prompt as the broll-director skill so behavior cannot drift.
+  class BrollDirectorController
+    PROMPT_RELATIVE_PATH = ".claude/skills/broll-director/agent_prompt.md"
+    DEFAULT_DENSITY = "medium"
+    DEFAULT_SCORE_THRESHOLD = 0.5
+    MODEL = AnthropicClient::VISION_MODEL
+
+    def initialize(libraries_root:, repo_root:, notifier:, registry:, client:)
+      raise ArgumentError, "libraries_root required" if libraries_root.to_s.empty?
+      raise ArgumentError, "repo_root required" if repo_root.to_s.empty?
+      raise ArgumentError, "notifier required" if notifier.nil?
+      raise ArgumentError, "registry required" if registry.nil?
+      raise ArgumentError, "client required" if client.nil?
+
+      @libraries_root = Pathname.new(libraries_root)
+      @repo_root = Pathname.new(repo_root)
+      @notifier = notifier
+      @registry = registry
+      @client = client
+    end
+
+    def validate_and_start!(library:, roughcut_stem:, density: DEFAULT_DENSITY,
+                            score_threshold: DEFAULT_SCORE_THRESHOLD)
+      job_id = @registry.create(library)
+      Thread.new do
+        begin
+          run!(
+            library: library, roughcut_stem: roughcut_stem,
+            density: density, score_threshold: score_threshold,
+            job_id: job_id
+          )
+        rescue StandardError => e
+          warn "[broll-director #{job_id}] FAILED #{e.class}: #{e.message}"
+          @notifier.notify("broll_job_failed", job_id: job_id, message: e.message)
+        end
+      end
+      job_id
+    end
+
+    def run!(library:, roughcut_stem:, density:, score_threshold:, job_id: nil)
+      lib_dir = @libraries_root.join(library)
+      roughcut_path = lib_dir.join("roughcuts", "#{roughcut_stem}.yaml")
+      raise "rough cut not found at #{roughcut_path}" unless roughcut_path.file?
+
+      notify(job_id, "broll_job_started", library: library, roughcut_stem: roughcut_stem)
+      notify(job_id, "broll_phase", phase: "gather", message: "Gathering transcripts and templates…")
+
+      inputs = ButterCut::BrollDirectorInputs.gather(
+        library_dir: lib_dir.to_s,
+        roughcut_path: roughcut_path.to_s,
+        hyperframes_dir: @repo_root.join("hyperframes").to_s
+      )
+
+      notify(job_id, "broll_phase", phase: "model", message: "Asking the director for candidates…")
+      raw = call_model(inputs, density, score_threshold)
+      candidates = parse_or_retry(raw, inputs, density, score_threshold)
+
+      notify(job_id, "broll_phase", phase: "write", message: "Validating and writing manifest…")
+      manifest_hash = ButterCut::BrollDirectorPostprocess.assemble(
+        library_name: inputs[:library_name],
+        roughcut_stem: inputs[:roughcut_stem],
+        roughcut: inputs[:roughcut],
+        candidates: candidates,
+        available_templates: inputs[:available_templates],
+        density: density,
+        score_threshold: score_threshold
+      )
+
+      manifest_path = lib_dir.join("roughcuts", "#{roughcut_stem}.broll.yaml")
+      warn_if_overwriting(manifest_path)
+      ButterCut::BrollManifest.from_hash(manifest_hash).save(manifest_path.to_s)
+
+      notify(job_id, "broll_job_done",
+             manifest_path: manifest_path.to_s,
+             entries_written: manifest_hash["entries"].length,
+             density: density)
+
+      { manifest_path: manifest_path.to_s, entries_written: manifest_hash["entries"].length }
+    end
+
+    private
+
+    def notify(job_id, event, **payload)
+      return if job_id.nil?
+      @notifier.notify(event, job_id: job_id, **payload)
+    end
+
+    def call_model(inputs, density, score_threshold)
+      system = prompt_text
+      user = JSON.pretty_generate(
+        LIBRARY_NAME: inputs[:library_name],
+        ROUGHCUT_STEM: inputs[:roughcut_stem],
+        ROUGHCUT_YAML: inputs[:roughcut],
+        THEME: inputs[:theme],
+        SOURCE_VIDEOS: inputs[:source_videos],
+        AVAILABLE_TEMPLATES: inputs[:available_templates],
+        DENSITY: density,
+        SCORE_THRESHOLD: score_threshold
+      )
+      @client.complete(system: system, user: user, model: MODEL)
+    end
+
+    def parse_or_retry(raw, _inputs, _density, _score_threshold)
+      JSON.parse(raw)
+    rescue JSON::ParserError => e
+      retry_user = "Your previous response was not valid JSON: #{e.message}\n\n" \
+                   "Return ONLY the JSON array, no surrounding text."
+      raw2 = @client.complete(system: prompt_text, user: retry_user, model: MODEL)
+      JSON.parse(raw2)
+    end
+
+    def prompt_text
+      path = @repo_root.join(PROMPT_RELATIVE_PATH)
+      raise "broll-director prompt missing: #{path}" unless path.file?
+      path.read
+    end
+
+    def warn_if_overwriting(path)
+      return unless path.file?
+      prior = begin
+        YAML.safe_load(path.read, permitted_classes: [Date, Time])
+      rescue StandardError
+        {}
+      end
+      n = (prior["entries"] || []).length
+      warn "[broll-director] overwriting existing manifest at #{path} (#{n} prior entries)"
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "yaml"
+require "pathname"
+require "date"
+require_relative "../../../lib/buttercut_ui_sidecar/broll_director_controller"
+
+RSpec.describe ButtercutUiSidecar::BrollDirectorController do
+  let(:repo_root) { File.expand_path("../../../../..", __dir__) }
+  let(:notifier) { double("notifier", notify: nil) }
+  let(:registry) {
+    Class.new {
+      def initialize; @jobs = {}; end
+      def create(_); id = "job-#{@jobs.size + 1}"; @jobs[id] = { canceled: false }; id; end
+      def canceled?(id); @jobs[id][:canceled]; end
+    }.new
+  }
+
+  let(:fixture_lib) {
+    File.expand_path("../../../../../spec/fixtures/broll_director/sample_library", __dir__)
+  }
+
+  def with_libraries_root
+    Dir.mktmpdir do |tmp|
+      FileUtils.cp_r(fixture_lib, File.join(tmp, "sample-library"))
+      yield Pathname.new(tmp)
+    end
+  end
+
+  it "writes a validated manifest using a stubbed model response" do
+    canned = File.read(File.expand_path(
+      "../../../../../spec/fixtures/broll_director/canned_model_response.json", __dir__
+    ))
+    client = double("anthropic_client")
+    allow(client).to receive(:complete).and_return(canned)
+
+    with_libraries_root do |root|
+      controller = described_class.new(
+        libraries_root: root.to_s,
+        repo_root: repo_root,
+        notifier: notifier,
+        registry: registry,
+        client: client
+      )
+      result = controller.run!(
+        library: "sample-library",
+        roughcut_stem: "sample",
+        density: "medium",
+        score_threshold: 0.5
+      )
+
+      expect(result[:entries_written]).to be > 0
+      manifest_path = root.join("sample-library/roughcuts/sample.broll.yaml")
+      expect(manifest_path.file?).to be true
+      data = YAML.safe_load(manifest_path.read, permitted_classes: [Date, Time])
+      expect(data["library"]).to eq("sample-library")
+      expect(data["roughcut"]).to eq("sample")
+      expect(data["entries"]).not_to be_empty
+    end
+  end
+
+  it "raises when the rough cut does not exist" do
+    with_libraries_root do |root|
+      controller = described_class.new(
+        libraries_root: root.to_s, repo_root: repo_root,
+        notifier: notifier, registry: registry,
+        client: double("c")
+      )
+      expect {
+        controller.run!(library: "sample-library", roughcut_stem: "nope",
+                        density: "medium", score_threshold: 0.5)
+      }.to raise_error(/rough cut not found/)
+    end
+  end
+end

--- a/ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb
+++ b/ui/sidecar/spec/lib/buttercut_ui_sidecar/broll_director_controller_spec.rb
@@ -5,18 +5,13 @@ require "json"
 require "yaml"
 require "pathname"
 require "date"
+require_relative "../../../lib/buttercut_ui_sidecar/job_registry"
 require_relative "../../../lib/buttercut_ui_sidecar/broll_director_controller"
 
 RSpec.describe ButtercutUiSidecar::BrollDirectorController do
   let(:repo_root) { File.expand_path("../../../../..", __dir__) }
   let(:notifier) { double("notifier", notify: nil) }
-  let(:registry) {
-    Class.new {
-      def initialize; @jobs = {}; end
-      def create(_); id = "job-#{@jobs.size + 1}"; @jobs[id] = { canceled: false }; id; end
-      def canceled?(id); @jobs[id][:canceled]; end
-    }.new
-  }
+  let(:registry) { ButtercutUiSidecar::JobRegistry.new }
 
   let(:fixture_lib) {
     File.expand_path("../../../../../spec/fixtures/broll_director/sample_library", __dir__)
@@ -72,6 +67,22 @@ RSpec.describe ButtercutUiSidecar::BrollDirectorController do
         controller.run!(library: "sample-library", roughcut_stem: "nope",
                         density: "medium", score_threshold: 0.5)
       }.to raise_error(/rough cut not found/)
+    end
+  end
+
+  it "rejects roughcut_stem values that try to escape the roughcuts directory" do
+    with_libraries_root do |root|
+      controller = described_class.new(
+        libraries_root: root.to_s, repo_root: repo_root,
+        notifier: notifier, registry: registry,
+        client: double("c")
+      )
+      ["../../../etc/passwd", "foo/bar", "..\\\\evil", "", "a/b"].each do |bad|
+        expect {
+          controller.run!(library: "sample-library", roughcut_stem: bad,
+                          density: "medium", score_threshold: 0.5)
+        }.to raise_error(ArgumentError, /invalid roughcut_stem/), "expected reject for #{bad.inspect}"
+      end
     end
   end
 end

--- a/ui/sidecar/spec/spec_helper.rb
+++ b/ui/sidecar/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path("..", __dir__)
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)
 
 RSpec.configure do |c|
   c.expect_with(:rspec) { |e| e.syntax = :expect }

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -165,6 +165,26 @@ async fn start_roughcut(library: String, brief_id: String) -> Result<Value, Stri
 }
 
 #[tauri::command]
+async fn start_broll_director(
+    library: String,
+    roughcut_stem: String,
+    density: Option<String>,
+    score_threshold: Option<f64>,
+) -> Result<Value, String> {
+    sidecar::call(
+        "start_broll_director",
+        json!({
+            "library": library,
+            "roughcut_stem": roughcut_stem,
+            "density": density,
+            "score_threshold": score_threshold,
+        }),
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 async fn export_roughcut_artifacts(
     library: String,
     yaml_path: String,
@@ -370,6 +390,7 @@ pub fn run() {
             upsert_brief,
             fork_brief,
             start_roughcut,
+            start_broll_director,
             export_roughcut_artifacts,
             send_to_resolve,
             read_library_text_file

--- a/ui/src/ipc/events.ts
+++ b/ui/src/ipc/events.ts
@@ -72,3 +72,31 @@ export async function listenRoughcutJobEvents(
 ): Promise<UnlistenFn> {
   return listenSidecarJobChannel<RoughcutJobEvent>(jobId, handler);
 }
+
+export type BrollDirectorJobEvent =
+  | {
+      method: "broll_job_started";
+      params: { job_id: string; library: string; roughcut_stem: string; ts?: string };
+    }
+  | {
+      method: "broll_phase";
+      params: { job_id: string; phase: string; message?: string; ts?: string };
+    }
+  | {
+      method: "broll_job_done";
+      params: {
+        job_id: string;
+        manifest_path: string;
+        entries_written: number;
+        density?: string;
+        ts?: string;
+      };
+    }
+  | { method: "broll_job_failed"; params: { job_id: string; message: string; ts?: string } };
+
+export async function listenBrollDirectorJobEvents(
+  jobId: string,
+  handler: (event: BrollDirectorJobEvent) => void,
+): Promise<UnlistenFn> {
+  return listenSidecarJobChannel<BrollDirectorJobEvent>(jobId, handler);
+}

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -120,13 +120,20 @@ export async function startRoughcut(library: string, briefId: string): Promise<{
   return invoke("start_roughcut", { library, briefId });
 }
 
+export type BrollDirectorDensity = "low" | "medium" | "high";
+
 export async function startBrollDirector(args: {
   library: string;
   roughcutStem: string;
-  density?: string;
+  density?: BrollDirectorDensity;
   scoreThreshold?: number;
 }): Promise<string> {
-  // The sidecar's `broll_director_start` returns the raw job_id string.
+  if (
+    args.scoreThreshold != null &&
+    (!Number.isFinite(args.scoreThreshold) || args.scoreThreshold < 0 || args.scoreThreshold > 1)
+  ) {
+    throw new Error("scoreThreshold must be a finite number between 0 and 1");
+  }
   return invoke<string>("start_broll_director", {
     library: args.library,
     roughcutStem: args.roughcutStem,

--- a/ui/src/ipc/sidecar.ts
+++ b/ui/src/ipc/sidecar.ts
@@ -120,6 +120,21 @@ export async function startRoughcut(library: string, briefId: string): Promise<{
   return invoke("start_roughcut", { library, briefId });
 }
 
+export async function startBrollDirector(args: {
+  library: string;
+  roughcutStem: string;
+  density?: string;
+  scoreThreshold?: number;
+}): Promise<string> {
+  // The sidecar's `broll_director_start` returns the raw job_id string.
+  return invoke<string>("start_broll_director", {
+    library: args.library,
+    roughcutStem: args.roughcutStem,
+    density: args.density ?? null,
+    scoreThreshold: args.scoreThreshold ?? null,
+  });
+}
+
 export async function exportRoughcutArtifacts(
   library: string,
   yamlPath: string,

--- a/ui/src/routes/library/AddBrollButton.tsx
+++ b/ui/src/routes/library/AddBrollButton.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from "react";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { startBrollDirector } from "../../ipc/sidecar";
+import { listenBrollDirectorJobEvents, type BrollDirectorJobEvent } from "../../ipc/events";
+
+type Props = {
+  library: string;
+  roughcutStem: string;
+  hasManifest: boolean;
+  manifestEntryCount?: number;
+};
+
+type Phase = "idle" | "gather" | "model" | "write" | "done" | "error";
+
+export function AddBrollButton({
+  library,
+  roughcutStem,
+  hasManifest,
+  manifestEntryCount,
+}: Props) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [message, setMessage] = useState<string>("");
+  const [entries, setEntries] = useState<number | undefined>(manifestEntryCount);
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+  const activeJobIdRef = useRef<string | null>(null);
+
+  // Tear down any subscription on unmount.
+  useEffect(() => {
+    return () => {
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+      activeJobIdRef.current = null;
+    };
+  }, []);
+
+  const disposeListener = () => {
+    unlistenRef.current?.();
+    unlistenRef.current = null;
+    activeJobIdRef.current = null;
+  };
+
+  const running = phase !== "idle" && phase !== "done" && phase !== "error";
+
+  const handleClick = async () => {
+    if (running) return;
+    setPhase("gather");
+    setMessage("Starting…");
+
+    try {
+      // Sidecar's broll_director_start returns the raw job_id string.
+      const jobId = await startBrollDirector({ library, roughcutStem });
+      activeJobIdRef.current = jobId;
+
+      const unlisten = await listenBrollDirectorJobEvents(jobId, (ev: BrollDirectorJobEvent) => {
+        switch (ev.method) {
+          case "broll_job_started":
+            // Confirms our job_id; nothing else to do.
+            break;
+          case "broll_phase":
+            setPhase((ev.params.phase as Phase) ?? "gather");
+            setMessage(ev.params.message ?? ev.params.phase);
+            break;
+          case "broll_job_done":
+            setPhase("done");
+            setEntries(ev.params.entries_written);
+            setMessage(`${ev.params.entries_written} graphics ready to render`);
+            disposeListener();
+            break;
+          case "broll_job_failed":
+            setPhase("error");
+            setMessage(ev.params.message ?? "Director failed");
+            disposeListener();
+            break;
+          default:
+            break;
+        }
+      });
+      unlistenRef.current = unlisten;
+    } catch (err) {
+      setPhase("error");
+      setMessage(err instanceof Error ? err.message : String(err));
+      disposeListener();
+    }
+  };
+
+  const label = (() => {
+    if (running) return message || "Working…";
+    if (phase === "done") return `B-Roll ready (${entries ?? "?"})`;
+    if (phase === "error") return `Failed — retry`;
+    if (hasManifest) return `Re-run B-Roll Director (${manifestEntryCount ?? "?"} entries)`;
+    return "Add B-Roll";
+  })();
+
+  return (
+    <button
+      type="button"
+      className="add-broll-button"
+      disabled={running}
+      onClick={handleClick}
+      aria-busy={running}
+      title={
+        hasManifest
+          ? "Replaces existing manifest"
+          : "Generate b-roll manifest from this rough cut"
+      }
+    >
+      {label}
+    </button>
+  );
+}

--- a/ui/src/routes/library/AddBrollButton.tsx
+++ b/ui/src/routes/library/AddBrollButton.tsx
@@ -12,6 +12,19 @@ type Props = {
 
 type Phase = "idle" | "gather" | "model" | "write" | "done" | "error";
 
+const PHASES: ReadonlySet<Phase> = new Set([
+  "idle",
+  "gather",
+  "model",
+  "write",
+  "done",
+  "error",
+]);
+
+function toPhase(value: string | undefined): Phase {
+  return value && PHASES.has(value as Phase) ? (value as Phase) : "gather";
+}
+
 export function AddBrollButton({
   library,
   roughcutStem,
@@ -44,8 +57,8 @@ export function AddBrollButton({
           case "broll_job_started":
             break;
           case "broll_phase":
-            setPhase((ev.params.phase as Phase) ?? "gather");
-            setMessage(ev.params.message ?? ev.params.phase);
+            setPhase(toPhase(ev.params.phase));
+            setMessage(ev.params.message ?? ev.params.phase ?? "");
             break;
           case "broll_job_done":
             setPhase("done");

--- a/ui/src/routes/library/AddBrollButton.tsx
+++ b/ui/src/routes/library/AddBrollButton.tsx
@@ -20,24 +20,14 @@ export function AddBrollButton({
 }: Props) {
   const [phase, setPhase] = useState<Phase>("idle");
   const [message, setMessage] = useState<string>("");
-  const [entries, setEntries] = useState<number | undefined>(manifestEntryCount);
   const unlistenRef = useRef<UnlistenFn | null>(null);
-  const activeJobIdRef = useRef<string | null>(null);
-
-  // Tear down any subscription on unmount.
-  useEffect(() => {
-    return () => {
-      unlistenRef.current?.();
-      unlistenRef.current = null;
-      activeJobIdRef.current = null;
-    };
-  }, []);
 
   const disposeListener = () => {
     unlistenRef.current?.();
     unlistenRef.current = null;
-    activeJobIdRef.current = null;
   };
+
+  useEffect(() => disposeListener, []);
 
   const running = phase !== "idle" && phase !== "done" && phase !== "error";
 
@@ -47,14 +37,11 @@ export function AddBrollButton({
     setMessage("Starting…");
 
     try {
-      // Sidecar's broll_director_start returns the raw job_id string.
       const jobId = await startBrollDirector({ library, roughcutStem });
-      activeJobIdRef.current = jobId;
 
       const unlisten = await listenBrollDirectorJobEvents(jobId, (ev: BrollDirectorJobEvent) => {
         switch (ev.method) {
           case "broll_job_started":
-            // Confirms our job_id; nothing else to do.
             break;
           case "broll_phase":
             setPhase((ev.params.phase as Phase) ?? "gather");
@@ -62,7 +49,6 @@ export function AddBrollButton({
             break;
           case "broll_job_done":
             setPhase("done");
-            setEntries(ev.params.entries_written);
             setMessage(`${ev.params.entries_written} graphics ready to render`);
             disposeListener();
             break;
@@ -70,8 +56,6 @@ export function AddBrollButton({
             setPhase("error");
             setMessage(ev.params.message ?? "Director failed");
             disposeListener();
-            break;
-          default:
             break;
         }
       });
@@ -83,13 +67,13 @@ export function AddBrollButton({
     }
   };
 
-  const label = (() => {
+  function buttonLabel(): string {
     if (running) return message || "Working…";
-    if (phase === "done") return `B-Roll ready (${entries ?? "?"})`;
-    if (phase === "error") return `Failed — retry`;
+    if (phase === "done") return message || "B-Roll ready";
+    if (phase === "error") return "Failed — retry";
     if (hasManifest) return `Re-run B-Roll Director (${manifestEntryCount ?? "?"} entries)`;
     return "Add B-Roll";
-  })();
+  }
 
   return (
     <button
@@ -104,7 +88,7 @@ export function AddBrollButton({
           : "Generate b-roll manifest from this rough cut"
       }
     >
-      {label}
+      {buttonLabel()}
     </button>
   );
 }

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -17,6 +17,7 @@ import { parseRoughcutRecipeJson, type RecipeJson } from "../../lib/recipeTypes"
 import type { VideoEntry } from "./types";
 import RoughcutStagePreview from "./RoughcutStagePreview";
 import RoughcutTimeline from "./RoughcutTimeline";
+import { AddBrollButton } from "./AddBrollButton";
 import {
   listenRoughcutJobEvents,
   type RoughcutArtifactPaths,
@@ -565,6 +566,11 @@ export default function BriefComposer({ library, videos }: { library: string; vi
                 >
                   Send to Resolve
                 </button>
+                <AddBrollButton
+                  library={library}
+                  roughcutStem={basenameNoExt(donePaths.yaml_path)}
+                  hasManifest={false}
+                />
               </div>
               {exportStatus && <p className="brief-composer__phase">{exportStatus}</p>}
               {exportError && <pre className="brief-composer__error">{exportError}</pre>}


### PR DESCRIPTION
Closes #30. Editorial layer of the Hyperframes epic (#26).

## Summary

- Director skill (`.claude/skills/broll-director/`) — given an existing rough cut + the transcripts/visual transcripts/summaries of the videos it references, emits a sibling `<roughcut>.broll.yaml` manifest the existing `render-broll` skill (#28) and roughcut integration (#33) consume.
- UI button — added to the rough-cut export sheet in `BriefComposer.tsx`. Shares the same `agent_prompt.md` as the skill via the new `BrollDirectorController` sidecar so the two surfaces cannot drift.
- Pure-Ruby helpers under `lib/buttercut/` (`BrollDirectorInputs`, `BrollDirectorPostprocess`) handle gathering inputs from disk and turning model output into a validated manifest (`BrollManifest.from_hash` is the validation gate before write).

## Architecture (settled in spec)

- **Per-rough-cut, cut-relative timing.** Director runs after a rough cut is approved; manifest's `start`/`end` are seconds into the rough cut. Matches the manifest schema as shipped.
- **Two surfaces, one prompt.** Skill and sidecar both load `.claude/skills/broll-director/agent_prompt.md`.
- **Template discovery from filesystem.** Director reads `hyperframes/compositions/*/README.md` so adding templates (#29) needs no director change.
- **Density / threshold are caller inputs**, not yet a library.yaml block — #31's territory.
- **Re-run overwrites** with a one-line warning; existing rendered MP4s under `broll/` are untouched.
- **UI button stops at manifest write** — render and re-export are #34's territory.

Spec: `docs/superpowers/specs/2026-05-07-broll-director-design.md`
Plan: `docs/superpowers/plans/2026-05-07-broll-director.md`

## Test plan

- [x] Gem suite: `bundle exec rspec` — 230 examples, 0 failures, 3 pending (pre-existing)
- [x] Sidecar suite: `cd ui/sidecar && bundle exec rspec` — 105 examples, 0 failures
- [x] UI typecheck: `cd ui && ./node_modules/.bin/tsc --noEmit` — 0 errors
- [x] `BrollManifest.from_hash` is called before any manifest write (validation gate)
- [ ] **Manual smoke not part of automated coverage:** running the live model end-to-end against a real library. The controller spec exercises the full pipeline against a canned model response.

## Follow-ups (intentionally out of scope)

- Surface a `brollManifest` field on the rough-cut artifact response so the button can show entry counts and "Re-run B-Roll Director" labeling (button currently always renders as "Add B-Roll" / `hasManifest={false}`).
- `broll:` block in library.yaml + migration → #31
- Late-render workflow / non-destructive swap-in-place → #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * B-Roll Director: generate B-roll manifests from rough cuts with density and score-threshold controls; UI button, background job, and frontend command to start and monitor jobs with lifecycle events and progress messages.
  * Job run overwrites existing manifest (does not delete rendered media) and reports entries written.

* **Documentation**
  * Added design, plan, and canonical agent prompt documenting inputs, JSON schema, and post-processing rules.

* **Tests**
  * New unit/integration specs and fixtures covering input validation, postprocessing, controller behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->