### PR TITLE
feat: starter Hyperframes templates (term-card, step-counter, quote, stat, comparison) (#29)

### DIFF
--- a/hyperframes/compositions/README.md
+++ b/hyperframes/compositions/README.md
@@ -1,0 +1,34 @@
+# Hyperframes compositions
+
+Each subdirectory is a self-contained Hyperframes composition: HTML + GSAP + a `hyperframes.json` config. The b-roll director auto-discovers templates by walking this directory and reading each composition's `README.md` (see `lib/buttercut/broll_director_inputs.rb#load_templates`), so any new template added here becomes available to the director without further wiring.
+
+## Catalog
+
+| Template       | Purpose                                              | Key `content` fields                          |
+|----------------|------------------------------------------------------|-----------------------------------------------|
+| code-callout   | Monospace command + caption over a terminal/IDE shot | `command`, `caption`                          |
+| term-card      | Vocabulary term + definition                         | `term`, `definition`                          |
+| step-counter   | "Step N of M" structural marker                      | `step`, `total`, `title`                      |
+| quote          | Pull quote with optional attribution                 | `quote`, `attribution`                        |
+| stat           | Big number + label + optional caption                | `value`, `label`, `caption`                   |
+| comparison     | Two-column compare/contrast                          | `left_label`, `left_text`, `right_label`, `right_text` |
+
+See each composition's own `README.md` for full variable shape, required vs. optional, and length guidance.
+
+## Common conventions
+
+All templates in this directory follow the same conventions so the render pipeline can treat them uniformly.
+
+**Theme tokens.** Each composition takes a `theme` object alongside its content variables. Recognized keys:
+
+- `color_bg`, `color_fg`, `color_accent` — applied to `--bg`, `--fg`, `--accent` CSS custom properties.
+- `font_display`, `font_mono` — applied to `--font-display`, `--font-mono`.
+- `motion` — one of `snappy` (default), `smooth`, or `minimal`. Controls in/out durations and the amount of translation/scale on entrance.
+
+Unset tokens fall back to the built-in `tutorial-dark` defaults so renders without a theme block still look right. See `themes/*.yaml` at the repo root for preset values.
+
+**Duration.** Fixed at 5s per composition. Hyperframes resolves `data-duration` at compile time, so a runtime `duration` variable cannot change the encoded length. Variable durations need a pre-render templating step — tracked as a follow-up.
+
+**Aspect.** 1920x1080 only at the moment. 9:16 variants are a follow-up.
+
+**Animation library.** GSAP, loaded from CDN. Each composition exposes its timeline at `window.__timelines["<id>"]` for the Hyperframes runtime.

--- a/hyperframes/compositions/comparison/README.md
+++ b/hyperframes/compositions/comparison/README.md
@@ -1,0 +1,19 @@
+# comparison
+
+Two-column compare/contrast. The right column is highlighted in the accent color — use it for the "after," "good," or "preferred" side.
+
+## Variables
+
+| Name        | Type   | Required | Description                                                                                |
+|-------------|--------|----------|--------------------------------------------------------------------------------------------|
+| left_label  | string | yes      | Short header for the left column (e.g. `Before`, `Old way`).                               |
+| left_text   | string | yes      | One-sentence description of the left side. Keep under ~10 words.                           |
+| right_label | string | yes      | Short header for the right column (e.g. `After`, `New way`).                               |
+| right_text  | string | yes      | One-sentence description of the right side. Keep under ~10 words.                          |
+| theme       | object | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_fg, color_accent, motion). |
+
+**Duration:** fixed at 5s.
+
+**Motion:** respects `theme.motion`. The two columns slide in from opposite sides with a small stagger; the `vs` divider pops in with a back-out overshoot.
+
+Aspect: 1920x1080. 9:16 variant TBD.

--- a/hyperframes/compositions/comparison/hyperframes.json
+++ b/hyperframes/compositions/comparison/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "blocks",
+    "components": "components",
+    "assets": "assets"
+  }
+}

