### PR TITLE
feat: roughcut job observability + UI elapsed-time + max_tokens cap

### DIFF
--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -185,11 +185,11 @@ module ButtercutUiSidecar
                user_bytes: user_blob.bytesize,
                clips_in_lib: (library_data["videos"] || []).length)
 
-      log.call("anthropic_request_send", model: MODEL, max_tokens: 24_576)
+      log.call("anthropic_request_send", model: MODEL, max_tokens: 8192)
       api_started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       response = @client.messages_create(
         model: MODEL,
-        max_tokens: 24_576,
+        max_tokens: 8192,
         temperature: 0.2,
         system: system_instructions,
         messages: [{ role: "user", content: user_blob }]

--- a/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
+++ b/ui/sidecar/lib/buttercut_ui_sidecar/roughcut_controller.rb
@@ -138,6 +138,8 @@ module ButtercutUiSidecar
         run_job(job: job, library: library, lib_dir: lib_dir, library_data: library_data,
                 combined_ndjson: combined, prompt_text: prompt_text, target_duration: target)
       rescue StandardError => e
+        warn "[roughcut #{job_id}] FAILED #{e.class}: #{e.message}"
+        warn e.backtrace.first(8).map { |l| "  #{l}" }.join("\n") if e.backtrace
         notify_failed(job_id, e.message)
       ensure
         @registry.delete(job_id)
@@ -153,7 +155,17 @@ module ButtercutUiSidecar
     end
 
     def run_job(job:, library:, lib_dir:, library_data:, combined_ndjson:, prompt_text:, target_duration:)
+      job_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      log = ->(step, **details) {
+        elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - job_started_at).round(2)
+        suffix = details.empty? ? "" : " " + details.map { |k, v| "#{k}=#{v}" }.join(" ")
+        warn "[roughcut #{job.id} +#{elapsed}s] #{step}#{suffix}"
+      }
+
+      log.call("starting", library: library, target_s: target_duration)
+
       if job.canceled?
+        log.call("canceled_before_start")
         @notifier.notify("roughcut_job_failed", job_id: job.id, message: "canceled")
         return
       end
@@ -168,7 +180,13 @@ module ButtercutUiSidecar
         prompt_text: prompt_text,
         target_duration: target_duration
       )
+      log.call("prompt_built",
+               system_bytes: system_instructions.bytesize,
+               user_bytes: user_blob.bytesize,
+               clips_in_lib: (library_data["videos"] || []).length)
 
+      log.call("anthropic_request_send", model: MODEL, max_tokens: 24_576)
+      api_started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       response = @client.messages_create(
         model: MODEL,
         max_tokens: 24_576,
@@ -176,11 +194,19 @@ module ButtercutUiSidecar
         system: system_instructions,
         messages: [{ role: "user", content: user_blob }]
       )
+      api_elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - api_started).round(2)
       body = AnthropicClient.message_body_text(response)
+      log.call("anthropic_response", api_seconds: api_elapsed, body_bytes: body.bytesize)
+
       yaml_text = extract_yaml_fence(body)
+      log.call("yaml_extracted", yaml_bytes: yaml_text.bytesize)
+
       rough = YAML.safe_load(yaml_text, permitted_classes: [Date, Time, Symbol]) || {}
       (rough["clips"] || []).each { |c| c["dialogue"] = "" unless c.key?("dialogue") }
+      log.call("yaml_parsed", clip_count: (rough["clips"] || []).length)
+
       validate_roughcut_shape!(rough, library_data)
+      log.call("validated")
 
       enrich_metadata!(rough)
       ts = Time.now.utc.strftime("%Y%m%d_%H%M%S")
@@ -189,12 +215,15 @@ module ButtercutUiSidecar
       roughcuts_dir.mkpath
       yaml_path = roughcuts_dir.join("#{stem}.yaml")
       yaml_path.write(YAML.dump(stringify_keys_deep(rough)))
