### PR TITLE
chore: pin hyperframes registry to v0.5.5 (#43)

### DIFF
--- a/hyperframes/compositions/code-callout/hyperframes.json
+++ b/hyperframes/compositions/code-callout/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",

--- a/hyperframes/compositions/comparison/hyperframes.json
+++ b/hyperframes/compositions/comparison/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",

--- a/hyperframes/compositions/quote/hyperframes.json
+++ b/hyperframes/compositions/quote/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",

--- a/hyperframes/compositions/stat/hyperframes.json
+++ b/hyperframes/compositions/stat/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",

--- a/hyperframes/compositions/step-counter/hyperframes.json
+++ b/hyperframes/compositions/step-counter/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",

--- a/hyperframes/compositions/term-card/hyperframes.json
+++ b/hyperframes/compositions/term-card/hyperframes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
-  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry",
   "paths": {
     "blocks": "blocks",
     "components": "components",


### PR DESCRIPTION
Closes #43.

## Summary

- All six composition `hyperframes.json` files previously referenced `https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry`. `main` is a moving ref, so an upstream change could silently shift composition behavior between renders.
- Repointed every file to `https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry` — `v0.5.5` is the latest stable hyperframes release and matches the CLI version we lint/render with locally.

Affected: `code-callout`, `comparison`, `quote`, `stat`, `step-counter`, `term-card`.

## Test plan

- [x] `bundle exec rspec spec/buttercut/broll_director_inputs_spec.rb spec/broll_renderer_spec.rb` — 14 examples, 0 failures
- [x] `npx hyperframes lint` on all six compositions — 0 errors (warnings unchanged from baseline)
- [x] Verified the pinned URL resolves: `curl -I https://raw.githubusercontent.com/heygen-com/hyperframes/refs/tags/v0.5.5/registry/registry.json` → 200
- [ ] Render one composition end-to-end against the pinned registry (manual; requires Hyperframes node deps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned compositions to a stable release version (v0.5.5) instead of tracking the development branch, ensuring consistent behavior across code-callout, comparison, quote, stat, step-counter, and term-card components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/William-Hill/buttercut/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->