--- a/hyperframes/compositions/comparison/index.html
+++ b/hyperframes/compositions/comparison/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[
+    {"id":"left_label","type":"string","label":"Left label","default":"Before"},
+    {"id":"left_text","type":"string","label":"Left text","default":"Manual rebase, error-prone"},
+    {"id":"right_label","type":"string","label":"Right label","default":"After"},
+    {"id":"right_text","type":"string","label":"Right text","default":"Interactive rebase, in-flight fixes"},
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
+  ]'
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>comparison</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d0d0d;
+        --fg: #f5f5f4;
+        --accent: #ff6b35;
+        --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
+      .col {
+        background: rgba(255,255,255,0.03);
+        border: 1px solid rgba(255,255,255,0.08);
+        border-radius: 24px;
+        padding: 64px;
+        min-height: 600px;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="comparison"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="w-full h-full flex items-center justify-center px-32 gap-12">
+        <div id="left" class="col opacity-0 flex-1 max-w-[760px]">
+          <div id="ll" class="text-sm uppercase tracking-[0.3em] mono mb-6" style="color: var(--muted);">Before</div>
+          <div id="lt" class="text-4xl leading-snug font-medium" style="color: var(--fg);">Manual rebase, error-prone</div>
+        </div>
+        <div id="vs" class="opacity-0 mono text-3xl uppercase tracking-[0.3em]" style="color: var(--accent);">vs</div>
+        <div id="right" class="col opacity-0 flex-1 max-w-[760px]" style="border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent);">
+          <div id="rl" class="text-sm uppercase tracking-[0.3em] mono mb-6" style="color: var(--accent);">After</div>
+          <div id="rt" class="text-4xl leading-snug font-medium" style="color: var(--fg);">Interactive rebase, in-flight fixes</div>
+        </div>
+      </div>
+    </div>
+    <script>
+      const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
+      const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
+
+      document.getElementById('ll').textContent = vars.left_label || 'Before';
+      document.getElementById('lt').textContent = vars.left_text || '';
+      document.getElementById('rl').textContent = vars.right_label || 'After';
+      document.getElementById('rt').textContent = vars.right_text || '';
+
+      const motion = (theme.motion || 'snappy');
+      const cfg = motion === 'minimal'
+        ? { dur: 0.3, ease: 'none', x: 0, gap: 0.0 }
+        : motion === 'smooth'
+          ? { dur: 0.7, ease: 'power2.out', x: 24, gap: 0.15 }
+          : { dur: 0.45, ease: 'power3.out', x: 32, gap: 0.12 };
+
+      const tl = gsap.timeline({ paused: true });
+      tl.fromTo('#left',  { opacity: 0, x: -cfg.x }, { opacity: 1, x: 0, duration: cfg.dur, ease: cfg.ease }, 0);
+      tl.fromTo('#right', { opacity: 0, x:  cfg.x }, { opacity: 1, x: 0, duration: cfg.dur, ease: cfg.ease }, cfg.gap);
+      tl.fromTo('#vs',    { opacity: 0, scale: 0.7 }, { opacity: 1, scale: 1, duration: cfg.dur, ease: 'back.out(1.7)' }, cfg.dur * 0.6);
+      tl.to(['#left','#right','#vs'], { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2 - 0.5) }, cfg.dur + 0.5);
+      tl.to(['#left','#right','#vs'], { opacity: 0, duration: cfg.dur, ease: 'power2.in' }, Math.max(cfg.dur, duration - cfg.dur));
+      window.__timelines = window.__timelines || {};
+      window.__timelines["comparison"] = tl;
+    </script>
+  </body>
+</html>

--- a/hyperframes/compositions/comparison/index.html
+++ b/hyperframes/compositions/comparison/index.html
@@ -82,12 +82,19 @@
           ? { dur: 0.7, ease: 'power2.out', x: 24, gap: 0.15 }
           : { dur: 0.45, ease: 'power3.out', x: 32, gap: 0.12 };
 