+      log.call("yaml_written", path: yaml_path.to_s)
 
       editor = resolve_editor_flag(library_data)
       xml_path = roughcuts_dir.join(editor == "fcpx" ? "#{stem}.fcpxml" : "#{stem}.xml")
 
       @notifier.notify("roughcut_phase", job_id: job.id, phase: "export", message: "Exporting XML and recipe…")
+      log.call("export_start", editor: editor, xml: xml_path.to_s)
       export!(yaml_path: yaml_path, xml_path: xml_path, editor: editor)
+      log.call("export_done")
 
       xml_base = xml_path.to_s.sub(/\.[^.]+\z/, "")
       recipe_path = "#{xml_base}.recipe.json"
@@ -217,6 +246,7 @@ module ButtercutUiSidecar
         apply_path: Pathname.new(apply_path).expand_path.to_s,
         clips: clips
       )
+      log.call("done", clip_count: clips.length)
     end
 
     def export!(yaml_path:, xml_path:, editor:)

--- a/ui/src/routes/library/BriefComposer.tsx
+++ b/ui/src/routes/library/BriefComposer.tsx
@@ -106,6 +106,8 @@ export default function BriefComposer({ library, videos }: { library: string; vi
   const [targetSeconds, setTargetSeconds] = useState(120);
   const [currentBriefId, setCurrentBriefId] = useState<string | null>(null);
   const [phaseMessage, setPhaseMessage] = useState<string | null>(null);
+  const [phaseStartedAt, setPhaseStartedAt] = useState<number | null>(null);
+  const [phaseElapsedSec, setPhaseElapsedSec] = useState(0);
   const [jobRunning, setJobRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [donePaths, setDonePaths] = useState<RoughcutArtifactPaths | null>(null);
@@ -145,6 +147,19 @@ export default function BriefComposer({ library, videos }: { library: string; vi
     },
     [],
   );
+
+  // Tick once per second so the phase message can show elapsed time.
+  useEffect(() => {
+    if (phaseStartedAt === null) {
+      setPhaseElapsedSec(0);
+      return;
+    }
+    setPhaseElapsedSec(Math.floor((Date.now() - phaseStartedAt) / 1000));
+    const id = window.setInterval(() => {
+      setPhaseElapsedSec(Math.floor((Date.now() - phaseStartedAt) / 1000));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [phaseStartedAt]);
 
   useEffect(() => {
     setPlayheadSec(0);
@@ -231,11 +246,13 @@ export default function BriefComposer({ library, videos }: { library: string; vi
 
       activeJobIdRef.current = jobId;
       setJobRunning(true);
+      setPhaseStartedAt(Date.now());
 
       const unlisten = await listenRoughcutJobEvents(jobId, (ev: RoughcutJobEvent) => {
         switch (ev.method) {
           case "roughcut_phase":
             setPhaseMessage(ev.params.message ?? ev.params.phase);
+            setPhaseStartedAt(Date.now());
             break;
           case "roughcut_job_done":
             setDonePaths({
@@ -256,6 +273,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
               });
             setJobRunning(false);
             setPhaseMessage(null);
+            setPhaseStartedAt(null);
             setExportFormat("resolve");
             activeJobIdRef.current = null;
             disposeRoughcutListener(unlisten, unlistenRef);
@@ -264,6 +282,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
             setError(ev.params.message);
             setJobRunning(false);
             setPhaseMessage(null);
+            setPhaseStartedAt(null);
             activeJobIdRef.current = null;
             disposeRoughcutListener(unlisten, unlistenRef);
             break;
@@ -276,6 +295,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
       setError(String(e));
       setJobRunning(false);
       setPhaseMessage(null);
+      setPhaseStartedAt(null);
       activeJobIdRef.current = null;
       unlistenRef.current?.();
       unlistenRef.current = null;
@@ -290,6 +310,7 @@ export default function BriefComposer({ library, videos }: { library: string; vi
     activeJobIdRef.current = null;
     setJobRunning(false);
     setPhaseMessage(null);
+    setPhaseStartedAt(null);
   }
 
   async function handleExportArtifacts(format: ExportFormat): Promise<RoughcutArtifactPaths | null> {
@@ -409,7 +430,12 @@ export default function BriefComposer({ library, videos }: { library: string; vi
               </button>
             )}
           </div>
-          {phaseMessage && <p className="brief-composer__phase">{phaseMessage}</p>}
+          {phaseMessage && (
+            <p className="brief-composer__phase">
+              {phaseMessage}
+              {phaseStartedAt !== null && <> · {phaseElapsedSec}s</>}
+            </p>
+          )}
           {error && <pre className="brief-composer__error">{error}</pre>}
         </div>
 

--- a/ui/src/routes/library/TranscriptZone.tsx
+++ b/ui/src/routes/library/TranscriptZone.tsx
@@ -104,6 +104,13 @@ export default function TranscriptZone({ library, video, onSeek, onClipChange }:
     return () => { cancelled = true; };
   }, [library, video]);
 
+  const fetchMatchCount = useCallback(async (token: string) => {
+    const r = await findTranscriptMatches(library, [token], "library");
+    const matches = r.matches.length;
+    const clips = new Set(r.matches.map((m) => m.clip)).size;
+    return { matches, clips };
+  }, [library]);
+
   if (!matchesActive(state, library, video)) {
     return <div ref={containerRef} className="transcript-zone transcript-zone--empty">{video ? "Loading transcripts…" : "No clip selected."}</div>;
   }
@@ -144,13 +151,6 @@ export default function TranscriptZone({ library, video, onSeek, onClipChange }:
     }
     setPopover(null);
   };
-
-  const fetchMatchCount = useCallback(async (token: string) => {
-    const r = await findTranscriptMatches(library, [token], "library");
-    const matches = r.matches.length;
-    const clips = new Set(r.matches.map((m) => m.clip)).size;
-    return { matches, clips };
-  }, [library]);
 
   const applyClipReplaceFromPanel = async (clipName: string, m: FinderMatch, newTokens: string[]) => {
     await editor.editClipScope(clipName, {


### PR DESCRIPTION
Three small changes split across three commits so the deliberate behavior change is cleanly revertable.

## Summary

- **\`feat(ui)\`** \`e3d4a73\` — live per-phase elapsed-time counter on the brief composer (\`Generating roughcut… · 14s\`) so long phases don't look frozen. Also moves \`TranscriptZone\`'s \`fetchMatchCount\` \`useCallback\` above an early conditional return — pure rules-of-hooks correctness fix, no behavior change.
- **\`feat(sidecar)\`** \`f6ef0ac\` — per-step timing logs through the roughcut job (\`prompt_built\`, \`anthropic_request_send\`, \`anthropic_response\`, \`yaml_extracted\`, \`yaml_parsed\`, \`validated\`, \`yaml_written\`, \`export_start/done\`, \`done\`) with elapsed seconds and useful counters. On exception, also prints class/message + 8 backtrace lines to stderr before the existing \`notify_failed\`. No behavior change.
- **\`tune(sidecar)\`** \`8c39cb5\` — drops Anthropic \`max_tokens\` on the roughcut call from \`24576\` → \`8192\`. Reduces worst-case latency / cost and turns truncation into a clean validation error. Kept as its own commit so it's trivially revertable if a real roughcut hits the cap.

## Test plan

- [x] \`bundle exec rspec spec/lib/buttercut_ui_sidecar/roughcut_controller_spec.rb\` — 10 examples, 0 failures (with the new logging in place)
- [x] \`npx tsc --noEmit\` in \`ui/\` — clean
- [ ] Run a real roughcut end-to-end via the desktop app and confirm: phase counter ticks; sidecar log shows the new timing lines; no truncation under the new \`max_tokens\` cap