+      const isMinimal = motion === 'minimal';
+      const vsFrom = isMinimal ? { opacity: 0 } : { opacity: 0, scale: 0.7 };
+      const vsTo = isMinimal
+        ? { opacity: 1, duration: cfg.dur, ease: 'none' }
+        : { opacity: 1, scale: 1, duration: cfg.dur, ease: 'back.out(1.7)' };
+      const outEase = isMinimal ? 'none' : 'power2.in';
+
       const tl = gsap.timeline({ paused: true });
       tl.fromTo('#left',  { opacity: 0, x: -cfg.x }, { opacity: 1, x: 0, duration: cfg.dur, ease: cfg.ease }, 0);
       tl.fromTo('#right', { opacity: 0, x:  cfg.x }, { opacity: 1, x: 0, duration: cfg.dur, ease: cfg.ease }, cfg.gap);
-      tl.fromTo('#vs',    { opacity: 0, scale: 0.7 }, { opacity: 1, scale: 1, duration: cfg.dur, ease: 'back.out(1.7)' }, cfg.dur * 0.6);
+      tl.fromTo('#vs', vsFrom, vsTo, cfg.dur * 0.6);
       tl.to(['#left','#right','#vs'], { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2 - 0.5) }, cfg.dur + 0.5);
-      tl.to(['#left','#right','#vs'], { opacity: 0, duration: cfg.dur, ease: 'power2.in' }, Math.max(cfg.dur, duration - cfg.dur));
+      tl.to(['#left','#right','#vs'], { opacity: 0, duration: cfg.dur, ease: outEase }, Math.max(cfg.dur, duration - cfg.dur));
       window.__timelines = window.__timelines || {};
       window.__timelines["comparison"] = tl;
     </script>

--- a/hyperframes/compositions/comparison/index.html
+++ b/hyperframes/compositions/comparison/index.html
@@ -6,7 +6,6 @@
     {"id":"left_text","type":"string","label":"Left text","default":"Manual rebase, error-prone"},
     {"id":"right_label","type":"string","label":"Right label","default":"After"},
     {"id":"right_text","type":"string","label":"Right text","default":"Interactive rebase, in-flight fixes"},
-    {"id":"duration","type":"number","label":"Duration","default":5},
     {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >

--- a/hyperframes/compositions/quote/README.md
+++ b/hyperframes/compositions/quote/README.md
@@ -1,0 +1,17 @@
+# quote
+
+Pull quote for emphasis. Use sparingly — works best when the speaker says something quotable that lands and you want the audience to sit with it.
+
+## Variables
+
+| Name        | Type   | Required | Description                                                                                |
+|-------------|--------|----------|--------------------------------------------------------------------------------------------|
+| quote       | string | yes      | The quote text. Keep under ~16 words for legibility.                                       |
+| attribution | string | no       | Person, role, or source. Omit for unattributed pull quotes.                                |
+| theme       | object | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_fg, color_accent, motion). |
+
+**Duration:** fixed at 5s.
+
+**Motion:** respects `theme.motion`. The fade is gentler than other templates so the quote feels considered, not popped.
+
+Aspect: 1920x1080. 9:16 variant TBD.

--- a/hyperframes/compositions/quote/hyperframes.json
+++ b/hyperframes/compositions/quote/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "blocks",
+    "components": "components",
+    "assets": "assets"
+  }
+}

--- a/hyperframes/compositions/quote/index.html
+++ b/hyperframes/compositions/quote/index.html
@@ -4,7 +4,6 @@
   data-composition-variables='[
     {"id":"quote","type":"string","label":"Quote","default":"Make it work, make it right, make it fast."},
     {"id":"attribution","type":"string","label":"Attribution","default":"Kent Beck"},
-    {"id":"duration","type":"number","label":"Duration","default":5},
     {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >
@@ -52,7 +51,7 @@
         <div id="card" class="opacity-0 max-w-[75%] relative">
           <div class="mark" style="color: var(--accent);">&ldquo;</div>
           <div id="quote" class="text-6xl leading-tight font-medium" style="color: var(--fg); font-style: italic;">Make it work, make it right, make it fast.</div>
-          <div class="mt-10 flex items-center gap-4">
+          <div id="attr-row" class="mt-10 flex items-center gap-4">
             <div class="h-[2px] w-12" style="background: var(--accent);"></div>
             <div id="attr" class="text-2xl tracking-wide" style="color: var(--muted);">Kent Beck</div>
           </div>
@@ -72,7 +71,12 @@
       if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
 
       document.getElementById('quote').textContent = vars.quote || '';
-      document.getElementById('attr').textContent = vars.attribution || '';
+      const attribution = (vars.attribution || '').trim();
+      if (attribution) {
+        document.getElementById('attr').textContent = attribution;
+      } else {
+        document.getElementById('attr-row').style.display = 'none';
+      }
 
       const motion = (theme.motion || 'snappy');
       const cfg = motion === 'minimal'

--- a/hyperframes/compositions/quote/index.html
+++ b/hyperframes/compositions/quote/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[
+    {"id":"quote","type":"string","label":"Quote","default":"Make it work, make it right, make it fast."},
+    {"id":"attribution","type":"string","label":"Attribution","default":"Kent Beck"},
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
+  ]'
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>quote</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d0d0d;
+        --fg: #f5f5f4;
+        --accent: #ff6b35;
+        --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
+      .mark {
+        position: absolute;
+        top: -80px;
+        left: -40px;
+        font-size: 18rem;
+        line-height: 1;
+        font-family: Georgia, 'Times New Roman', serif;
+        font-style: italic;
+        opacity: 0.18;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="quote"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="w-full h-full flex items-center justify-center px-40">
+        <div id="card" class="opacity-0 max-w-[75%] relative">
+          <div class="mark" style="color: var(--accent);">&ldquo;</div>
+          <div id="quote" class="text-6xl leading-tight font-medium" style="color: var(--fg); font-style: italic;">Make it work, make it right, make it fast.</div>
+          <div class="mt-10 flex items-center gap-4">
+            <div class="h-[2px] w-12" style="background: var(--accent);"></div>
+            <div id="attr" class="text-2xl tracking-wide" style="color: var(--muted);">Kent Beck</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
+      const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
+
+      document.getElementById('quote').textContent = vars.quote || '';
+      document.getElementById('attr').textContent = vars.attribution || '';
+
+      const motion = (theme.motion || 'snappy');
+      const cfg = motion === 'minimal'
+        ? { dur: 0.4, ease: 'none', y: 0 }
+        : motion === 'smooth'
+          ? { dur: 0.9, ease: 'power2.out', y: 12 }
+          : { dur: 0.6, ease: 'power3.out', y: 16 };
+
+      const tl = gsap.timeline({ paused: true });
+      tl.fromTo('#card', { opacity: 0, y: cfg.y }, { opacity: 1, y: 0, duration: cfg.dur, ease: cfg.ease }, 0);
+      tl.to('#card', { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2) }, cfg.dur);
+      tl.to('#card', { opacity: 0, y: -cfg.y, duration: cfg.dur, ease: cfg.ease.replace('.out', '.in') }, Math.max(cfg.dur, duration - cfg.dur));
+      window.__timelines = window.__timelines || {};
+      window.__timelines["quote"] = tl;
+    </script>
+  </body>
+</html>

--- a/hyperframes/compositions/stat/README.md
+++ b/hyperframes/compositions/stat/README.md
@@ -1,0 +1,18 @@
+# stat
+
+Large number + label, with optional caption. Use when a specific figure is the point of the moment.
+
+## Variables
+
+| Name    | Type   | Required | Description                                                                                |
+|---------|--------|----------|--------------------------------------------------------------------------------------------|
+| value   | string | yes      | The headline value as a string (so units like `%`, `x`, `ms`, `$` survive). Keep ≤ ~6 chars. |
+| label   | string | yes      | Short description of what the value measures. Keep under ~5 words.                         |
+| caption | string | no       | Optional smaller mono caption underneath (e.g. source, sample size).                       |
+| theme   | object | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_fg, color_accent, motion). |
+
+**Duration:** fixed at 5s.
+
+**Motion:** respects `theme.motion`. `snappy` uses a slight `back.out` overshoot on the value for emphasis; `smooth` and `minimal` scale in calmly.
+
+Aspect: 1920x1080. 9:16 variant TBD.

--- a/hyperframes/compositions/stat/hyperframes.json
+++ b/hyperframes/compositions/stat/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "blocks",
+    "components": "components",
+    "assets": "assets"
+  }
+}

--- a/hyperframes/compositions/stat/index.html
+++ b/hyperframes/compositions/stat/index.html
@@ -5,7 +5,6 @@
     {"id":"value","type":"string","label":"Value","default":"42%"},
     {"id":"label","type":"string","label":"Label","default":"faster builds"},
     {"id":"caption","type":"string","label":"Caption","default":""},
-    {"id":"duration","type":"number","label":"Duration","default":5},
     {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >
@@ -61,7 +60,13 @@
 
       document.getElementById('value').textContent = vars.value || '';
       document.getElementById('label').textContent = vars.label || '';
-      document.getElementById('caption').textContent = vars.caption || '';
+      const captionText = (vars.caption || '').trim();
+      const captionEl = document.getElementById('caption');
+      if (captionText) {
+        captionEl.textContent = captionText;
+      } else {
+        captionEl.style.display = 'none';
+      }
 
       const motion = (theme.motion || 'snappy');
       const cfg = motion === 'minimal'

--- a/hyperframes/compositions/stat/index.html
+++ b/hyperframes/compositions/stat/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[
+    {"id":"value","type":"string","label":"Value","default":"42%"},
+    {"id":"label","type":"string","label":"Label","default":"faster builds"},
+    {"id":"caption","type":"string","label":"Caption","default":""},
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
+  ]'
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>stat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d0d0d;
+        --fg: #f5f5f4;
+        --accent: #ff6b35;
+        --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="stat"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="w-full h-full flex items-center justify-center">
+        <div id="card" class="opacity-0 text-center max-w-[80%]">
+          <div id="value" class="font-bold leading-none tracking-tight" style="color: var(--accent); font-size: 22rem;">42%</div>
+          <div id="label" class="text-5xl mt-8 font-semibold" style="color: var(--fg);">faster builds</div>
+          <div id="caption" class="text-2xl mt-6 mono" style="color: var(--muted);"></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
+      const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
+
+      document.getElementById('value').textContent = vars.value || '';
+      document.getElementById('label').textContent = vars.label || '';
+      document.getElementById('caption').textContent = vars.caption || '';
+
+      const motion = (theme.motion || 'snappy');
+      const cfg = motion === 'minimal'
+        ? { dur: 0.3, ease: 'none', scale: 1 }
+        : motion === 'smooth'
+          ? { dur: 0.7, ease: 'power2.out', scale: 0.94 }
+          : { dur: 0.45, ease: 'back.out(1.7)', scale: 0.85 };
+
+      const tl = gsap.timeline({ paused: true });
+      tl.fromTo('#value', { opacity: 0, scale: cfg.scale }, { opacity: 1, scale: 1, duration: cfg.dur, ease: cfg.ease }, 0);
+      tl.fromTo('#label', { opacity: 0, y: 10 }, { opacity: 1, y: 0, duration: cfg.dur, ease: 'power2.out' }, cfg.dur * 0.5);
+      tl.to('#card', { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2 - 0.5) }, cfg.dur + 0.5);
+      tl.to('#card', { opacity: 0, duration: cfg.dur, ease: 'power2.in' }, Math.max(cfg.dur, duration - cfg.dur));
+      window.__timelines = window.__timelines || {};
+      window.__timelines["stat"] = tl;
+    </script>
+  </body>
+</html>

--- a/hyperframes/compositions/step-counter/README.md
+++ b/hyperframes/compositions/step-counter/README.md
@@ -1,0 +1,18 @@
+# step-counter
+
+"Step N of M" + a short title. Use to mark structural moments in a tutorial.
+
+## Variables
+
+| Name     | Type   | Required | Description                                                                                |
+|----------|--------|----------|--------------------------------------------------------------------------------------------|
+| step     | number | yes      | Current step number (1-based).                                                             |
+| total    | number | yes      | Total number of steps.                                                                     |
+| title    | string | yes      | Short title for the step. Keep under ~6 words.                                             |
+| theme    | object | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_fg, color_accent, motion). |
+
+**Duration:** fixed at 5s.
+
+**Motion:** respects `theme.motion`. Slides in from the left rather than up — feels more "advancing through steps."
+
+Aspect: 1920x1080. 9:16 variant TBD.

--- a/hyperframes/compositions/step-counter/hyperframes.json
+++ b/hyperframes/compositions/step-counter/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "blocks",
+    "components": "components",
+    "assets": "assets"
+  }
+}

--- a/hyperframes/compositions/step-counter/index.html
+++ b/hyperframes/compositions/step-counter/index.html
@@ -65,8 +65,13 @@
       if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
       if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
 
-      document.getElementById('step').textContent = String(vars.step ?? 1);
-      document.getElementById('total').textContent = String(vars.total ?? 3);
+      const parsedStep = Number(vars.step);
+      const parsedTotal = Number(vars.total);
+      const totalValue = Number.isFinite(parsedTotal) ? Math.max(1, Math.floor(parsedTotal)) : 3;
+      const stepValue = Number.isFinite(parsedStep) ? Math.max(1, Math.floor(parsedStep)) : 1;
+      const safeStep = Math.min(stepValue, totalValue);
+      document.getElementById('step').textContent = String(safeStep);
+      document.getElementById('total').textContent = String(totalValue);
       document.getElementById('title').textContent = vars.title || '';
 
       const motion = (theme.motion || 'snappy');

--- a/hyperframes/compositions/step-counter/index.html
+++ b/hyperframes/compositions/step-counter/index.html
@@ -5,7 +5,6 @@
     {"id":"step","type":"number","label":"Step","default":1},
     {"id":"total","type":"number","label":"Total","default":3},
     {"id":"title","type":"string","label":"Title","default":"Set up the project"},
-    {"id":"duration","type":"number","label":"Duration","default":5},
     {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >

--- a/hyperframes/compositions/step-counter/index.html
+++ b/hyperframes/compositions/step-counter/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[
+    {"id":"step","type":"number","label":"Step","default":1},
+    {"id":"total","type":"number","label":"Total","default":3},
+    {"id":"title","type":"string","label":"Title","default":"Set up the project"},
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
+  ]'
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>step-counter</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d0d0d;
+        --fg: #f5f5f4;
+        --accent: #ff6b35;
+        --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="step-counter"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="w-full h-full flex items-center justify-center px-32">
+        <div id="card" class="opacity-0 flex items-center gap-16 max-w-[80%]">
+          <div class="flex flex-col items-center justify-center" style="min-width: 280px;">
+            <div class="text-sm uppercase tracking-[0.3em] mono mb-3" style="color: var(--muted);">step</div>
+            <div class="flex items-baseline gap-3">
+              <div id="step" class="mono text-[14rem] leading-none font-bold" style="color: var(--accent);">1</div>
+              <div class="text-4xl mono" style="color: var(--muted);">/</div>
+              <div id="total" class="mono text-6xl" style="color: var(--muted);">3</div>
+            </div>
+          </div>
+          <div class="h-40 w-[3px]" style="background: var(--accent); opacity: 0.4;"></div>
+          <div id="title" class="text-6xl font-semibold leading-tight" style="color: var(--fg);">Set up the project</div>
+        </div>
+      </div>
+    </div>
+    <script>
+      const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
+      const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
+
+      document.getElementById('step').textContent = String(vars.step ?? 1);
+      document.getElementById('total').textContent = String(vars.total ?? 3);
+      document.getElementById('title').textContent = vars.title || '';
+
+      const motion = (theme.motion || 'snappy');
+      const cfg = motion === 'minimal'
+        ? { dur: 0.25, ease: 'none', x: 0 }
+        : motion === 'smooth'
+          ? { dur: 0.7, ease: 'power2.out', x: 24 }
+          : { dur: 0.4, ease: 'power3.out', x: 32 };
+
+      const tl = gsap.timeline({ paused: true });
+      tl.fromTo('#card', { opacity: 0, x: -cfg.x }, { opacity: 1, x: 0, duration: cfg.dur, ease: cfg.ease }, 0);
+      tl.to('#card', { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2) }, cfg.dur);
+      tl.to('#card', { opacity: 0, x: cfg.x, duration: cfg.dur, ease: cfg.ease.replace('.out', '.in') }, Math.max(cfg.dur, duration - cfg.dur));
+      window.__timelines = window.__timelines || {};
+      window.__timelines["step-counter"] = tl;
+    </script>
+  </body>
+</html>

--- a/hyperframes/compositions/term-card/README.md
+++ b/hyperframes/compositions/term-card/README.md
@@ -1,0 +1,17 @@
+# term-card
+
+Term + short definition. Use as a cutaway when a new vocabulary word appears, or as an overlay during a definitional beat.
+
+## Variables
+
+| Name       | Type   | Required | Description                                                                                  |
+|------------|--------|----------|----------------------------------------------------------------------------------------------|
+| term       | string | yes      | The word or phrase being defined. Keep to ~1–3 words.                                        |
+| definition | string | yes      | One-sentence definition. Keep under ~12 words for legibility.                                |
+| theme      | object | no       | Resolved theme tokens (font_display, font_mono, color_bg, color_fg, color_accent, motion).   |
+
+**Duration:** fixed at 5s. See note in `code-callout/README.md`.
+
+**Motion:** respects `theme.motion` (`snappy` default, `smooth`, `minimal`).
+
+Aspect: 1920x1080. 9:16 variant TBD.

--- a/hyperframes/compositions/term-card/hyperframes.json
+++ b/hyperframes/compositions/term-card/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "blocks",
+    "components": "components",
+    "assets": "assets"
+  }
+}

--- a/hyperframes/compositions/term-card/index.html
+++ b/hyperframes/compositions/term-card/index.html
@@ -4,7 +4,6 @@
   data-composition-variables='[
     {"id":"term","type":"string","label":"Term","default":"rebase"},
     {"id":"definition","type":"string","label":"Definition","default":"Replay commits onto a new base."},
-    {"id":"duration","type":"number","label":"Duration","default":5},
     {"id":"theme","type":"object","label":"Theme tokens","default":{}}
   ]'
 >

--- a/hyperframes/compositions/term-card/index.html
+++ b/hyperframes/compositions/term-card/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[
+    {"id":"term","type":"string","label":"Term","default":"rebase"},
+    {"id":"definition","type":"string","label":"Definition","default":"Replay commits onto a new base."},
+    {"id":"duration","type":"number","label":"Duration","default":5},
+    {"id":"theme","type":"object","label":"Theme tokens","default":{}}
+  ]'
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>term-card</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d0d0d;
+        --fg: #f5f5f4;
+        --accent: #ff6b35;
+        --muted: #a3a3a3;
+        --font-display: 'Inter', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 1920px; height: 1080px; overflow: hidden; background: var(--bg); color: var(--fg); }
+      body { font-family: var(--font-display); }
+      .mono { font-family: var(--font-mono); }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="term-card"
+      data-start="0"
+      data-duration="5"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div class="w-full h-full flex items-center justify-center px-32">
+        <div id="card" class="opacity-0 max-w-[70%]">
+          <div class="text-sm uppercase tracking-[0.3em] mono mb-6" style="color: var(--accent);">term</div>
+          <div id="term" class="text-8xl font-bold leading-none" style="color: var(--fg);">rebase</div>
+          <div class="h-[3px] w-32 my-10" style="background: var(--accent);"></div>
+          <div id="def" class="text-3xl leading-snug" style="color: var(--muted);">Replay commits onto a new base.</div>
+        </div>
+      </div>
+    </div>
+    <script>
+      const vars = (window.__hyperframes && window.__hyperframes.getVariables && window.__hyperframes.getVariables()) || {};
+      const duration = 5;
+
+      const theme = vars.theme || {};
+      const root = document.documentElement.style;
+      if (theme.color_bg) root.setProperty('--bg', theme.color_bg);
+      if (theme.color_fg) root.setProperty('--fg', theme.color_fg);
+      if (theme.color_accent) root.setProperty('--accent', theme.color_accent);
+      if (theme.font_display) root.setProperty('--font-display', `'${theme.font_display}', system-ui, sans-serif`);
+      if (theme.font_mono) root.setProperty('--font-mono', `'${theme.font_mono}', ui-monospace, monospace`);
+
+      document.getElementById('term').textContent = vars.term || 'rebase';
+      document.getElementById('def').textContent = vars.definition || '';
+
+      const motion = (theme.motion || 'snappy');
+      const cfg = motion === 'minimal'
+        ? { dur: 0.25, ease: 'none', y: 0 }
+        : motion === 'smooth'
+          ? { dur: 0.7, ease: 'power2.out', y: 16 }
+          : { dur: 0.4, ease: 'power3.out', y: 24 };
+
+      const tl = gsap.timeline({ paused: true });
+      tl.fromTo('#card', { opacity: 0, y: cfg.y }, { opacity: 1, y: 0, duration: cfg.dur, ease: cfg.ease }, 0);
+      tl.to('#card', { opacity: 1, duration: Math.max(0, duration - cfg.dur * 2) }, cfg.dur);
+      tl.to('#card', { opacity: 0, y: -cfg.y, duration: cfg.dur, ease: cfg.ease.replace('.out', '.in') }, Math.max(cfg.dur, duration - cfg.dur));
+      window.__timelines = window.__timelines || {};
+      window.__timelines["term-card"] = tl;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #29. Companion to the previously-shipped code-callout (#35).

## Summary

- Adds the remaining five starter templates from the #29 catalog: `term-card`, `step-counter`, `quote`, `stat`, `comparison`.
- Each composition follows the conventions established by `code-callout`: 1920x1080, fixed 5s duration, GSAP timeline exposed at `window.__timelines`, theme tokens applied via CSS custom properties.
- Each respects `theme.motion` (`snappy` default, `smooth`, `minimal`) by varying in/out duration, easing, and translation distance.
- Adds `hyperframes/compositions/README.md` as a catalog index documenting content shapes and shared conventions.
- B-roll director auto-discovery (`broll_director_inputs.rb#load_templates`) picks the new templates up — no wiring change needed.

## Out of scope (follow-ups)

- 9:16 portrait variants — matches existing code-callout precedent (also 16:9 only today).
- Variable-duration support — Hyperframes resolves `data-duration` at compile time, so this needs a pre-render templating step. Same constraint as code-callout.

## Test plan

- [x] Existing broll specs pass (`bundle exec rspec spec/buttercut/broll_director_inputs_spec.rb spec/broll_renderer_spec.rb`)
- [x] `npx hyperframes lint` on each new composition: 0 errors (one warning about `object` variable type — same warning code-callout produces; runtime works)
- [x] `BrollDirectorInputs#load_templates` discovers all six templates by name
- [ ] Render one entry per template end-to-end via `render-broll` skill against a tutorial-dark theme (manual; requires Hyperframes node deps)
- [ ] Render with `motion: smooth` and `motion: minimal` to spot-check easing differences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five composition templates (comparison, quote, stat, step-counter, term-card) for creating dynamic 5s content with configurable variables, theme tokens, and motion presets.
  * Templates expose playback timelines for external control and support responsive aspect guidance.

* **Documentation**
  * Added comprehensive docs describing composition organization, discovery, template catalogs, expected inputs, theme conventions, and usage notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/William-Hill/buttercut/pull/42)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->